### PR TITLE
Remove redundant mis-spelled method

### DIFF
--- a/app/controllers/workbaskets/base_controller.rb
+++ b/app/controllers/workbaskets/base_controller.rb
@@ -66,8 +66,9 @@ module Workbaskets
     end
 
     def new
-      self.workbasket = Workbaskets::Workbasket.buld_new_workbasket!(
-        settings_type, current_user
+      self.workbasket = Workbaskets::Workbasket.create(
+        type: settings_type,
+        user: current_user
       )
 
       redirect_to initial_step_url

--- a/app/controllers/workbaskets/edit_certificate_controller.rb
+++ b/app/controllers/workbaskets/edit_certificate_controller.rb
@@ -34,8 +34,9 @@ module Workbaskets
     end
 
     def new
-      self.workbasket = Workbaskets::Workbasket.buld_new_workbasket!(
-        settings_type, current_user
+      self.workbasket = Workbaskets::Workbasket.create(
+        type: settings_type,
+        user: current_user
       )
 
       workbasket_settings.update(

--- a/app/controllers/workbaskets/edit_footnote_controller.rb
+++ b/app/controllers/workbaskets/edit_footnote_controller.rb
@@ -34,8 +34,9 @@ module Workbaskets
     end
 
     def new
-      self.workbasket = Workbaskets::Workbasket.buld_new_workbasket!(
-        settings_type, current_user
+      self.workbasket = Workbaskets::Workbasket.create(
+        type: settings_type,
+        user: current_user
       )
 
       workbasket_settings.update(

--- a/app/controllers/workbaskets/edit_geographical_area_controller.rb
+++ b/app/controllers/workbaskets/edit_geographical_area_controller.rb
@@ -34,8 +34,9 @@ module Workbaskets
     end
 
     def new
-      self.workbasket = Workbaskets::Workbasket.buld_new_workbasket!(
-        settings_type, current_user
+      self.workbasket = Workbaskets::Workbasket.create(
+        type: settings_type,
+        user: current_user
       )
 
       workbasket_settings.update(

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -530,16 +530,6 @@ module Workbaskets
         999
       end
 
-      def buld_new_workbasket!(type, current_user)
-        workbasket = Workbaskets::Workbasket.new(
-          type: type,
-          user: current_user
-        )
-        workbasket.save
-
-        workbasket
-      end
-
       def clean_up!
         %w(
           bulk_edit_of_measures

--- a/spec/support/shared_contexts/form_savers/regulation_saver_base_context.rb
+++ b/spec/support/shared_contexts/form_savers/regulation_saver_base_context.rb
@@ -4,7 +4,7 @@ shared_context "regulation_saver_base_context" do
   include_context "form_savers_base_context"
 
   let(:workbasket) do
-    ::Workbaskets::Workbasket::buld_new_workbasket!(:create_regulation, user)
+    ::Workbaskets::Workbasket::create(type: :create_regulation, user: user)
   end
 
   let(:regulation_saver) do


### PR DESCRIPTION
Removes `Workbaskets::Workbasket.buld_new_workbasket!`.

😅 This method is redundant and unnecessary; it doesn't do anything more than `#create` already does and is misleadingly-named, since it saves the record rather than just builds it. Also, it was mis-spelled, which was annoying.