### PR TITLE
positive-confirmations-inline

### DIFF
--- a/app/assets/stylesheets/components/alert.scss
+++ b/app/assets/stylesheets/components/alert.scss
@@ -39,3 +39,19 @@
     top: -0.4em;
   }
 }
+
+/* Form actions */
+
+.form-actions {
+  .alert--success {
+    margin-top: 3rem;
+    top: 0;
+    font-size: 1.6rem;
+    font-weight: normal;
+    line-height: 3.6rem;
+  }
+  .icon {
+    width: 3.3rem;
+    top: 0;
+  }
+}

--- a/app/views/workbaskets/create_additional_code/_action_links.html.slim
+++ b/app/views/workbaskets/create_additional_code/_action_links.html.slim
@@ -1,7 +1,7 @@
 .form-actions
   h3.heading-medium
     | Finish
-
+    = render "workbaskets/shared/success_message", f: f
   .submit_group_for_cross_check_block
     button type="submit" name="submit_for_cross_check" class="button js-workbasket-base-continue-button js-workbasket-base-submit-button" v-on:click.prevent="submitCrossCheck" v-if="!submitting" :disabled="saving || submitting"
       | Submit for cross-check

--- a/app/views/workbaskets/create_additional_code/_form.html.slim
+++ b/app/views/workbaskets/create_additional_code/_form.html.slim
@@ -15,7 +15,6 @@
     = render "workbaskets/create_additional_code/steps/main/details"
 
   = render "workbaskets/create_additional_code/steps/#{params[:step].to_s}", f: f
-  = render "workbaskets/shared/success_message", f: f
   = render "workbaskets/create_additional_code/conformance_errors", f: f
 
   = render "workbaskets/create_additional_code/action_links", f: f

--- a/app/views/workbaskets/create_certificate/_action_links.slim
+++ b/app/views/workbaskets/create_certificate/_action_links.slim
@@ -1,7 +1,7 @@
 .form-actions
   h3.heading-medium
     | Finish
-
+    = render "workbaskets/shared/success_message", f: f
   .submit_group_for_cross_check_block
     = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 

--- a/app/views/workbaskets/create_certificate/_form.html.slim
+++ b/app/views/workbaskets/create_certificate/_form.html.slim
@@ -10,7 +10,6 @@
     = render "workbaskets/create_certificate/steps/main/details"
 
   = render "workbaskets/create_certificate/steps/#{params[:step].to_s}", f: f
-  = render "workbaskets/shared/success_message", f: f
   = render "workbaskets/create_certificate/conformance_rules_container", f: f
 
   = render "workbaskets/create_certificate/action_links", f: f

--- a/app/views/workbaskets/create_footnote/_action_links.html.slim
+++ b/app/views/workbaskets/create_footnote/_action_links.html.slim
@@ -1,7 +1,7 @@
 .form-actions
   h3.heading-medium
     | Finish
-
+    = render "workbaskets/shared/success_message", f: f
   .submit_group_for_cross_check_block
     = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 

--- a/app/views/workbaskets/create_footnote/_form.html.slim
+++ b/app/views/workbaskets/create_footnote/_form.html.slim
@@ -10,7 +10,6 @@
     = render "workbaskets/create_footnote/steps/main/details"
 
   = render "workbaskets/create_footnote/steps/#{params[:step].to_s}", f: f
-  = render "workbaskets/shared/success_message", f: f
   = render "workbaskets/create_footnote/conformance_rules_container", f: f
 
   = render "workbaskets/create_footnote/action_links", f: f

--- a/app/views/workbaskets/create_geographical_area/_action_links.html.slim
+++ b/app/views/workbaskets/create_geographical_area/_action_links.html.slim
@@ -1,7 +1,7 @@
 .form-actions
   h3.heading-medium
     | Finish
-
+    = render "workbaskets/shared/success_message", f: f
   .submit_group_for_cross_check_block
     = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 

--- a/app/views/workbaskets/create_geographical_area/_form.html.slim
+++ b/app/views/workbaskets/create_geographical_area/_form.html.slim
@@ -10,7 +10,6 @@
     = render "workbaskets/create_geographical_area/steps/main/details"
 
   = render "workbaskets/create_geographical_area/steps/#{params[:step].to_s}", f: f
-  = render "workbaskets/shared/success_message", f: f
   = render "workbaskets/create_geographical_area/conformance_rules_container", f: f
 
   = render "workbaskets/create_geographical_area/action_links", f: f

--- a/app/views/workbaskets/create_measures/_form.html.slim
+++ b/app/views/workbaskets/create_measures/_form.html.slim
@@ -11,7 +11,6 @@
                         } do |f|
 
   = render "workbaskets/create_measures/steps/#{params[:step].to_s}", f: f
-  = render "workbaskets/shared/success_message", f: f
   = render "workbaskets/shared/errors_container", f: f
 
   - if step_pointer.duties_conditions_footnotes?

--- a/app/views/workbaskets/create_quota/_form.html.slim
+++ b/app/views/workbaskets/create_quota/_form.html.slim
@@ -11,7 +11,6 @@
                         } do |f|
 
   = render "workbaskets/create_quota/steps/#{params[:step].to_s}", f: f
-  = render "workbaskets/shared/success_message", f: f
   = render "workbaskets/shared/errors_container", f: f
 
   - if step_pointer.configure_quota? || step_pointer.conditions_footnotes?

--- a/app/views/workbaskets/shared/_action_links.html.slim
+++ b/app/views/workbaskets/shared/_action_links.html.slim
@@ -2,6 +2,7 @@
   h3.heading-medium
     - if step_pointer.has_next_step?
       | Next step
+      = render "workbaskets/shared/success_message", f: f
     - else
       | Finish
 


### PR DESCRIPTION
Places 'Progress saved' message under 'Next step' or 'Finish' headings for the following views:

- Create new additional codes
- Create new geographical area
- Create a new footnote
- Create measures
- Create a certificate, license or document

Here's what the new positioning looks like:

![image](https://user-images.githubusercontent.com/6898065/54425309-e7769a00-470c-11e9-8241-c844880f2497.png)
![image](https://user-images.githubusercontent.com/6898065/54425384-1a209280-470d-11e9-837a-65be085e3485.png)

Note: 'Create new registration' doesn't have 'Save progress' functionality so ignoring