### PR TITLE
Remove state 'ready_for_approval'.

### DIFF
--- a/app/assets/javascripts/components/find-additional-codes.js
+++ b/app/assets/javascripts/components/find-additional-codes.js
@@ -72,7 +72,6 @@ $(document).ready(function() {
           { value: "editing", label: "Editing" },
           { value: "awaiting_cross_check", label: "Awaiting cross-check" },
           { value: "cross_check_rejected", label: "Cross-check rejected" },
-          { value: "ready_for_approval", label: "Ready for approval" },
           { value: "awaiting_approval", label: "Awaiting approval" },
           { value: "approval_rejected", label: "Approval rejected" },
           { value: "ready_for_export", label: "Ready for export" },

--- a/app/assets/javascripts/components/find-measures.js
+++ b/app/assets/javascripts/components/find-measures.js
@@ -87,7 +87,6 @@ $(document).ready(function() {
           { value: "editing", label: "Editing" },
           { value: "awaiting_cross_check", label: "Awaiting cross-check" },
           { value: "cross_check_rejected", label: "Cross-check rejected" },
-          { value: "ready_for_approval", label: "Ready for approval" },
           { value: "awaiting_approval", label: "Awaiting approval" },
           { value: "approval_rejected", label: "Approval rejected" },
           { value: "ready_for_export", label: "Ready for export" },

--- a/app/assets/javascripts/components/find-quotas.js
+++ b/app/assets/javascripts/components/find-quotas.js
@@ -90,7 +90,6 @@ $(document).ready(function() {
           { value: "editing", label: "Editing" },
           { value: "awaiting_cross_check", label: "Awaiting cross-check" },
           { value: "cross_check_rejected", label: "Cross-check rejected" },
-          { value: "ready_for_approval", label: "Ready for approval" },
           { value: "awaiting_approval", label: "Awaiting approval" },
           { value: "approval_rejected", label: "Approval rejected" },
           { value: "ready_for_export", label: "Ready for export" },

--- a/app/controllers/workbaskets/workflows/approves_controller.rb
+++ b/app/controllers/workbaskets/workflows/approves_controller.rb
@@ -3,7 +3,6 @@ module Workbaskets
     class ApprovesController < Workbaskets::Workflows::BaseController
       before_action :require_to_be_approver!
       # before_action :require_approve_not_to_be_aready_started!, only: [:new]
-      # before_action :check_approve_permissions!, only: [:create, :show]
 
       expose(:checker) do
         ::WorkbasketInteractions::Workflow::Approve.new(
@@ -13,10 +12,6 @@ module Workbaskets
 
       expose(:check_completed_url) do
         approve_url(workbasket.id)
-      end
-
-      def new
-        workbasket.assign_approver!(current_user)
       end
 
     private
@@ -30,18 +25,12 @@ module Workbaskets
 
       def require_approve_not_to_be_aready_started!
         if workbasket.approve_process_can_not_be_started? &&
-            !workbasket.can_continue_approve?(current_user)
+            !workbasket.awaiting_approval?
           redirect_to read_only_url
           false
         end
       end
 
-      def check_approve_permissions!
-        unless workbasket.approver_is?(current_user)
-          redirect_to read_only_url
-          false
-        end
-      end
     end
   end
 end

--- a/app/controllers/workbaskets/workflows/cross_checks_controller.rb
+++ b/app/controllers/workbaskets/workflows/cross_checks_controller.rb
@@ -1,8 +1,6 @@
 module Workbaskets
   module Workflows
     class CrossChecksController < Workbaskets::Workflows::BaseController
-      # before_action :require_cross_check_not_to_be_aready_started!, only: [:new]
-      # before_action :check_cross_check_permissions!, only: [:create, :show]
 
       expose(:checker) do
         ::WorkbasketInteractions::Workflow::CrossCheck.new(
@@ -14,27 +12,6 @@ module Workbaskets
         cross_check_url(workbasket.id)
       end
 
-      def new
-        workbasket.assign_cross_checker!(current_user)
-      end
-
-    private
-
-      def require_cross_check_not_to_be_aready_started!
-        if workbasket.cross_check_process_can_not_be_started? &&
-            !workbasket.can_continue_cross_check?(current_user)
-
-          redirect_to read_only_url
-          false
-        end
-      end
-
-      def check_cross_check_permissions!
-        unless workbasket.cross_checker_is?(current_user)
-          redirect_to read_only_url
-          false
-        end
-      end
     end
   end
 end

--- a/app/controllers/workbaskets/workflows/workflow_transitions_controller.rb
+++ b/app/controllers/workbaskets/workflows/workflow_transitions_controller.rb
@@ -12,7 +12,7 @@ module Workbaskets
     private
 
       def check_permissions!
-        unless current_user.author_of_workbasket?(workbasket) || current_user.approver? || workbasket.cross_checker_is?(current_user)
+        unless current_user.author_of_workbasket?(workbasket) || current_user.approver?
           redirect_to read_only_url
           false
         end

--- a/app/decorators/workbaskets/workbasket_decorator.rb
+++ b/app/decorators/workbaskets/workbasket_decorator.rb
@@ -43,8 +43,6 @@ module Workbaskets
         "Awaiting cross-check"
       when :cross_check_rejected
         "Cross-check rejected"
-      when :ready_for_approval
-        "Ready for approval"
       when :awaiting_approval
         "Awaiting approval"
       when :approval_rejected

--- a/app/helpers/workbasket_workflow_helper.rb
+++ b/app/helpers/workbasket_workflow_helper.rb
@@ -16,7 +16,6 @@ module WorkbasketWorkflowHelper
 
   def workbasket_view_show_actions_allowed?
     workbasket.awaiting_cross_check? ||
-      workbasket.ready_for_approval? ||
       workbasket.ready_for_export? ||
       workbasket.awaiting_cds_upload_create_new?
   end

--- a/app/models/workbaskets/event.rb
+++ b/app/models/workbaskets/event.rb
@@ -1,10 +1,5 @@
 module Workbaskets
   class Event < Sequel::Model(:workbaskets_events)
-    EXTRA_STATES = %w(
-      cross_check_process_started
-      approve_process_started
-    ).freeze
-
     plugin :timestamps
 
     many_to_one :workbasket, key: :workbasket_id,
@@ -19,7 +14,7 @@ module Workbaskets
                   :user_id,
                   :workbasket_id
 
-      inclusion_of :event_type, in: ::Workbaskets::Workbasket::STATUS_LIST.map(&:to_s) + EXTRA_STATES
+      inclusion_of :event_type, in: ::Workbaskets::Workbasket::STATUS_LIST.map(&:to_s)
     end
 
     def user_name

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -30,9 +30,6 @@ module Workbaskets
       :cross_check_rejected,           # Cross-check rejected
                                        # Did not pass cross-check, returned to submitter
                                        #
-      :ready_for_approval,             # Ready for approval
-                                       # Has passed cross-check but not yet submitted for approval
-                                       #
       :awaiting_approval,              # Awaiting approval
                                        # Submitted for approval, pending response from Approver
                                        #
@@ -302,28 +299,6 @@ module Workbaskets
             end
           end
 
-          def assign_cross_checker!(current_user)
-            add_event!(current_user, :cross_check_process_started)
-
-            self.cross_checker_id = current_user.id
-            save
-          end
-
-          def assign_approver!(current_user)
-            add_event!(current_user, :approve_process_started)
-
-            self.approver_id = current_user.id
-            save
-          end
-
-          def cross_checker_is?(current_user)
-            cross_checker_id.to_i == current_user.id
-          end
-
-          def approver_is?(current_user)
-            approver_id.to_i == current_user.id
-          end
-
           def edit_type?
             EDIT_WORKABSKETS.include?(type)
           end
@@ -367,10 +342,6 @@ module Workbaskets
 
           def approve_process_can_not_be_started?
             !approve_process_can_be_started?
-          end
-
-          def can_continue_approve?(current_user)
-            awaiting_approval? && current_user.approver?
           end
 
           def awaiting_cds_upload_new_or_edit_item?

--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/_actions_allowed.html.slim
@@ -4,10 +4,6 @@
       = link_to "Withdraw workbasket from workflow", "#", data: { target_url: withdraw_workbasket_from_workflow_bulk_edit_of_measure_url(workbasket.id) }, class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 
-    - if workbasket.ready_for_approval? && (iam_workbasket_author? || current_user.approver? || workbasket.cross_checker_is?(current_user))
-      = link_to "Submit for approval", submit_for_approval_workflow_transitions_url(workbasket.id), class: "button", method: :post
-      br
-
     - if current_user.approver?
       - if workbasket.ready_for_export?
         = link_to "Schedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"

--- a/app/views/workbaskets/create_geographical_area/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/create_geographical_area/workflow_screens_parts/_actions_allowed.html.slim
@@ -4,10 +4,6 @@
       = link_to "Withdraw workbasket from workflow", "#", data: { target_url: withdraw_workbasket_from_workflow_create_geographical_area_url(workbasket.id) }, class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 
-    - if workbasket.ready_for_approval? && (iam_workbasket_author? || current_user.approver? || workbasket.cross_checker_is?(current_user))
-      = link_to "Submit for approval", submit_for_approval_workflow_transitions_url(workbasket.id), class: "button", method: :post
-      br
-
     - if current_user.approver?
       - if workbasket.ready_for_export?
         = link_to "Schedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/_actions_allowed.html.slim
@@ -4,10 +4,6 @@
       = link_to "Withdraw workbasket from workflow", "#", data: { target_url: withdraw_workbasket_from_workflow_create_measure_url(workbasket.id) }, class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 
-    - if workbasket.ready_for_approval? && (iam_workbasket_author? || current_user.approver? || workbasket.cross_checker_is?(current_user))
-      = link_to "Submit for approval", submit_for_approval_workflow_transitions_url(workbasket.id), class: "button", method: :post
-      br
-
     - if current_user.approver?
       - if workbasket.ready_for_export?
         = link_to "Schedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/_actions_allowed.html.slim
@@ -4,10 +4,6 @@
       = link_to "Withdraw workbasket from workflow", "#", data: { target_url: withdraw_workbasket_from_workflow_create_measure_url(workbasket.id) }, class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 
-    - if workbasket.ready_for_approval? && (iam_workbasket_author? || current_user.approver? || workbasket.cross_checker_is?(current_user))
-      = link_to "Submit for approval", submit_for_approval_workflow_transitions_url(workbasket.id), class: "button", method: :post
-      br
-
     - if current_user.approver?
       - if workbasket.ready_for_export?
         = link_to "Schedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"

--- a/app/views/workbaskets/main_menu_parts/_actions.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_actions.html.slim
@@ -46,7 +46,7 @@
   = link_to "Review for cross-check", new_cross_check_url(workbasket.id)
 
 - if @current_user.approver?
-  - if workbasket.can_continue_approve?(@current_user)
+  - if workbasket.awaiting_approval?
     | &nbsp;|&nbsp;
     = link_to "Review for approval", new_approve_url(workbasket.id)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,6 @@ en:
       editing: "Editing"
       awaiting_cross_check: "Awaiting cross-check"
       cross_check_rejected: "Cross-check rejected"
-      ready_for_approval: "Ready for approval"
       awaiting_approval: "Awaiting approval"
       approval_rejected: "Approval rejected"
       ready_for_export: "Ready for export"

--- a/spec/unit/searches/measures/status_filter_spec.rb
+++ b/spec/unit/searches/measures/status_filter_spec.rb
@@ -9,18 +9,18 @@ describe "Measure search: status filter" do
     create(:measure, status: "new_in_progress")
   end
 
-  let(:ready_for_approval_measure) do
-    create(:measure, status: "ready_for_approval")
+  let(:awaiting_approval_measure) do
+    create(:measure, status: "awaiting_approval")
   end
 
-  let(:second_ready_for_approval_measure) do
-    create(:measure, status: "ready_for_approval")
+  let(:second_awaiting_approval_measure) do
+    create(:measure, status: "awaiting_approval")
   end
 
   before do
     new_in_progress_measure
-    ready_for_approval_measure
-    second_ready_for_approval_measure
+    awaiting_approval_measure
+    second_awaiting_approval_measure
   end
 
   describe "Valid Search" do
@@ -37,14 +37,14 @@ describe "Measure search: status filter" do
       res = search_results(
         enabled: true,
         operator: 'is',
-        value: "ready_for_approval"
+        value: "awaiting_approval"
       )
 
       expect(res.count).to be_eql(2)
 
       measure_sids = res.map(&:measure_sid)
-      expect(measure_sids).to include(ready_for_approval_measure.measure_sid)
-      expect(measure_sids).to include(second_ready_for_approval_measure.measure_sid)
+      expect(measure_sids).to include(awaiting_approval_measure.measure_sid)
+      expect(measure_sids).to include(second_awaiting_approval_measure.measure_sid)
       expect(measure_sids).not_to include(new_in_progress_measure.measure_sid)
     end
 


### PR DESCRIPTION
Remove assigning of cross-checker and approver state workbasket events.
https://trello.com/c/w1eRy95L/760-whenever-the-user-enter-the-cross-check-page-a-status-change-entry-is-made-in-the-events-for-the-workbasket-this-leads-to-a-very