### PR TITLE
Fix pry behaviour issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,13 +92,12 @@ end
 group :development do
   gem "foreman"
   gem "letter_opener"
-  gem "byebug"
   gem "govuk-lint"
 end
 
 group :development, :test do
   gem "dotenv-rails"
-  gem "pry-byebug"
+  gem "pry"
   gem "pry-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,6 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.3)
-    byebug (10.0.2)
     capybara (3.12.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -292,9 +291,6 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-byebug (3.6.0)
-      byebug (~> 10.0)
-      pry (~> 0.10)
     pry-rails (0.3.8)
       pry (>= 0.10.4)
     public_suffix (3.0.3)
@@ -503,7 +499,6 @@ DEPENDENCIES
   bootstrap-datepicker-rails (~> 1.7.1.1)
   bootstrap-sass (~> 3.3.7)
   builder (~> 3.2)
-  byebug
   capybara
   chromedriver-helper
   codeclimate-test-reporter
@@ -547,7 +542,7 @@ DEPENDENCIES
   pg (~> 1.1, >= 1.1.3)
   pikaday-gem
   plek (~> 1.11)
-  pry-byebug
+  pry
   pry-rails
   puma (~> 3.4)
   rabl (~> 0.12)


### PR DESCRIPTION
The `pry-byebug` gem appears to be buggy. It will almost always halt at the wrong place.

This seems to be an issue with maintenance of the gem, as I found this linked to from someone with similar issues:

https://github.com/deivid-rodriguez/pry-byebug/issues/45#issuecomment-68314470

Reverting to the standard `pry` gem seems to fix the issues.