### PR TITLE
Allow withdrawing and editing of create quota workbaskets

### DIFF
--- a/app/helpers/workbasket_helper.rb
+++ b/app/helpers/workbasket_helper.rb
@@ -329,4 +329,8 @@ module WorkbasketHelper
       withdraw_workbasket_from_workflow_create_quotum_url(workbasket.id)
     end
   end
+
+  def show_withdraw_edit?(workbasket)
+    workbasket.can_withdraw? && @current_user.author_of_workbasket?(workbasket) && (workbasket.object.type == "create_measures" || workbasket.object.type == "create_quota")
+  end
 end

--- a/app/helpers/workbasket_helper.rb
+++ b/app/helpers/workbasket_helper.rb
@@ -321,4 +321,12 @@ module WorkbasketHelper
       edit_geographical_area_url(workbasket.id)
     end
   end
+
+  def workbasket_edit_link(workbasket)
+    if workbasket.object.type == "create_measures"
+      withdraw_workbasket_from_workflow_create_measure_url(workbasket.id)
+    elsif workbasket.object.type == "create_quota"
+      withdraw_workbasket_from_workflow_create_quotum_url(workbasket.id)
+    end
+  end
 end

--- a/app/views/workbaskets/main_menu_parts/_actions.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_actions.html.slim
@@ -34,7 +34,7 @@
 
 / withdraw_workbasket_from_workflow_create_quotum
 
-- if workbasket.can_withdraw? && @current_user.author_of_workbasket?(workbasket) && (workbasket.object.type == "create_measures" || workbasket.object.type == "create_quota")
+- if show_withdraw_edit?(workbasket)
   | &nbsp;|&nbsp;
   = link_to "Withdraw/edit", "#", data: { target_url: workbasket_edit_link(workbasket) }, class: "js-main-menu-show-withdraw-confirmation-link"
 - elsif workbasket.new_in_progress?

--- a/app/views/workbaskets/main_menu_parts/_actions.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_actions.html.slim
@@ -32,9 +32,11 @@
 /       | &nbsp;|&nbsp;
 /       = link_to "Reschedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true
 
-- if workbasket.can_withdraw? && @current_user.author_of_workbasket?(workbasket) && workbasket.object.type == "create_measures"
+/ withdraw_workbasket_from_workflow_create_quotum
+
+- if workbasket.can_withdraw? && @current_user.author_of_workbasket?(workbasket) && (workbasket.object.type == "create_measures" || workbasket.object.type == "create_quota")
   | &nbsp;|&nbsp;
-  = link_to "Withdraw/edit", "#", data: { target_url: withdraw_workbasket_from_workflow_create_measure_url(workbasket.id) }, class: "js-main-menu-show-withdraw-confirmation-link"
+  = link_to "Withdraw/edit", "#", data: { target_url: workbasket_edit_link(workbasket) }, class: "js-main-menu-show-withdraw-confirmation-link"
 - elsif workbasket.new_in_progress?
   | &nbsp;|&nbsp;
   = link_to "Delete", "#", data: { target_url: workbasket_view_link_based_on_type(workbasket) }, class: "js-main-menu-show-delete-confirmation-link"

--- a/spec/features/workbasket/main_menu_spec.rb
+++ b/spec/features/workbasket/main_menu_spec.rb
@@ -27,7 +27,7 @@ describe 'workbasket table', js: true do
       expect(page).to have_content('Continue')
     end
 
-    context "user's workbasket has been submitted for cross checker" do
+    context "user's `create measure` workbasket has been submitted for cross checker" do
       it 'shows status `Awaiting cross-check` and option to withdraw or edit' do
         current_users_workbasket.status = :awaiting_cross_check
         current_users_workbasket.save
@@ -39,13 +39,39 @@ describe 'workbasket table', js: true do
       end
     end
 
-    context "user's workbasket has been rejected by cross checker" do
+    context "user's `create measure` workbasket has been rejected by cross checker" do
       it 'shows workbasket with status `Cross-check rejected`' do
         current_users_workbasket.status = :cross_check_rejected
         current_users_workbasket.save
         visit root_path
         expect(page).to have_content(current_users_workbasket.title)
         expect(page).to have_content('Create Measure')
