### PR TITLE
- No longer use status 'ready_for_approval'

### DIFF
--- a/app/interactors/workbasket_interactions/workflow/cross_check.rb
+++ b/app/interactors/workbasket_interactions/workflow/cross_check.rb
@@ -4,12 +4,10 @@ module WorkbasketInteractions
     private
 
       def post_approve_action!
-        if submit_for_approval.present?
-          workbasket.move_status_to!(
-            current_user,
-            :awaiting_approval
-          )
-        end
+        workbasket.move_status_to!(
+          current_user,
+          :awaiting_approval
+        )
       end
 
       def post_reject_action!

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -216,13 +216,13 @@ module Workbaskets
       def relevant_for_manager(current_user)
         if current_user.approver?
           where(
-            "user_id = ? OR status = ?",
-            current_user.id, "awaiting_cross_check"
+            "user_id = ? OR status IN ('awaiting_cross_check', 'awaiting_approval')",
+            current_user.id
           )
         else
           where(
-            "user_id = ? OR status IN ('awaiting_cross_check', 'awaiting_approval')",
-            current_user.id
+            "user_id = ? OR status = ?",
+            current_user.id, "awaiting_cross_check"
           )
         end
       end
@@ -365,17 +365,12 @@ module Workbaskets
             awaiting_cross_check? && !current_user.author_of_workbasket?(self)
           end
 
-          def approve_process_can_be_started?
-            awaiting_approval? &&
-              approver_id.blank?
-          end
-
           def approve_process_can_not_be_started?
             !approve_process_can_be_started?
           end
 
           def can_continue_approve?(current_user)
-            awaiting_approval? && approver_is?(current_user)
+            awaiting_approval? && current_user.approver?
           end
 
           def awaiting_cds_upload_new_or_edit_item?

--- a/app/views/shared/vue_templates/_cross_check_decision.html.slim
+++ b/app/views/shared/vue_templates/_cross_check_decision.html.slim
@@ -11,22 +11,6 @@ script type="text/x-template" id="cross-check-decision-template"
       label.with_bigger_font-size :for="radioID" v-if="rejectTypeSelected"
         | I am not happy with the measure(s).
 
-    .panel.panel-border-narrow.hidden.js-cross-check-approve-details-block v-if="approveTypeSelected"
-      label.form-label
-        | Do you want to submit the measure(s) for approval now?
-
-        span.form-hint.with_bigger_font-size
-          | Leave this option unselected if the measures are not yet ready to be sent to CDS.
-
-      .parent-group-target
-        .form-group
-          .find-measures__checkbox-column
-            .multiple-choice
-              input name="cross_check[submit_for_approval]" type="hidden" v-model="cross_check.submit_for_approval" value="1"
-              input#toggle-type name="cross_check[submit_for_approval]" type="checkbox" v-model="cross_check.submit_for_approval" value="1"
-              label.with_bigger_font-size for="toggle-type"
-                | Immediately submit for approval
-
     .panel.panel-border-narrow.hidden.js-cross-check-reject-details-block v-if="rejectTypeSelected"
       label.form-label
         | Provide your reasons and/or state the changes required:

--- a/app/views/workbaskets/main_menu_parts/_actions.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_actions.html.slim
@@ -44,7 +44,7 @@
   = link_to "Review for cross-check", new_cross_check_url(workbasket.id)
 
 - if @current_user.approver?
-  - if workbasket.approve_process_can_be_started? || workbasket.can_continue_approve?(@current_user)
+  - if workbasket.can_continue_approve?(@current_user)
     | &nbsp;|&nbsp;
     = link_to "Review for approval", new_approve_url(workbasket.id)
 


### PR DESCRIPTION
 move baskets straight to 'awaiting_approval' after cross-check

- Fix bug where approvers could not see approval link but non-approvers could. (Wat!)