### PR TITLE
Eager load associations on create measure forms

### DIFF
--- a/app/controllers/duty_expressions_controller.rb
+++ b/app/controllers/duty_expressions_controller.rb
@@ -12,6 +12,6 @@ class DutyExpressionsController < ::BaseController
       end
     end
 
-    scope.sort_by(&:duty_expression_id)
+    scope.eager(:duty_expression_description).all.sort_by(&:duty_expression_id)
   end
 end

--- a/app/controllers/footnotes/footnote_types_controller.rb
+++ b/app/controllers/footnotes/footnote_types_controller.rb
@@ -1,7 +1,7 @@
 module Footnotes
   class FootnoteTypesController < ::BaseController
     def collection
-      FootnoteType.q_search(params[:q])
+      FootnoteType.q_search(params[:q]).eager(:footnote_type_description).all
     end
   end
 end

--- a/app/controllers/measures/measure_actions_controller.rb
+++ b/app/controllers/measures/measure_actions_controller.rb
@@ -1,7 +1,7 @@
 module Measures
   class MeasureActionsController < ::BaseController
     def collection
-      MeasureAction.q_search(params)
+      MeasureAction.q_search(params).eager(:measure_action_description).all
     end
   end
 end

--- a/app/controllers/measures/measure_condition_codes_controller.rb
+++ b/app/controllers/measures/measure_condition_codes_controller.rb
@@ -1,7 +1,7 @@
 module Measures
   class MeasureConditionCodesController < ::BaseController
     def collection
-      MeasureConditionCode.q_search(params)
+      MeasureConditionCode.q_search(params).eager(:measure_condition_code_description).all
     end
   end
 end

--- a/app/controllers/measures/monetary_units_controller.rb
+++ b/app/controllers/measures/monetary_units_controller.rb
@@ -1,7 +1,7 @@
 module Measures
   class MonetaryUnitsController < ::BaseController
     def collection
-      MonetaryUnit.q_search(params)
+      MonetaryUnit.q_search(params).eager(:monetary_unit_description).all
     end
   end
 end


### PR DESCRIPTION
Some more optimisations to make the development log more readable by reducing the number of database queries. These address the second page of the create measure form, where there are eight HTTP requests (mostly AJAX requests to retrieve lists of things the user can select from)

Also improves performance. Previously it took 1.42s over the eight HTPP requests, now it's 1.07s.