### PR TITLE
Fix bug caused when status changed to 'editing'

### DIFF
--- a/app/models/concerns/workbasket_helpers/settings_base.rb
+++ b/app/models/concerns/workbasket_helpers/settings_base.rb
@@ -55,6 +55,13 @@ module WorkbasketHelpers
       public_send("#{step}_step_validation_passed").present?
     end
 
+    def reset_step_validations(steps= [])
+      ([:main] + steps).each do |step|
+        public_send("#{step}_step_validation_passed=", false)
+      end
+      save
+    end
+
     def set_searchable_data_for_created_measures!
       measures.map do |measure|
         measure.manual_add = true

--- a/app/models/workbaskets/bulk_edit_of_quotas_settings.rb
+++ b/app/models/workbaskets/bulk_edit_of_quotas_settings.rb
@@ -132,5 +132,10 @@ module Workbaskets
         workbasket, Measure.new, target_id
       )
     end
+
+    def reset_step_validations
+      super([:configure_quota, :conditions_footnotes])
+    end
+
   end
 end

--- a/app/models/workbaskets/create_measures_settings.rb
+++ b/app/models/workbaskets/create_measures_settings.rb
@@ -33,5 +33,9 @@ module Workbaskets
       @additional_codes_covered ||= measures.where("additional_code_id IS NOT NULL AND additional_code_type_id IS NOT NULL")
                                             .pluck(:additional_code_type_id, :additional_code_id).map(&:join).uniq
     end
+
+    def reset_step_validations
+      super([:duties_conditions_footnotes])
+    end
   end
 end

--- a/app/models/workbaskets/create_quota_settings.rb
+++ b/app/models/workbaskets/create_quota_settings.rb
@@ -78,5 +78,9 @@ module Workbaskets
       diff = (latest_period_date.year - earliest_period_date.year)
       [1, diff].max
     end
+
+    def reset_step_validations
+      super([:configure_quota, :conditions_footnotes])
+    end
   end
 end

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -362,7 +362,7 @@ module Workbaskets
           end
 
           def can_continue_cross_check?(current_user)
-            awaiting_cross_check? && !current_user.author_of_workbasket?(self) && cross_checker_id.blank?
+            awaiting_cross_check? && !current_user.author_of_workbasket?(self)
           end
 
           def approve_process_can_be_started?
@@ -410,6 +410,8 @@ module Workbaskets
       self.last_update_by_id = current_user.id
       self.last_status_change_at = Time.zone.now
 
+      reset_settings_step_validations if new_status.to_sym == :editing
+
       save
     end
 
@@ -422,6 +424,10 @@ module Workbaskets
       )
 
       event.save
+    end
+
+    def reset_settings_step_validations
+      settings.reset_step_validations
     end
 
     def settings

--- a/spec/integration/workbaskets/workbasket_spec.rb
+++ b/spec/integration/workbaskets/workbasket_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+include WorkbasketHelper
+
+RSpec.describe(Workbaskets::Workbasket) do
+  describe "#move_status_to!" do
+    it "resets all steps_passed in the workbasket settings" do
+
+      user = create(:user)
+      workbasket = create(:workbasket, :create_measures)
+      workbasket.settings.main_step_validation_passed = true
+      workbasket.settings.duties_conditions_footnotes_step_validation_passed = true
+      workbasket.settings.save
+
+      decorated_basket = workbasket.decorate
+
+      expect(decorated_basket.settings.duties_conditions_footnotes_step_validation_passed).to be true
+      workbasket.move_status_to!(user, "editing")
+      expect(decorated_basket.settings.duties_conditions_footnotes_step_validation_passed).to be false
+    end
+  end
+end


### PR DESCRIPTION
When changing status to "Editing" reset all of the 'validation_step_passed', so they need to go through the 'generation' of the measures/quotas/etc. again.