+        expect(page).to have_content('Cross-check rejected')
+        expect(page).to have_content('Withdraw/edit')
+      end
+    end
+
+    context "user's `create quota` workbasket has been submitted for cross checker" do
+      it 'shows status `Awaiting cross-check` and option to withdraw or edit' do
+        current_users_workbasket.type = :create_quota
+        current_users_workbasket.status = :awaiting_cross_check
+        current_users_workbasket.save
+        visit root_path
+        expect(page).to have_content(current_users_workbasket.title)
+        expect(page).to have_content('Create Quota')
+        expect(page).to have_content('Awaiting cross-check')
+        expect(page).to have_content('Withdraw/edit')
+      end
+    end
+
+    context "user's `create quota` workbasket has been rejected by cross checker" do
+      it 'shows workbasket with status `Cross-check rejected`' do
+        current_users_workbasket.type = :create_quota
+        current_users_workbasket.status = :cross_check_rejected
+        current_users_workbasket.save
+        visit root_path
+        expect(page).to have_content(current_users_workbasket.title)
+        expect(page).to have_content('Create Quota')
         expect(page).to have_content('Cross-check rejected')
         expect(page).to have_content('Withdraw/edit')
       end
@@ -66,7 +92,6 @@ describe 'workbasket table', js: true do
 
       it 'displays other users workbasket data' do
         visit root_path
-
         expect(page).to have_content(current_users_workbasket.title)
         expect(page).to have_content('Create Measure')
         expect(page).to have_content('New - in progress')

--- a/spec/features/workbasket/quota/quota_spec.rb
+++ b/spec/features/workbasket/quota/quota_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "adding quotas", :js do
-  context 'succesfully completed form' do
+RSpec.describe "quotas", :js do
+  context 'create quota' do
     let!(:measurement_unit) { create(:measurement_unit, :with_description) }
 
     let(:regulation) do
@@ -38,6 +38,40 @@ RSpec.describe "adding quotas", :js do
     end
   end
 
+  context 'edit quota' do
+    let!(:measurement_unit) { create(:measurement_unit, :with_description) }
+
+    let(:regulation) do
+      regulation = create(
+      :base_regulation,
+        :not_replaced,
+        base_regulation_id: "D0399990",
+        information_text: "Test regulation",
+      )
+    end
+    let(:measure_type_series) { create(:measure_type_series_description) }
+    let(:measure_type) { create(:measure_type, order_number_capture_code: 1, measure_type_series_id: measure_type_series.measure_type_series_id) }
+    let(:measure_type_series_description) do
+      create(:measure_type_series_description, measure_type_series_id: measure_type_series.measure_type_series_id)
+    end
+    let(:commodity) { create(:commodity, :declarable) }
+    let(:test_order_number) { '090909' }
+    let(:workbasket_description) { "test quota description" }
+
+    it 'creates new quota order number ' do
+      create_required_model_instances
+      stub_measure_types_controller
+      visit_create_quota_page
+      fill_out_create_quota_form
+      fill_out_configure_quota_form
+      skip_optional_footnote_form
+      expect_to_be_on_submit_for_cross_check_page
+      click_button 'Submit for cross-check'
+      navigate_to_edit_form
+      change_precision_quota_and_submit
+      expect(page).to have_content('Quota submitted')
+    end
+  end
 
   def visit_create_quota_page
     visit(root_path)
@@ -98,5 +132,21 @@ RSpec.describe "adding quotas", :js do
 
   def stub_measure_types_controller
     allow_any_instance_of(Measures::MeasureTypesController).to receive(:collection).and_return([measure_type])
+  end
+
+  def navigate_to_edit_form
+    click_link 'Return to main menu'
+    click_link 'Withdraw/edit'
+    click_link 'Confirm'
+  end
+
+  def change_precision_quota_and_submit
+    within(find("fieldset", text: "What is the maximum precision for this quota")) do
+      search_for_value(type_value: "2", select_value: "2")
+    end
+    click_button 'Continue'
+    click_button 'Continue'
+    click_button 'Continue'
+    click_button 'Submit for cross-check'
   end
 end


### PR DESCRIPTION
Show 'Withdraw/Edit' option on create quota workbaskets from main menu.

Clicking the link allows users to edit and resubmit their quota for cross check.