### PR TITLE
ON6 bugfix

### DIFF
--- a/app/interactors/workbasket_interactions/settings_saver_base.rb
+++ b/app/interactors/workbasket_interactions/settings_saver_base.rb
@@ -140,16 +140,6 @@ module WorkbasketInteractions
       end
 
       if self.class::WORKBASKET_TYPE == "CreateQuota"
-        if quota_ordernumber.present?
-          unless order_number_saver.valid?
-            general_errors[:quota_ordernumber] = order_number_saver.errors
-                                                                   .join('. ')
-          end
-
-        else
-          general_errors[:quota_ordernumber] = errors_translator(:quota_ordernumber)
-        end
-
         if geographical_area_id.present?
           if candidates.flatten.compact.blank?
             general_errors[:commodity_codes] = errors_translator(:blank_commodity_and_additional_codes)
@@ -192,6 +182,15 @@ module WorkbasketInteractions
           if quota_precision.blank?
             general_errors[:maximum_precision] = errors_translator(:maximum_precision_blank)
           end
+        end
+
+        if quota_ordernumber.present? && general_errors.blank? && !order_number_saver.valid?
+          general_errors[:quota_ordernumber] = order_number_saver.errors
+                                                                 .join('. ')
+        end
+
+        unless quota_ordernumber.present?
+          general_errors[:quota_ordernumber] = errors_translator(:quota_ordernumber)
         end
       end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/u2xFT56y/765-on6-conformance-error-on-creating-a-new-quota

ON6 conformance error is getting raised when a user does not fill in the quota periods.

The expected behaviour is that it shows an error that tells the user that they missed filling
in a field and does not show conformance errors until the form is correctly completed.

This PR fixes this bug by only doing conformance checks if the quota period section of the
quota form is filled out and raising general validation errors if it is not.