### PR TITLE
Remove all linting from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,13 +61,13 @@ jobs: # a collection of steps
           paths:
             - vendor/bundle
 
-      - run:
-          name: Lint Ruby code
-          command: bin/lint_ruby
-
-      - run:
-          name: Lint JavaScript code
-          command: bin/lint_js
+      # - run:
+      #     name: Lint Ruby code
+      #     command: bin/lint_ruby
+      #
+      # - run:
+      #     name: Lint JavaScript code
+      #     command: bin/lint_js
 
       - run:
           name: Wait for DB


### PR DESCRIPTION
Due to the current state of the codebase, it is likely that every file will require
a lot of work to be able to pass the linting requirements. This will slow development
down and, with a tight deadline, this is not our current priority so this change
will remove the linting steps from our CI process.