### PR TITLE
Add feature test for creating quota

### DIFF
--- a/app/views/shared/vue_templates/_measure_component.html.erb
+++ b/app/views/shared/vue_templates/_measure_component.html.erb
@@ -6,7 +6,7 @@
           Duty expression
         </label>
 
-        <custom-select url="/duty_expressions" label-field="description" value-field="duty_expression_id" code-field="duty_expression_code" v-model="measureComponent.duty_expression_id" date-sensitive="true" code-class-name="prefix--duty-expression" abbreviation-class-name="abbreviation--duty-expression" :options-filter="expressionsFriendlyDuplicate" :on-change="onDutyExpressionSelected" :compact="true" :showCompactAbbreviation="true" placeholder="―" :id="(prefix ? prefix : '') + '-duty-expression'"></custom-select>
+        <custom-select data-test="duty-expression" url="/duty_expressions" label-field="description" value-field="duty_expression_id" code-field="duty_expression_code" v-model="measureComponent.duty_expression_id" date-sensitive="true" code-class-name="prefix--duty-expression" abbreviation-class-name="abbreviation--duty-expression" :options-filter="expressionsFriendlyDuplicate" :on-change="onDutyExpressionSelected" :compact="true" :showCompactAbbreviation="true" placeholder="―" :id="(prefix ? prefix : '') + '-duty-expression'"></custom-select>
       </form-group>
     </div>
 
@@ -15,7 +15,7 @@
         <label class="form-label" v-if="index === 0">
           Duty amount
         </label>
-        <input class="form-control" v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001" :id="(prefix ? prefix : '') + '-amount'">
+        <input class="form-control" v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001" :id="(prefix ? prefix : '') + '-amount'" id="duty-amount">
       </form-group>
       <form-group v-else="">
         <label class="form-label" v-if="index === 0">

--- a/app/views/shared/vue_templates/_measure_component.html.erb
+++ b/app/views/shared/vue_templates/_measure_component.html.erb
@@ -15,7 +15,7 @@
         <label class="form-label" v-if="index === 0">
           Duty amount
         </label>
-        <input class="form-control" v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001" :id="(prefix ? prefix : '') + '-amount'" id="duty-amount">
+        <input class="form-control" data-test="duty-amount" v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001" :id="(prefix ? prefix : '') + '-amount'">
       </form-group>
       <form-group v-else="">
         <label class="form-label" v-if="index === 0">

--- a/app/views/shared/vue_templates/_opening_balances_manager.html.erb
+++ b/app/views/shared/vue_templates/_opening_balances_manager.html.erb
@@ -14,7 +14,7 @@
 
         <div class="row" v-if="isAnnual">
           <div class="col-md-3" >
-            <input class="form-control" v-model="section.balance" />
+            <input class="form-control" v-model="section.balance" id="annual-opening-balance" />
           </div>
         </div>
 

--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -5,7 +5,7 @@
         What period type will this section have?
       </label>
 
-      <div class="row">
+      <div class="row" id="quota-period-select">
         <div class="col-md-3">
           <custom-select :options="section_types" :allow-clear="true" label-field="label" value-field="id" v-model="section.type" placeholder="― select quota period type ―"></custom-select>
         </div>
@@ -28,7 +28,7 @@
                     <input value="January" disabled class='form-control string'>
                   </div>
                   <div class="col-md-4">
-                    <input :value="section.start_date && section.start_date.split('/')[2]" @input="section.start_date = `01/01/${$event.target.value}`" class='form-control string'>
+                    <input :value="section.start_date && section.start_date.split('/')[2]" @input="section.start_date = `01/01/${$event.target.value}`" class='form-control string' id='quota-period-year'>
                   </div>
                 </div>
             </div>
@@ -86,7 +86,7 @@
 
           <div class="row">
             <div class="col-md-3">
-              <custom-select url="/measurement_units" label-field="description" value-field="measurement_unit_code" code-field="measurement_unit_code" v-model="section.measurement_unit_code" placeholder="― select measurement unit ―" date-sensitive="true" code-class-name="prefix--measurement-unit" abbreviation-class-name="abbreviation--measurement-unit"></custom-select>
+              <custom-select id="measurement-unit-code" url="/measurement_units" label-field="description" value-field="measurement_unit_code" code-field="measurement_unit_code" v-model="section.measurement_unit_code" placeholder="― select measurement unit ―" date-sensitive="true" code-class-name="prefix--measurement-unit" abbreviation-class-name="abbreviation--measurement-unit"></custom-select>
             </div>
             <div class="col-md-3">
               <custom-select url="/measurement_unit_qualifiers" label-field="description" value-field="measurement_unit_qualifier_code" code-field="measurement_unit_qualifier_code" v-model="section.measurement_unit_qualifier_code" placeholder="― optionally select qualifier ―" date-sensitive=true code-class-name="prefix--measurement-unit-qualifier"></custom-select>

