### PR TITLE
Restore validation during save due to different rollback behaviour

### DIFF
--- a/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
@@ -78,6 +78,8 @@ module WorkbasketInteractions
         @do_not_rollback_transactions = true
         @measure_sids = []
 
+        validate!
+
         settings.measure_sids_jsonb = @measure_sids.to_json
 
         if settings.save


### PR DESCRIPTION
Removing the `validate!` call here resulted in the measures and related objects not saving because of the preceding `@do_not_rollback_transactions = true` being set. This alters the behaviour of `validate!` such that it actually performs the saving! Also, no failed tests picked this up.

I am reverting the change for now while a better solution is worked on.