### PR TITLE
Summary pages for measures should display the entered commodity codes

### DIFF
--- a/app/views/workbaskets/create_measures/steps/review_and_submit/_details.html.slim
+++ b/app/views/workbaskets/create_measures/steps/review_and_submit/_details.html.slim
@@ -42,7 +42,7 @@ table.create-measures-details-table
       td.heading_column
         | Goods
       td
-        = attributes_parser.commodity_codes_formatted
+        = attributes_parser.commodity_codes
 
     tr
       td.heading_column

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -30,7 +30,7 @@ table.create-measures-details-table
       td.heading_column
         | Goods
       td
-        = attributes_parser.commodity_codes_formatted
+        = attributes_parser.commodity_codes
 
     tr
       td.heading_column

--- a/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
+++ b/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
@@ -44,7 +44,7 @@ table.create-measures-details-table
       td.heading_column
         | Goods
       td
-        = attributes_parser.commodity_codes_formatted
+        = attributes_parser.commodity_codes
 
     tr
       td.heading_column

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -44,7 +44,7 @@ table.create-measures-details-table
       td.heading_column
         | Goods
       td
-        = attributes_parser.commodity_codes_formatted
+        = attributes_parser.commodity_codes
 
     tr
       td.heading_column


### PR DESCRIPTION
Summary pages for measures should display the entered commodity codes, not the filtered codes.

https://trello.com/c/8c91fOrf/761-create-measures-in-summary-pages-display-the-commodity-codes-that-the-user-entered-not-the-filtered-codes