### PR TITLE
Serialize cookies with json

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,5 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
-
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
# Merge https://github.com/uktrade/trade-tariff-management/pull/56/files first!

We previously used marshal, the accepted standard practise is to use json to serialize cookies.

A brief explanation can be found here: https://www.happybearsoftware.com/almost-protect-yourself-from-cookie-session-store