### PR TITLE
Add sent_to_cds partial

### DIFF
--- a/app/views/workbaskets/events/_sent_to_cds.html.slim
+++ b/app/views/workbaskets/events/_sent_to_cds.html.slim
@@ -1,0 +1,11 @@
+tr
+  td.heading_column
+    | Sent to CDS by
+  td
+    = event.user_name
+
+tr
+  td.heading_column
+    | Sent to CDS on
+  td
+    = workbasket_event_date(event)


### PR DESCRIPTION
Currently when user clicks to view a workbasket with the status of
`sent_to_cds` they get an error due to the relevant partial not existing

This PR adds a partial view for the `sent_to_cds` event and fixes this
issue.