### PR TITLE
Quota period bug

### DIFF
--- a/app/assets/javascripts/components/quota-form.js
+++ b/app/assets/javascripts/components/quota-form.js
@@ -128,72 +128,22 @@ $(document).ready(function() {
         if (window.all_settings.quota_periods) {
           data.quota_sections = objectToArray(window.all_settings.quota_periods).map(function(section) {
 
-            if (section.type == "custom") {
-              section.repeat = section.repeat === "true";
-              section.opening_balances = [];
-              section.duty_expressions = [];
+            section.repeat = section.repeat === "true";
+            section.opening_balances = [];
+            section.duty_expressions = [];
 
-              section.periods = objectToArray(section.periods).map(function(period) {
-                period.critical = period.critical === "true";
+            section.periods = objectToArray(section.periods).map(function(period) {
+              period.critical = period.critical === "true";
 
-                period.duty_expressions = objectToArray(period.duty_expressions).map(function(e) {
-                  delete e.$order;
-                  e.duty_expression_id = self.getDutyExpressionId(e);
-
-                  return e;
-                });
-
-                return period;
-              });
-
-            } else {
-              section.critical = section.critical === "true";
-              section.staged = section.staged === "true";
-              section.criticality_each_period = section.criticality_each_period === "true";
-              section.duties_each_period = section.duties_each_period === "true";
-              section.periods = [];
-
-              section.duty_expressions = objectToArray(section.duty_expressions).map(function(e) {
+              period.duty_expressions = objectToArray(period.duty_expressions).map(function(e) {
                 delete e.$order;
                 e.duty_expression_id = self.getDutyExpressionId(e);
 
                 return e;
               });
 
-              section.opening_balances = objectToArray(section.opening_balances).map(function(balance) {
-                if (section.type == "annual") {
-                  balance.critical = balance.critical === "true";
-
-                  balance.duty_expressions = objectToArray(balance.duty_expressions).map(function(e) {
-                    delete e.$order;
-                    e.duty_expression_id = self.getDutyExpressionId(e);
-
-                    return e;
-                  });
-                } else {
-                  var ks = {
-                    bi_annual: ["semester1", "semester2"],
-                    quarterly: ["quarter1", "quarter2", "quarter3", "quarter4"],
-                    monthly: ["month1", "month2", "month3", "month4", "month5", "month6", "month7", "month8", "month9", "month10", "month11", "month12"]
-                  };
-
-                  ks[section.type].forEach(function(k) {
-                    balance[k].critical = balance[k].critical === "true";
-
-
-                    balance[k].duty_expressions = objectToArray(balance[k].duty_expressions).map(function(e) {
-                      delete e.$order;
-                      e.duty_expression_id = self.getDutyExpressionId(e);
-
-                      return e;
-                    });
-                  });
-                }
-
-                return balance;
-              });
-            }
-
+              return period;
+            });
             section.parent_quota.associate = section.parent_quota.associate === true ||
                                              section.parent_quota.associate === "true";
 

--- a/app/interactors/workbasket_interactions/edit_quota/settings_extractor.rb
+++ b/app/interactors/workbasket_interactions/edit_quota/settings_extractor.rb
@@ -75,7 +75,7 @@ module WorkbasketInteractions
       def extract_quota_periods_settings
         {
             '0': {
-                'type': 'custom',
+                'type': quota_definition.workbasket_type_of_quota,
                 'repeat': 'false',
                 'balance': '',
                 'measurement_unit_id': '',

--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <div class="panel panel-border-narrow" v-if="section.type">
-      <fieldset v-if="section.type != 'custom'">
+      <fieldset v-if="(section.type != 'custom' && section.periods.length == 0 )">
         <div class="form-group">
           <label class="form-label" for="annual_start_date">
             What is the start date of this section?
@@ -156,6 +156,47 @@
         </p>
       </fieldset>
       <br>
+      <fieldset v-if="showOpeningBalanceFields">
+        <div class="form-group">
+          <label class="form-label">
+            Do you want to associate this quota section with a parent quota?
+
+            <span class="form-hint">
+              An associated parent quota will have its own balance, which is deprecated simultaneously with the current period's balance when drawings are made.
+            </span>
+          </label>
+
+          <div class="multiple-choice">
+            <input id="" type="checkbox" v-model="section.parent_quota.associate">
+            <label for="toggle-type">
+              Yes - associate this quota section with a parent quota
+            </label>
+          </div>
+
+          <div class="panel panel-border-narrow" v-if="section.parent_quota.associate">
+            <div class="form-group">
+              <label class="form-label">Parent quota order number</label>
+              <div class="bootstrap-row">
+                <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
+                  <input type="text" maxlength="6" class="form-control" v-model="section.parent_quota.order_number">
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">
+                Parent quota opening balance(s)
+
+                <span class="form-hint">
+                  This defaults to the total of the opening balances entered above, for this section. You can optionally change the value here. The balance here will be measured in the same units as the quota specified here.
+                </span>
+              </label>
+
+              <parent-quota-opening-balances :section="section" :update-balances="updateBalances"></parent-quota-opening-balances>
+            </div>
+          </div>
+        </div>
+      </fieldset>
 
       <info-message v-if="!showOpeningBalanceFields">
         Answer the questions above to see inputs for defining each quota period.

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -70,7 +70,7 @@ FactoryGirl.define do
 
     trait :actual do
       validity_start_date { Date.today.ago(3.years) }
-      validity_end_date   { nil }
+      validity_end_date   { Date.today + 1.year }
     end
 
     trait :xml do

--- a/spec/interactors/workbasket_interactions/edit_quota/settings_extractor_spec.rb
+++ b/spec/interactors/workbasket_interactions/edit_quota/settings_extractor_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe WorkbasketInteractions::EditQuota::SettingsExtractor do
+  let!(:quota_definition) { create(:quota_definition, :actual, workbasket_type_of_quota: 'Annual') }
+  let!(:quota_order_number) { create(:quota_order_number, quota_order_number_sid: quota_definition.quota_order_number_sid ) }
+  let!(:quota_order_number_origin) { create(:quota_order_number_origin, quota_order_number_sid: quota_order_number.quota_order_number_sid) }
+
+  it 'returns quota period' do
+    extractor = WorkbasketInteractions::EditQuota::SettingsExtractor.new(quota_definition.quota_definition_sid)
+    quota_periods = extractor.send(:extract_quota_periods_settings)
+    expect(quota_periods[:'0'][:type]).to eq 'Annual'
+  end
+end


### PR DESCRIPTION
When we go to edit an 'annual' quota the UI shows the quota as a 'custom' quota. This PR fixes this bug.

Before:
<img width="1327" alt="screenshot 2019-01-29 at 13 20 11" src="https://user-images.githubusercontent.com/13124899/51911035-af1f3480-23c8-11e9-8bde-93e65abcccf6.png">

After:
<img width="999" alt="screenshot 2019-01-29 at 13 26 22" src="https://user-images.githubusercontent.com/13124899/51911349-7df33400-23c9-11e9-926e-75b92a2dee31.png">

