### PR TITLE
Fix incorrect error when saving a Quota without a geographical origin.

### DIFF
--- a/app/interactors/workbasket_interactions/settings_saver_base.rb
+++ b/app/interactors/workbasket_interactions/settings_saver_base.rb
@@ -18,6 +18,7 @@ module WorkbasketInteractions
       measure_components
       conditions
       footnotes
+      geographical_area_id
       excluded_geographical_areas
       quota_periods
       quota_precision
@@ -138,10 +139,6 @@ module WorkbasketInteractions
         end
       end
 
-      if self.class::WORKBASKET_TYPE == "CreateMeasures" && workbasket_name.blank?
-        general_errors[:workbasket_name] = errors_translator(:blank_workbasket_name)
-      end
-
       if self.class::WORKBASKET_TYPE == "CreateQuota"
         if quota_ordernumber.present?
           unless order_number_saver.valid?
@@ -152,31 +149,35 @@ module WorkbasketInteractions
         else
           general_errors[:quota_ordernumber] = errors_translator(:quota_ordernumber)
         end
-      end
 
-      if candidates.flatten.compact.blank?
-        general_errors[:commodity_codes] = errors_translator(:blank_commodity_and_additional_codes)
-      end
-
-      if commodity_codes.blank? && commodity_codes_exclusions.present?
-        general_errors[:commodity_codes_exclusions] = errors_translator(:commodity_codes_exclusions)
-      end
-
-      if settings_params['start_date'].present? && (
-          commodity_codes.present? ||
-          additional_codes.present?
-        ) && candidates.flatten.compact.blank?
-
-        @errors[:commodity_codes] = errors_translator(:commodity_codes_invalid)
-      end
-
-      if self.class::WORKBASKET_TYPE == "CreateQuota" && step_pointer.configure_quota?
-        if quota_periods.blank?
-          general_errors[:quota_periods] = errors_translator(:no_any_quota_period)
+        if geographical_area_id.present?
+          if candidates.flatten.compact.blank?
+            general_errors[:commodity_codes] = errors_translator(:blank_commodity_and_additional_codes)
+          end
+        else
+          general_errors[:geographical_area_id] = errors_translator(:no_geographical_area)
         end
 
-        if quota_precision.blank?
-          general_errors[:maximum_precision] = errors_translator(:maximum_precision_blank)
+        if commodity_codes.blank? && commodity_codes_exclusions.present?
+          general_errors[:commodity_codes_exclusions] = errors_translator(:commodity_codes_exclusions)
+        end
+
+        if settings_params['start_date'].present? && (
+            commodity_codes.present? ||
+            additional_codes.present?
+          ) && candidates.flatten.compact.blank?
+
+          @errors[:commodity_codes] = errors_translator(:commodity_codes_invalid)
+        end
+
+        if step_pointer.configure_quota?
+          if quota_periods.blank?
+            general_errors[:quota_periods] = errors_translator(:no_any_quota_period)
+          end
+
+          if quota_precision.blank?
+            general_errors[:maximum_precision] = errors_translator(:maximum_precision_blank)
+          end
         end
       end
 

--- a/app/value_objects/workbasket_value_objects/attributes_parser_base.rb
+++ b/app/value_objects/workbasket_value_objects/attributes_parser_base.rb
@@ -54,6 +54,10 @@ module WorkbasketValueObjects
       end
     end
 
+    def geographical_area_id
+      ops[:geographical_area_id]
+    end
+
     def excluded_geographical_areas
       if ops[:excluded_geographical_areas].present?
         ops[:excluded_geographical_areas].uniq

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
       commodity_codes_exclusions: "Exceptions: if one or more codes are entered here, Goods commodity codes field must not be empty; each exception code must be a child of one of the goods commodity codes above."
       commodity_codes_invalid: "There are no any valid code specified in 'Goods commodity codes' or 'Additional codes' inputs! Please, double check params"
       no_any_quota_period: "Need to specify at least of one valid quota period. Period type, Start date, Length of period, Balance and Measurement Unit are required!"
+      no_geographical_area: "A geographical origin (or Erga Omnes) must be specified."
       maximum_precision_blank: "Maximum precision must be specified."
 
   create_geographical_area:


### PR DESCRIPTION
[https://trello.com/c/nTGqz0f1/644-quota-incorrect-commodity-codes-error]

Expected error: The Create quota page should show ask user to select Origin.
Actual : The Configure Quota page shows an incorrect error asking to fill in commodity code in the previous page (Which has already been filled in).