### PR TITLE
Remove Base64 and zip versions of the xml export, as they are not needed

### DIFF
--- a/app/services/xml_generation/metadata.rb
+++ b/app/services/xml_generation/metadata.rb
@@ -20,7 +20,6 @@ module XmlGeneration
 
     attr_accessor :xml_export,
                   :xml_file_path,
-                  :zip_file_path,
                   :extract_start_date_time,
                   :extract_end_date_time,
                   :extract_database_date_time
@@ -28,7 +27,6 @@ module XmlGeneration
     def initialize(xml_export)
       @xml_export = xml_export
       @xml_file_path = xml_export.tmp_xml_file.path
-      @zip_file_path = xml_export.tmp_zip_file.path
 
       @extract_start_date_time = xml_export.extract_start_date_time.xmlschema
       @extract_end_date_time = xml_export.extract_end_date_time.xmlschema
@@ -49,10 +47,6 @@ module XmlGeneration
 
     def xml_file_size
       File.size(xml_file_path)
-    end
-
-    def compressed_checksum
-      get_md5_checksum(zip_file_path)
     end
 
     def destinations

--- a/app/services/xml_generation/taric_export.rb
+++ b/app/services/xml_generation/taric_export.rb
@@ -7,10 +7,7 @@ module XmlGeneration
                   :extract_end_date_time,
                   :extract_database_date_time,
                   :xml_data,
-                  :tmp_xml_file,
-                  :tmp_base_64_file,
-                  :tmp_zip_file,
-                  :tmp_metadata_file
+                  :tmp_xml_file
 
     def initialize(record)
       @record = record
@@ -57,15 +54,15 @@ module XmlGeneration
       data = ::XmlGeneration::NodeEnvelope.new(result_groups)
       @extract_database_date_time = Time.now.utc
 
-      unless record.envelope_id.present?
-        raise "Cannot export Taric XML without an envelope_id (id=#{record.id})"
+      unless @record.envelope_id.present?
+        raise "Cannot export Taric XML without an envelope_id (id=#{@record.id})"
       end
 
       if data.present?
         @xml_data = renderer.render(
           data,
           xml: xml_builder,
-          envelope_id: record.envelope_id,
+          envelope_id: @record.envelope_id,
         )
       end
     end
@@ -75,23 +72,20 @@ module XmlGeneration
     end
 
     def xml_generator_search
-      if record.workbasket
-        ::XmlGeneration::WorkbasketSearch.new(record.date_filters)
+      if @record.workbasket
+        ::XmlGeneration::WorkbasketSearch.new(@record.date_filters)
       else
-        ::XmlGeneration::DBSearch.new(record.date_filters)
+        ::XmlGeneration::DBSearch.new(@record.date_filters)
       end
     end
 
     def validate_xml_data!
       errors = ::XmlGeneration::XmlXsdValidator.new(xml_data).run
-      record.update(validation_errors: errors.to_json)
+      @record.update(validation_errors: errors.to_json)
     end
 
     def attach_files!
       attach_xml_file!
-      attach_base_64_version!
-      attach_zip_version!
-
       @extract_end_date_time = Time.now.utc
     end
 
@@ -100,31 +94,14 @@ module XmlGeneration
       save_xml!(:xml, tmp_xml_file)
     end
 
-    def attach_base_64_version!
-      @tmp_base_64_file = put_data_into_tempfile!(:base_64, base_64_version)
-      save_xml!(:base_64, tmp_base_64_file)
-    end
-
-    def attach_zip_version!
-      @tmp_zip_file = generate_zip_file(tmp_xml_file)
-      save_xml!(:zip, tmp_zip_file)
-    end
-
     def attach_metadata_file!
       @tmp_metadata_file = put_data_into_tempfile!(:meta, metadata)
-      save_xml!(:meta, tmp_metadata_file)
+      save_xml!(:meta, @tmp_metadata_file)
     end
 
     def clean_up_tmp_files!
       clean_up_tmp_file!(tmp_xml_file)
-      clean_up_tmp_file!(tmp_base_64_file)
-      clean_up_tmp_file!(tmp_metadata_file)
-
-      clean_up_opened_file!(tmp_zip_file)
-    end
-
-    def base_64_version
-      Base64.encode64(xml_data)
+      clean_up_tmp_file!(@tmp_metadata_file)
     end
 
     def metadata
@@ -141,38 +118,22 @@ module XmlGeneration
       tmp_file
     end
 
-    def generate_zip_file(file_to_include)
-      zip_file_object = Zip::File.open(name_of_zip_file, Zip::File::CREATE) do |zipfile|
-        zipfile.add(name_of_base64_file, file_to_include.path)
-      end
-
-      File.open(zip_file_object.zipfile)
-    end
-
     def save_xml!(uploader_name, tmp_file)
-      record.public_send("#{uploader_name}=", File.open(tmp_file))
+      @record.public_send("#{uploader_name}=", File.open(tmp_file))
     end
 
     def tmp_file_name(version_name)
       "#{extract_start_date_time}_#{Time.now.to_i}_xml_export_#{version_name}_version"
     end
 
-    def name_of_base64_file
-      "#{filename_prefix}-EUFileSequence.B64"
-    end
-
     def name_of_metadata_file
       "DIT_TAQ01_V1_#{timestamp}_metadata.xml"
     end
 
