### PR TITLE
Remove redundant validate! method call

### DIFF
--- a/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
@@ -78,8 +78,6 @@ module WorkbasketInteractions
         @do_not_rollback_transactions = true
         @measure_sids = []
 
-        validate!
-
         settings.measure_sids_jsonb = @measure_sids.to_json
 
         if settings.save


### PR DESCRIPTION
This change affects the submission of the second page of the create measures form.

This method call to `validate!` looks innocuous but is actually very expensive to run (it executes dozens of database queries within a transaction which is then rolled back, which takes 2.5 seconds). It's also not used for anything; the output and mutations on the object don't appear to be subsequently used at all.

Additionally, in the [only use case](https://github.com/uktrade/trade-tariff-management/blob/master/app/controllers/workbaskets/base_controller.rb#L87) I can identify the `validate!` method is already called explicitly before `persist!`, meaning the validations are run twice within the same request unnecessarily, which adds an extra 2.5s to an already very long-running request (11.5s total, now 9s).

Also fills the development log with lots of redundant data.