### PR TITLE
Allow navigation to next workbasket in workflow

### DIFF
--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -9,7 +9,7 @@ ul class="list"
 
   - if mode == "approve" && next_approve.present? && workbasket.id != next_approve.id
     li
-      = link_to "Review next workbasket", new_approve_url(next_approve.id)
+      = link_to "Approve next workbasket", new_approve_url(next_approve.id)
 
   li
     = link_to "Return to main menu", root_url

--- a/app/views/workbaskets/create_geographical_area/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/create_geographical_area/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -9,7 +9,7 @@ ul class="list"
 
   - if mode == "approve" && next_approve.present? && workbasket.id != next_approve.id
     li
-      = link_to "Review next workbasket", new_approve_url(next_approve.id)
+      = link_to "Approve next workbasket", new_approve_url(next_approve.id)
 
   li
     = link_to "Return to main menu", root_url

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -9,7 +9,7 @@ ul class="list"
 
   - if mode == "approve" && next_approve.present? && workbasket.id != next_approve.id
     li
-      = link_to "Review next workbasket", new_approve_url(next_approve.id)
+      = link_to "Approve next workbasket", new_approve_url(next_approve.id)
 
   li
     = link_to "Return to main menu", root_url

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
@@ -9,4 +9,4 @@
     br
     | Once approved it will be made live.
 
-= render "workbaskets/create_quota/workflow_screens_parts/status_pages/next_step_links", mode: "approve"
+= render "workbaskets/create_quota/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -9,7 +9,7 @@ ul class="list"
 
   - if mode == "approve" && next_approve.present? && workbasket.id != next_approve.id
     li
-      = link_to "Review next workbasket", new_approve_url(next_approve.id)
+      = link_to "Approve next workbasket", new_approve_url(next_approve.id)
 
   li
     = link_to "Return to main menu", root_url

--- a/spec/features/workbasket/cross_check_and_approval/cross_check_and_approval_spec.rb
+++ b/spec/features/workbasket/cross_check_and_approval/cross_check_and_approval_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'cross check', :js do
       title: '093456',
       type: :create_quota,
       status: :awaiting_cross_check,)
-    end
+  end
   let!(:quota_order_number) { create(:quota_order_number, workbasket_id: workbasket.id) }
   let!(:quota_definition) { create(:quota_definition, :actual, quota_order_number_id: quota_order_number.id)}
   let!(:other_user) { create(:user, name: 'Other user') }
@@ -33,6 +33,7 @@ RSpec.describe 'cross check', :js do
       click_button('Finish cross-check')
       expect(page).to have_content('Quota cross-checked.')
       expect(workbasket.reload.status).to eq('awaiting_approval')
+      expect(page).to_not have_content("Cross-check next workbasket")
     end
 
     it 'allows rejecting' do
@@ -42,6 +43,29 @@ RSpec.describe 'cross check', :js do
       click_button('Finish cross-check')
       expect(page).to have_content('Quota cross-check rejected')
       expect(workbasket.reload.status).to eq('cross_check_rejected')
+      expect(page).to_not have_content("Cross-check next workbasket")
+    end
+
+    context 'user has more workbaskets to cross check' do
+      before(:example) do
+        another_workbasket = create(:workbasket, user_id: other_user.id, title: '097456', type: :create_quota, status: :awaiting_cross_check)
+        create(:quota_order_number, workbasket_id: another_workbasket.id)
+        create(:quota_definition, :actual, quota_order_number_id: quota_order_number.id)
+        another_measure = create(:measure, status: :awaiting_cross_check, workbasket_id: another_workbasket.id, measure_type: measure_type, geographical_area: geographical_area, quota_order_number: quota_order_number)
+        another_workbasket.settings.measure_sids_jsonb = "[#{another_measure.measure_sid}]"
+        another_workbasket.settings.save
+      end
+
+      it 'shows `Cross-check next workbasket` link' do
+        visit root_path
+        first(:link, 'Review for cross-check').click
+        select_approve
+        click_button('Finish cross-check')
+        expect(page).to have_content('Quota cross-checked')
+        expect(page).to have_content('Cross-check next workbasket')
+        click_link 'Cross-check next workbasket'
+        expect(page).to have_content('Cross-check and create quota')
+      end
     end
   end
 
@@ -62,6 +86,7 @@ RSpec.describe 'cross check', :js do
       confirm_approval
       expect(page).to have_content('Quota approved')
       expect(workbasket.reload.status).to eq('awaiting_cds_upload_create_new')
+      expect(page).to_not have_content('Approve next workbasket')
     end
 
     it 'allows rejecting' do
@@ -70,6 +95,28 @@ RSpec.describe 'cross check', :js do
       reject_approval
       expect(page).to have_content('Quota rejected')
       expect(workbasket.reload.status).to eq('approval_rejected')
+      expect(page).to_not have_content('Approve next workbasket')
+    end
+
+    context 'user has more workbaskets to approve' do
+      before(:example) do
+        another_workbasket = create(:workbasket, user_id: other_user.id, title: '097456', type: :create_quota, status: :awaiting_approval)
+        create(:quota_order_number, workbasket_id: another_workbasket.id)
+        create(:quota_definition, :actual, quota_order_number_id: quota_order_number.id)
+        another_measure = create(:measure, status: :awaiting_cross_check, workbasket_id: another_workbasket.id, measure_type: measure_type, geographical_area: geographical_area, quota_order_number: quota_order_number)
+        another_workbasket.settings.measure_sids_jsonb = "[#{another_measure.measure_sid}]"
+        another_workbasket.settings.save
+      end
+
+      it 'shows `Approve next workbasket` link' do
+        visit root_path
+        first(:link, 'Review for approval').click
+        confirm_approval
+        expect(page).to have_content('Quota approved')
+        expect(page).to have_content('Approve next workbasket')
+        click_link 'Approve next workbasket'
+        expect(page).to have_content('Approve new quota')
+      end
     end
   end
 


### PR DESCRIPTION
This change allows users to navigate to the next workbasket they need to cross check or approve
without going back to the main menu first.