-    def name_of_zip_file
-      "#{filename_prefix}.zip"
-    end
-
     # file name format "DIT_<Start Date-YYYYMMDD>-<End Date-YYYYMMDD>-<Timestamp-YYYYMMDDTHHMMSS>-EUFileSequence.XML"
     def filename_prefix
-      start_date = record.date_filters[:start_date].strftime("%Y%m%d")
-      end_date   = (record.date_filters[:end_date] || Date.today).strftime("%Y%m%d")
+      start_date = @record.date_filters[:start_date].strftime("%Y%m%d")
+      end_date   = (@record.date_filters[:end_date] || Date.today).strftime("%Y%m%d")
 
       "DIT_#{start_date}-#{end_date}-#{timestamp}"
     end
@@ -186,10 +147,6 @@ module XmlGeneration
       tmp_file.unlink
     end
 
-    def clean_up_opened_file!(opened_file)
-      opened_file.close
-      File.delete(opened_file)
-    end
 
     def template_name
       "main"

--- a/app/views/xml_generation/exports/_table.html.slim
+++ b/app/views/xml_generation/exports/_table.html.slim
@@ -37,9 +37,3 @@ table.table
 
               =<> link_to "Metadata file", export_item.meta.url, download: export_item.meta.original_filename
               br
-
-            - if export_item.base_64.present?
-              =<> link_to "Encoded BASE64", export_item.base_64.url, download: export_item.base_64.original_filename
-              span
-               =<> '|'
-              =<> link_to "Encoded BASE64 in ZIP", export_item.zip.url, download: export_item.zip.original_filename

--- a/app/views/xml_generation/templates/metadata.builder
+++ b/app/views/xml_generation/templates/metadata.builder
@@ -63,22 +63,6 @@ xml.tag!("BatchFileInterfaceMetadata", xmlns: "http://www.hmrc.gsi.gov.uk/mdg/ba
     xml_data_item(record, self.xml_file_size)
   end
 
-  env.tag!("compressed") do |record|
-    xml_data_item(record, self.class::COMPRESSED)
-  end
-
-  env.tag!("compressionAlgorithm") do |record|
-    xml_data_item(record, self.class::COMPRESSION_ALGORITHM)
-  end
-
-  env.tag!("compressedChecksum") do |record|
-    xml_data_item(record, self.compressed_checksum)
-  end
-
-  env.tag!("compressedChecksumAlgorithm") do |record|
-    xml_data_item(record, self.class::COMPRESSED_CHECKSUM_ALGORITHM)
-  end
-
   env.tag!("sourceLocation") do |record|
     xml_data_item(record, self.class::SOURCE_LOCATION)
   end

--- a/db/migrate/20190131153106_remove_unneeded_files_from_xml_export_files.rb
+++ b/db/migrate/20190131153106_remove_unneeded_files_from_xml_export_files.rb
@@ -1,0 +1,16 @@
+Sequel.migration do
+  up do
+    alter_table :xml_export_files do
+      drop_column :zip_data
+      drop_column :base_64_data
+    end
+  end
+
+  down do
+    alter_table :xml_export_files do
+      add_column :zip_data, String
+      add_column :base_64_data, String
+    end
+  end
+
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7962,8 +7962,6 @@ CREATE TABLE public.xml_export_files (
     xml_data text,
     issue_date timestamp without time zone,
     date_filters text,
-    base_64_data text,
-    zip_data text,
     meta_data text,
     workbasket boolean DEFAULT true,
     validation_errors jsonb DEFAULT '{}'::jsonb,
@@ -12523,3 +12521,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20181022164645_create_edit
 INSERT INTO "schema_migrations" ("filename") VALUES ('20181022164836_add_original_fields_to_edit_geographical_areas_workbasket_settings.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20181022112903_change_bulk_edit_of_quota_settings.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20181204111717_add_envelope_id_to_xml_export_files.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20190131153106_remove_unneeded_files_from_xml_export_files.rb');

--- a/spec/services/xml_generation/taric_export_spec.rb
+++ b/spec/services/xml_generation/taric_export_spec.rb
@@ -39,39 +39,7 @@ RSpec.describe XmlGeneration::TaricExport do
 
       # It's unclear if all these formats are required
       expect(xml_export_file.xml).to be_present
-      expect(xml_export_file.base_64).to be_present
-      expect(xml_export_file.zip).to be_present
       expect(xml_export_file.meta).to be_present
-    end
-
-    describe "Base64 version" do
-      it "matches the XML once decoded" do
-        create(:measure, :for_upload_today)
-
-        perform_taric_export(xml_export_file)
-        decoded_xml = Base64.decode64(xml_export_file.base_64.read)
-
-        expect(decoded_xml).to eq xml_export_file.xml.read
-      end
-    end
-
-    describe "zip version" do
-      it "includes the XML file" do
-        create(:measure, :for_upload_today)
-
-        perform_taric_export(xml_export_file)
-
-        Zip::File.open_buffer(xml_export_file.zip.to_io) do |zip|
-          expect(zip.entries.count).to eq 1
-
-          entry = zip.entries.first
-
-          # The current implementation may be wrong - the filename is B64,
-          # but the content is the standard XML, not the Base64 XML.
-          expect(entry.name).to end_with "-EUFileSequence.B64"
-          expect(entry.get_input_stream.read).to eq xml_export_file.xml.read
-        end
-      end
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/im0n3al6/732-remove-base64-and-zip-versions-of-the-xml-export-files-as-they-are-not-used-or-needed