### PR TITLE
Fix quota period type bug

### DIFF
--- a/app/interactors/workbasket_interactions/edit_quota/settings_extractor.rb
+++ b/app/interactors/workbasket_interactions/edit_quota/settings_extractor.rb
@@ -75,7 +75,7 @@ module WorkbasketInteractions
       def extract_quota_periods_settings
         {
             '0': {
-                'type': 'custom',
+                'type': quota_definition.workbasket_type_of_quota,
                 'repeat': 'false',
                 'balance': '',
                 'measurement_unit_id': '',

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -70,7 +70,7 @@ FactoryGirl.define do
 
     trait :actual do
       validity_start_date { Date.today.ago(3.years) }
-      validity_end_date   { nil }
+      validity_end_date   { Date.today + 1.year }
     end
 
     trait :xml do

--- a/spec/interactors/workbasket_interactions/edit_quota/settings_extractor_spec.rb
+++ b/spec/interactors/workbasket_interactions/edit_quota/settings_extractor_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe WorkbasketInteractions::EditQuota::SettingsExtractor do
+  let!(:quota_definition) { create(:quota_definition, :actual, workbasket_type_of_quota: 'Annual') }
+  let!(:quota_order_number) { create(:quota_order_number, quota_order_number_sid: quota_definition.quota_order_number_sid ) }
+  let!(:quota_order_number_origin) { create(:quota_order_number_origin, quota_order_number_sid: quota_order_number.quota_order_number_sid) }
+
+  it 'returns quota period' do
+    extractor = WorkbasketInteractions::EditQuota::SettingsExtractor.new(quota_definition.quota_definition_sid)
+    quota_periods = extractor.send(:extract_quota_periods_settings)
+    expect(quota_periods[:'0'][:type]).to eq 'Annual'
+  end
+end


### PR DESCRIPTION
Regardless of the period type we assign to a quota (i.e annual,
quarterly etc) when we go to edit the quota it shows up as
`custom`.

This PR fixes this bug.

I have added an end period date to the quota factory `actual` trait
as without one it quota definition could not be saved and so the
factory does not represent real data without this change.

Note: It looks like the seed data do not have a `workbasket_type_of_quota`
so additional work will need to be done for the existing data.