--- a/app/views/workbaskets/create_quota/steps/main/_order_number.html.slim
+++ b/app/views/workbaskets/create_quota/steps/main/_order_number.html.slim
@@ -13,4 +13,4 @@ fieldset
 
     .row
       .col-xs-2.col-md-2.col-lg-2
-        input.form-control maxlength="6" v-model="measure.quota_ordernumber"
+        input.form-control maxlength="6" v-model="measure.quota_ordernumber" name="quota_order_number"

--- a/app/views/workbaskets/create_quota/steps/main/_order_number_description.html.slim
+++ b/app/views/workbaskets/create_quota/steps/main/_order_number_description.html.slim
@@ -9,4 +9,4 @@ fieldset
 
     .row
       .col-xs-12.col-md-11.col-lg-9
-        textarea.form-control*{ "v-model" => "measure.quota_description", rows: 4 }
+        textarea.form-control*{ "v-model" => "measure.quota_description", rows: 4 } id="quota_description"

--- a/app/views/workbaskets/shared/steps/main/_measure_type.html.slim
+++ b/app/views/workbaskets/shared/steps/main/_measure_type.html.slim
@@ -1,4 +1,4 @@
-fieldset
+fieldset id="record_type_dropdown"
   h3.heading-medium
     | What type of
     =<> record_type

--- a/spec/features/workbasket/quota/quota_creation_spec.rb
+++ b/spec/features/workbasket/quota/quota_creation_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe "adding quotas", :js do
         information_text: "Test regulation",
       )
     end
-    let(:measure_type) { create(:measure_type, order_number_capture_code: 1) }
+    let(:measure_type_series) { create(:measure_type_series_description) }
+    let(:measure_type) { create(:measure_type, order_number_capture_code: 1, measure_type_series_id: measure_type_series.measure_type_series_id) }
+    let(:measure_type_series_description) do
+      create(:measure_type_series_description, measure_type_series_id: measure_type_series.measure_type_series_id)
+    end
     let(:commodity) { create(:commodity, :declarable) }
     let(:test_order_number) { '090909' }
 
@@ -89,7 +93,6 @@ RSpec.describe "adding quotas", :js do
   def create_required_model_instances
     create(:geographical_area, :erga_omnes)
     create(:user)
-    create(:measure_type_series_description)
     create(:duty_expression, :with_description, duty_expression_id: "01")
   end
 

--- a/spec/features/workbasket/quota/quota_creation_spec.rb
+++ b/spec/features/workbasket/quota/quota_creation_spec.rb
@@ -1,39 +1,58 @@
 require "rails_helper"
 
 RSpec.describe "adding quotas", :js do
-  it 'allows new quotas to be added' do
-    create(:geographical_area, :erga_omnes)
-    regulation = create(
-      :base_regulation,
-      :not_replaced,
-      base_regulation_id: "D0399990",
-      information_text: "Test regulation",
-    )
-    create(:user)
-    measure_type = create(:measure_type, order_number_capture_code: 1)
-    create(:measure_type_series_description)
-    commodity = create(:commodity, :declarable)
-    measurement_unit = create(:measurement_unit, :with_description)
-    create(:duty_expression, :with_description, duty_expression_id: "01")
-    allow_any_instance_of(Measures::MeasureTypesController).to receive(:collection).and_return([measure_type])
-    expect(QuotaOrderNumber.count).to eq 0
+  context 'succesfully completed form' do
+    let!(:measurement_unit) { create(:measurement_unit, :with_description) }
+
+    let(:regulation) do
+      regulation = create(
+        :base_regulation,
+        :not_replaced,
+        base_regulation_id: "D0399990",
+        information_text: "Test regulation",
+      )
+    end
+    let(:measure_type) { create(:measure_type, order_number_capture_code: 1) }
+    let(:commodity) { create(:commodity, :declarable) }
+    let(:test_order_number) { '090909' }
+
+
+    it 'creates new quota order number ' do
+      create_required_model_instances
+      stub_measure_types_controller
+
+      expect(QuotaOrderNumber.count).to eq 0
+
+      visit_create_quota_page
+      fill_out_create_quota_form
+      fill_out_configure_quota_form
+      skip_optional_footnote_form
+      expect_to_be_on_submit_for_cross_check_page
+
+      expect(QuotaOrderNumber.count).to eq 1
+    end
+  end
+
+
+  def visit_create_quota_page
     visit(root_path)
     click_on("Create a new quota")
+  end
 
+  def fill_out_create_quota_form
     within(find("fieldset", text: "Which regulation gives legal force")) do
       search_for_value(type_value: "test", select_value: regulation.information_text)
     end
 
-    fill_in :quota_order_number, with: "090909"
-    sleep 2
+    fill_in :quota_order_number, with: test_order_number
 
     within(find("fieldset", text: "What is the maximum precision for this quota")) do
       search_for_value(type_value: "3", select_value: "3")
     end
 
     within(find("fieldset", id: "record_type_dropdown")) do
-      find(".selectize-control input").click.send_keys("1")
-      select_dropdown_value("1")
+      find(".selectize-control input").click.send_keys(measure_type.measure_type_id)
+      select_dropdown_value(measure_type.measure_type_id)
     end
 
     fill_in :quota_description, with: 'test quota description'
