### PR TITLE
Remove sub quota and parent quota views

### DIFF
--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -153,47 +153,6 @@
         </p>
       </fieldset>
       <br>
-      <fieldset v-if="showOpeningBalanceFields">
-        <div class="form-group">
-          <label class="form-label">
-            Do you want to associate this quota section with a parent quota?
-
-            <span class="form-hint">
-              An associated parent quota will have its own balance, which is deprecated simultaneously with the current period's balance when drawings are made.
-            </span>
-          </label>
-
-          <div class="multiple-choice">
-            <input id="" type="checkbox" v-model="section.parent_quota.associate">
-            <label for="toggle-type">
-              Yes - associate this quota section with a parent quota
-            </label>
-          </div>
-
-          <div class="panel panel-border-narrow" v-if="section.parent_quota.associate">
-            <div class="form-group">
-              <label class="form-label">Parent quota order number</label>
-              <div class="bootstrap-row">
-                <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
-                  <input type="text" maxlength="6" class="form-control" v-model="section.parent_quota.order_number">
-                </div>
-              </div>
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">
-                Parent quota opening balance(s)
-
-                <span class="form-hint">
-                  This defaults to the total of the opening balances entered above, for this section. You can optionally change the value here. The balance here will be measured in the same units as the quota specified here.
-                </span>
-              </label>
-
-              <parent-quota-opening-balances :section="section" :update-balances="updateBalances"></parent-quota-opening-balances>
-            </div>
-          </div>
-        </div>
-      </fieldset>
 
       <info-message v-if="!showOpeningBalanceFields">
         Answer the questions above to see inputs for defining each quota period.

--- a/app/views/workbaskets/create_quota/steps/_conditions_footnotes.html.slim
+++ b/app/views/workbaskets/create_quota/steps/_conditions_footnotes.html.slim
@@ -2,4 +2,3 @@
 br
 = render "workbaskets/shared/steps/duties_conditions_footnotes/footnotes", f: f, record_type: 'quota'
 br
-= render "workbaskets/create_quota/steps/duties_conditions_footnotes/sub_quotas", f: f, record_type: 'quota'

--- a/app/views/workbaskets/create_quota/steps/_review_and_submit.html.slim
+++ b/app/views/workbaskets/create_quota/steps/_review_and_submit.html.slim
@@ -11,8 +11,6 @@
   = render "workbaskets/create_quota/steps/review_and_submit/details", read_only: read_only
   = render "workbaskets/create_quota/steps/review_and_submit/quota_periods", read_only: read_only
   = render "workbaskets/shared/steps/review_and_submit/measures", read_only: read_only, record_type: 'create_quota'
-  = render "workbaskets/create_quota/steps/review_and_submit/parent_quotas", read_only: read_only, record_type: 'create_quota'
-  = render "workbaskets/create_quota/steps/review_and_submit/sub_quotas", read_only: read_only, record_type: 'create_quota'
 
   - if read_only
     .form-actions


### PR DESCRIPTION
Remove sub quota and parent quota views from the create quota workflow
to remove complexity.