### PR TITLE
Upload XML to S3

### DIFF
--- a/app/services/xml_generation/taric_export.rb
+++ b/app/services/xml_generation/taric_export.rb
@@ -27,6 +27,7 @@ module XmlGeneration
       else
         mark_export_process_as_empty!
       end
+      upload_xml
       mark_workbasket_as_sent!
     end
 
@@ -35,6 +36,10 @@ module XmlGeneration
     end
 
   private
+
+    def upload_xml
+      XmlGeneration::Upload.new(record, timestamp).run
+    end
 
     def mark_export_process_as_started!
       @extract_start_date_time = Time.now.utc

--- a/app/services/xml_generation/upload.rb
+++ b/app/services/xml_generation/upload.rb
@@ -1,0 +1,61 @@
+require 'zip'
+require 'aws-sdk-s3'
+
+module XmlGeneration
+  class Upload
+
+    attr_reader :record, :timestamp
+
+    def initialize(record, timestamp)
+      @record = record
+      @timestamp = timestamp
+    end
+
+    def run
+      upload_main_file
+      upload_metadata_file
+    end
+
+    def bucket(remote_path)
+      s3 = Aws::S3::Resource.new(region: ENV['AWS_REGION'])
+      s3.bucket(ENV['AWS_BUCKET_NAME']).object(remote_path)
+    end
+
+    def upload_main_file
+      bucket(main_file_remote_path).upload_file(local_main_file_path)
+    end
+
+    def upload_metadata_file
+      bucket(metadata_remote_path).upload_file(local_metadata_file_path)
+    end
+
+    def remote_metadata_file_name
+      "DIT_TAQ01_V1_#{timestamp}_metadata.xml"
+    end
+
+    def remote_main_file_name
+      "DIT_TAQ01_V1_#{timestamp}.xml"
+    end
+
+    def local_main_file_path
+      path = record.xml.url.prepend('public')
+      Rails.root.join(path)
+    end
+
+    def local_metadata_file_path
+      Rails.root.join('public', 'uploads', 'store', local_metadata_filename)
+    end
+
+    def local_metadata_filename
+      JSON.parse(record.meta_data)['id']
+    end
+
+    def main_file_remote_path
+      "dev/xml_testing/#{remote_main_file_name}"
+    end
+
+    def metadata_remote_path
+      "dev/xml_testing/#{remote_metadata_file_name}"
+    end
+  end
+end

--- a/spec/services/xml_generation/taric_export_spec.rb
+++ b/spec/services/xml_generation/taric_export_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe XmlGeneration::TaricExport do
     )
   end
 
+  before(:example) do
+    allow_any_instance_of(XmlGeneration::Upload).to receive(:run) { true }
+  end
+
   it "generates valid XML" do
     create(:measure, :for_upload_today, workbasket_id: workbasket.id)
     parsed_xml = parsed_xml_for_export(xml_export_file)


### PR DESCRIPTION
We need to upload our data to an S3 bucket in order to pass it over to CDS.

This PR adds the logic to upload to S3 although the file names/bucket names
are just placeholders until we have more information on where we need to
upload the files to in production.