### PR TITLE
Workbasket name bug

### DIFF
--- a/app/interactors/workbasket_interactions/settings_saver_base.rb
+++ b/app/interactors/workbasket_interactions/settings_saver_base.rb
@@ -43,7 +43,7 @@ module WorkbasketInteractions
     def initialize(workbasket, current_step, save_mode, settings_ops = {})
       if current_step == 'main' && self.class::WORKBASKET_TYPE == "CreateQuota"
         settings_ops['start_date'] = Date.today.strftime("%Y-%m-%d")
-        settings_ops['workbasket_name'] = settings_ops['quota_ordernumber']
+        settings_ops['workbasket_name'] = settings_ops['quota_description']
       end
 
       @workbasket = workbasket

--- a/spec/features/workbasket/quota/quota_creation_spec.rb
+++ b/spec/features/workbasket/quota/quota_creation_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "adding quotas", :js do
     end
     let(:commodity) { create(:commodity, :declarable) }
     let(:test_order_number) { '090909' }
+    let(:workbasket_description) { "test quota description" }
 
 
     it 'creates new quota order number ' do
@@ -34,6 +35,7 @@ RSpec.describe "adding quotas", :js do
       expect_to_be_on_submit_for_cross_check_page
 
       expect(QuotaOrderNumber.count).to eq 1
+      expect(Workbaskets::Workbasket.first.title).to eq workbasket_description
     end
   end
 
@@ -59,7 +61,7 @@ RSpec.describe "adding quotas", :js do
       select_dropdown_value(measure_type.measure_type_id)
     end
 
-    fill_in :quota_description, with: 'test quota description'
+    fill_in :quota_description, with: workbasket_description
 
     input_date('operation_date', Date.today.beginning_of_year)
 

--- a/spec/interactors/workbasket_interactions/create_quota/settings_saver_spec.rb
+++ b/spec/interactors/workbasket_interactions/create_quota/settings_saver_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe WorkbasketInteractions::CreateQuota::SettingsSaver do
+  let(:workbasket) { create(:workbasket) }
+  let(:geographical_area) { create(:geographical_area) }
+  let(:goods_nomenclature) { create(:goods_nomenclature) }
+  let(:base_regulation) { create(:base_regulation, replacement_indicator: 0) }
+  let(:test_quota_description) { "test quota description" }
+  let(:settings_ops) do
+    {
+      "operation_date" => "01/01/2019",
+      "measure_type_id" => "1",
+      "quota_ordernumber" => "090909",
+      "quota_precision" => "3",
+      "quota_description" => test_quota_description,
+      "quota_is_licensed" => "false",
+      "quota_licence" => "",
+      "reduction_indicator" => "",
+      "additional_codes" => "",
+      "commodity_codes" => goods_nomenclature.goods_nomenclature_item_id,
+      "commodity_codes_exclusions" => "",
+      "geographical_area_id" => geographical_area.geographical_area_id,
+      "excluded_geographical_areas" => [""],
+      "start_date" => "2019-01-17",
+      "quota_period" => "Annual",
+      "regulation_id" => base_regulation.base_regulation_id
+    }
+  end
+
+  context '#initialize' do
+    let(:settings_saver) { WorkbasketInteractions::CreateQuota::SettingsSaver.new(workbasket, 'main', '', settings_ops) }
+
+    it 'sets workbasket name to the quota order number in #setting_params' do
+      expect(settings_saver.settings_params['workbasket_name']).to eq test_quota_description
+    end
+  end
+end


### PR DESCRIPTION
Create quota workbasket names are meant to be the description that the user fills in during the create quota process, however they are currently the quota order number that the user fills in.

This PR corrects this bug.