### PR TITLE
Approval/Workflow changes

### DIFF
--- a/app/controllers/concerns/base_job_mixin.rb
+++ b/app/controllers/concerns/base_job_mixin.rb
@@ -18,7 +18,8 @@ module BaseJobMixin
     record = klass.new(
       {
         issue_date: Time.zone.now,
-        state: "P"
+        state: "P",
+        user_id: current_user.id
       }.merge(additional_params)
     )
     if persist_record(record)

--- a/app/controllers/workbaskets/workflows/schedule_export_to_cds_controller.rb
+++ b/app/controllers/workbaskets/workflows/schedule_export_to_cds_controller.rb
@@ -6,16 +6,10 @@ module Workbaskets
       end
 
       def create
-        if export_date.present?
-          workbasket.operation_date = export_date
-
-          if workbasket.save
-            workbasket.move_status_to!(
-              current_user,
-              :awaiting_cds_upload_create_new
-            )
-          end
-        end
+        workbasket.move_status_to!(
+          current_user,
+          :awaiting_cds_upload_create_new
+        )
       end
     end
   end

--- a/app/controllers/xml_generation/exports_controller.rb
+++ b/app/controllers/xml_generation/exports_controller.rb
@@ -35,7 +35,26 @@ module XmlGeneration
       nil
     end
 
+    def create
+      if valid_workbasket?
+        super
+      else
+        render :index
+      end
+    end
+
   private
+
+    def valid_workbasket?
+      if Workbaskets::Workbasket[params[:workbasket_id]].present?
+        if Workbaskets::Workbasket[params[:workbasket_id]].status != :awaiting_cds_upload_create_new
+          @form_error= "Workbasket status must be 'Awaiting CDS upload', currently it is '#{Workbaskets::Workbasket[params[:workbasket_id]].status.humanize}'."
+        end
+      else
+        @form_error= "Cannot find Workbasket '#{params[:workbasket_id]}'."
+      end
+      @form_error.blank?
+    end
 
     def persist_record(record)
       record.save_with_envelope_id

--- a/app/interactors/workbasket_interactions/workflow/approve.rb
+++ b/app/interactors/workbasket_interactions/workflow/approve.rb
@@ -16,11 +16,7 @@ module WorkbasketInteractions
       end
 
       def approve_status
-        if export_date.present?
-          workbasket.possible_approved_status
-        else
-          :ready_for_export
-        end
+        workbasket.possible_approved_status
       end
 
       def reject_status

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -216,7 +216,7 @@ module Workbaskets
       def relevant_for_manager(current_user)
         if current_user.approver?
           where(
-            "user_id = ? OR status IN ('awaiting_cross_check', 'awaiting_approval')",
+            "user_id = ? OR status IN ('awaiting_cross_check', 'awaiting_approval', 'awaiting_cds_upload_create_new', 'ready_for_export')",
             current_user.id
           )
         else

--- a/app/services/xml_generation/taric_export.rb
+++ b/app/services/xml_generation/taric_export.rb
@@ -27,6 +27,7 @@ module XmlGeneration
       else
         mark_export_process_as_empty!
       end
+      mark_workbasket_as_sent!
     end
 
     def name_of_xml_file
@@ -46,6 +47,10 @@ module XmlGeneration
 
     def mark_export_process_as_empty!
       record.update(state: "E")
+    end
+
+    def mark_workbasket_as_sent!
+      Workbaskets::Workbasket[@record.workbasket_selected].move_status_to!(User[@record.user_id], :sent_to_cds)
     end
 
     # data is a XmlGeneration::NodeEnvelope object

--- a/app/views/shared/base_export/_form.html.slim
+++ b/app/views/shared/base_export/_form.html.slim
@@ -1,16 +1,15 @@
 .search-form
+  -if @form_error
+    .error-summary role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1"
+      .heading-medium.error-summary-heading
+        = @form_error
+
   = simple_form_for record_name.downcase, url: redirect_url, html: { method: :post, "data-parsley-validate" => true, "autocomplete" => "off", class: "export-form" } do |f|
 
     .row
       .col-sm-3.col-md-2.col-lg-2
-        = f.input :workbasket_id, as: :string, label: 'Workbasket ID'.html_safe,  input_html: { name: :workbasket_id, class: 'form-control end-date' }
-    - if show_workbasket_checkbox
-      .row
-        .col-sm-3.col-md-2.col-lg-2
-          .multiple-choice
-            input type="checkbox" id="export_workbasket" name="workbasket" checked="checked"
-            label.form-label.boolean.optional for="export_workbasket"
-              | Workbasket
+        = f.input :workbasket_id, as: :integer, required: true, label: 'Workbasket ID'.html_safe,  input_html: { name: :workbasket_id, class: 'form-control end-date' }
+        = f.hidden_field  :export_workbasket, value:"true"
 
     .form-actions
       = f.button :submit, "Schedule #{record_name}", class: 'button', data: { 'disable-with' => 'Scheduling' }

--- a/db/migrate/20190212163200_add_user_id_to_xml_export_files.rb
+++ b/db/migrate/20190212163200_add_user_id_to_xml_export_files.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :xml_export_files do
+      add_column :user_id, Integer
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7965,7 +7965,8 @@ CREATE TABLE public.xml_export_files (
     workbasket boolean DEFAULT true,
     validation_errors jsonb DEFAULT '{}'::jsonb,
     envelope_id integer,
-    workbasket_selected integer
+    workbasket_selected integer,
+    user_id integer
 );
 
 
@@ -12523,3 +12524,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20181022112903_change_bulk
 INSERT INTO "schema_migrations" ("filename") VALUES ('20181204111717_add_envelope_id_to_xml_export_files.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190131153106_remove_unneeded_files_from_xml_export_files.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190201161401_change_xml_export_from_dates_to_workbasket.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20190212163200_add_user_id_to_xml_export_files.rb');

--- a/spec/requests/xml_generation/create_export_spec.rb
+++ b/spec/requests/xml_generation/create_export_spec.rb
@@ -2,14 +2,15 @@ require "rails_helper"
 
 RSpec.describe "creating a new XML generation export" do
   before { create(:user) }
+  let(:workbasket) { create(:workbasket, :create_measures, status: 'awaiting_cds_upload_create_new') }
 
   it "creates a XML export file record" do
-    expect { post xml_generation_exports_path }
+    expect { post xml_generation_exports_path workbasket_id: workbasket.id }
       .to change(XmlExport::File, :count).by(1)
   end
 
   it "sets the envelope ID for the XML export file record" do
-    post xml_generation_exports_path
+    post xml_generation_exports_path workbasket_id: workbasket.id
 
     expect(XmlExport::File.last.envelope_id).to be_present
   end

--- a/spec/services/xml_generation/taric_export_spec.rb
+++ b/spec/services/xml_generation/taric_export_spec.rb
@@ -3,11 +3,13 @@ require "rails_helper"
 RSpec.describe XmlGeneration::TaricExport do
   let(:operation_date) { Date.current }
   let!(:workbasket) { create(:workbasket, status: :awaiting_cds_upload_create_new) }
+  let(:user) { create(:user) }
   let(:xml_export_file) do
     build(
       :xml_export_file,
       workbasket: true,
-      workbasket_selected: workbasket.id
+      workbasket_selected: workbasket.id,
+      user_id: user.id
     )
   end
 


### PR DESCRIPTION
Add user id to xml_file information so we can change workbasket state after export and log who requested it.
Check workbasket is valid before allowing xml export
Move workbasket straight to 'awaiting_cds_upload' rather than using operation date