### PR TITLE
Display the commodity code exceptions that were entered.

### DIFF
--- a/app/value_objects/workbasket_value_objects/attributes_parser_base.rb
+++ b/app/value_objects/workbasket_value_objects/attributes_parser_base.rb
@@ -72,6 +72,11 @@ module WorkbasketValueObjects
                           .uniq : []
     end
 
+    def entered_exception_codes
+      ops['commodity_codes_exclusions']
+    end
+
+
     def candidates
       a_codes = @additional_codes_analyzer.collection
       gn_codes = @commodity_codes_analyzer.collection

--- a/app/views/workbaskets/create_measures/steps/review_and_submit/_details.html.slim
+++ b/app/views/workbaskets/create_measures/steps/review_and_submit/_details.html.slim
@@ -48,7 +48,7 @@ table.create-measures-details-table
       td.heading_column
         | Goods exceptions
       td
-        = attributes_parser.exclusions_formatted
+        = attributes_parser.entered_exception_codes
 
     tr
       td.heading_column

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -36,7 +36,7 @@ table.create-measures-details-table
       td.heading_column
         | Goods exceptions
       td
-        = attributes_parser.exclusions_formatted
+        = attributes_parser.entered_exception_codes
 
     tr
       td.heading_column

--- a/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
+++ b/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
@@ -50,7 +50,7 @@ table.create-measures-details-table
       td.heading_column
         | Goods exceptions
       td
-        = attributes_parser.exclusions_formatted
+        = attributes_parser.entered_exception_codes
 
     tr
       td.heading_column

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -50,7 +50,7 @@ table.create-measures-details-table
       td.heading_column
         | Goods exceptions
       td
-        = attributes_parser.exclusions_formatted
+        = attributes_parser.entered_exception_codes
 
     tr
       td.heading_column


### PR DESCRIPTION
Currently if an exception code is entered that is not a leaf node, then the page will show all the leaves instead of the original value entered. This change is made so that pages show the original exception codes entered.