### PR TITLE
Crosscheck feature test

### DIFF
--- a/app/views/workbaskets/main_menu_parts/_actions.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_actions.html.slim
@@ -33,7 +33,8 @@
 /       = link_to "Reschedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true
 
 - if workbasket.can_withdraw? && @current_user.author_of_workbasket?(workbasket) && workbasket.object.type == "create_measures"
-
+  | &nbsp;|&nbsp;
+  = link_to "Withdraw/edit", "#", data: { target_url: withdraw_workbasket_from_workflow_create_measure_url(workbasket.id) }, class: "js-main-menu-show-withdraw-confirmation-link"
 - elsif workbasket.new_in_progress?
   | &nbsp;|&nbsp;
   = link_to "Delete", "#", data: { target_url: workbasket_view_link_based_on_type(workbasket) }, class: "js-main-menu-show-delete-confirmation-link"

--- a/spec/features/workbasket/main_menu_spec.rb
+++ b/spec/features/workbasket/main_menu_spec.rb
@@ -27,8 +27,20 @@ describe 'workbasket table', js: true do
       expect(page).to have_content('Continue')
     end
 
+    context "user's workbasket has been submitted for cross checker" do
+      it 'shows status `Awaiting cross-check` and option to withdraw or edit' do
+        current_users_workbasket.status = :awaiting_cross_check
+        current_users_workbasket.save
+        visit root_path
+        expect(page).to have_content(current_users_workbasket.title)
+        expect(page).to have_content('Create Measure')
+        expect(page).to have_content('Awaiting cross-check')
+        expect(page).to have_content('Withdraw/edit')
+      end
+    end
+
     context "user's workbasket has been rejected by cross checker" do
-      it 'to do' do
+      it 'shows workbasket with status `Cross-check rejected`' do
         current_users_workbasket.status = :cross_check_rejected
         current_users_workbasket.save
         visit root_path
@@ -64,6 +76,7 @@ describe 'workbasket table', js: true do
         expect(page).to have_content('Create Quota')
         expect(page).to have_content('Awaiting cross-check')
         expect(page).to have_content('View')
+        expect(page).to_not have_content('Withdraw/edit')
       end
     end
 

--- a/spec/features/workbasket/main_menu_spec.rb
+++ b/spec/features/workbasket/main_menu_spec.rb
@@ -27,6 +27,17 @@ describe 'workbasket table', js: true do
       expect(page).to have_content('Continue')
     end
 
+    context "user's workbasket has been rejected by cross checker" do
+      it 'to do' do
+        current_users_workbasket.status = :cross_check_rejected
+        current_users_workbasket.save
+        visit root_path
+        expect(page).to have_content(current_users_workbasket.title)
+        expect(page).to have_content('Create Measure')
+        expect(page).to have_content('Cross-check rejected')
+      end
+    end
+
     context 'another user has created a workbasket which is awaiting cross check' do
       let!(:another_user) do
         create(:user)

--- a/spec/features/workbasket/main_menu_spec.rb
+++ b/spec/features/workbasket/main_menu_spec.rb
@@ -47,6 +47,7 @@ describe 'workbasket table', js: true do
         expect(page).to have_content(current_users_workbasket.title)
         expect(page).to have_content('Create Measure')
         expect(page).to have_content('Cross-check rejected')
+        expect(page).to have_content('Withdraw/edit')
       end
     end
 


### PR DESCRIPTION
Add tests for main menu spec to check for how workbaskets are displayed in different states.

Add back in link for `withdraw/edit` for `awaiting approval` and `rejected` status workbaskets which seems to have got lost in a previous PR.