@@ -43,19 +62,38 @@ RSpec.describe "adding quotas", :js do
     fill_in("Goods commodity codes", with: commodity.goods_nomenclature_item_id)
     select_radio("Erga Omnes")
     click_button('Continue')
+  end
+
+  def fill_out_configure_quota_form
     within(find("fieldset", text: "What period type will this section have?")) do
       search_for_value(type_value: "Annual", select_value: "Annual")
     end
     find('#quota-period-year').set('2019')
     within(find("form", text: "How will the quota balance(s) in this section be measured?")) do
       find("#measurement-unit-code").click
-      find(".selectize-dropdown-content .selection", text: 'a').click
+      find(".selectize-dropdown-content .selection", text: measurement_unit.measurement_unit_code).click
     end
     find("#annual-opening-balance").set(10000)
     find("#duty-amount").set(10)
     click_button('Continue')
+  end
+
+  def skip_optional_footnote_form
     click_button('Continue')
+  end
+
+  def expect_to_be_on_submit_for_cross_check_page
     expect(page).to have_content 'Review and submit'
-    expect(QuotaOrderNumber.count).to eq 1
+  end
+
+  def create_required_model_instances
+    create(:geographical_area, :erga_omnes)
+    create(:user)
+    create(:measure_type_series_description)
+    create(:duty_expression, :with_description, duty_expression_id: "01")
+  end
+
+  def stub_measure_types_controller
+    allow_any_instance_of(Measures::MeasureTypesController).to receive(:collection).and_return([measure_type])
   end
 end

--- a/spec/features/workbasket/quota/quota_creation_spec.rb
+++ b/spec/features/workbasket/quota/quota_creation_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "adding quotas", :js do
       find(".selectize-dropdown-content .selection", text: measurement_unit.measurement_unit_code).click
     end
     find("#annual-opening-balance").set(10000)
-    find("#duty-amount").set(10)
+    find('[data-test="duty-amount"]').set(10)
     click_button('Continue')
   end
 

--- a/spec/features/workbasket/quota/quota_creation_spec.rb
+++ b/spec/features/workbasket/quota/quota_creation_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "adding quotas", :js do
+  it 'allows new quotas to be added' do
+    create(:geographical_area, :erga_omnes)
+    regulation = create(
+      :base_regulation,
+      :not_replaced,
+      base_regulation_id: "D0399990",
+      information_text: "Test regulation",
+    )
+    create(:user)
+    measure_type = create(:measure_type, order_number_capture_code: 1)
+    create(:measure_type_series_description)
+    commodity = create(:commodity, :declarable)
+    measurement_unit = create(:measurement_unit, :with_description)
+    create(:duty_expression, :with_description, duty_expression_id: "01")
+    allow_any_instance_of(Measures::MeasureTypesController).to receive(:collection).and_return([measure_type])
+    expect(QuotaOrderNumber.count).to eq 0
+    visit(root_path)
+    click_on("Create a new quota")
+
+    within(find("fieldset", text: "Which regulation gives legal force")) do
+      search_for_value(type_value: "test", select_value: regulation.information_text)
+    end
+
+    fill_in :quota_order_number, with: "090909"
+    sleep 2
+
+    within(find("fieldset", text: "What is the maximum precision for this quota")) do
+      search_for_value(type_value: "3", select_value: "3")
+    end
+
+    within(find("fieldset", id: "record_type_dropdown")) do
+      find(".selectize-control input").click.send_keys("1")
+      select_dropdown_value("1")
+    end
+
+    fill_in :quota_description, with: 'test quota description'
+
+    input_date('operation_date', Date.today.beginning_of_year)
+
+    fill_in("Goods commodity codes", with: commodity.goods_nomenclature_item_id)
+    select_radio("Erga Omnes")
+    click_button('Continue')
+    within(find("fieldset", text: "What period type will this section have?")) do
+      search_for_value(type_value: "Annual", select_value: "Annual")
+    end
+    find('#quota-period-year').set('2019')
+    within(find("form", text: "How will the quota balance(s) in this section be measured?")) do
+      find("#measurement-unit-code").click
+      find(".selectize-dropdown-content .selection", text: 'a').click
+    end
+    find("#annual-opening-balance").set(10000)
+    find("#duty-amount").set(10)
+    click_button('Continue')
+    click_button('Continue')
+    expect(page).to have_content 'Review and submit'
+    expect(QuotaOrderNumber.count).to eq 1
+  end
+end


### PR DESCRIPTION
This PR adds happy path feature test for user creating a quota so that we can begin to
refactor and simplify some of the code surrounding it while being more confident that
we will know if these changes break expected functionality.

I have added attributes to some relevant html elements in order to make selecting them in the
test more transparent and less complicated.

In the test I have abstracted capybara behaviour into methods describing the page on 
which they are performed in an attempt to both make the test easier to understand at 
a glance and make the pinpointing of failing steps easier conceptually.
