### PR TITLE
confirmations-and-modals: bulk measures, save progress modal

### DIFF
--- a/app/views/measures/bulks/save_actions_popups/_base.html.slim
+++ b/app/views/measures/bulks/save_actions_popups/_base.html.slim
@@ -18,7 +18,7 @@
           .form-actions
             button.button style="display:none"
               | Nothing
-            a.secondary-button href="#" onClick="MicroModal.close('bem-#{modal_id}'); return false;"
+            a.button href="#" onClick="MicroModal.close('bem-#{modal_id}'); return false;"
               | OK
 
 


### PR DESCRIPTION
Replaces link with GOVUK button in bulk measures save progress confirmation modal.

Turns this:
![image](https://user-images.githubusercontent.com/6898065/54439122-13efdd80-4730-11e9-962b-50d20ac62139.png)

Into this:
![image](https://user-images.githubusercontent.com/6898065/54439135-1c481880-4730-11e9-81a2-bda94656c8f2.png)

Note: Somehow doubt this is the only confirmation modal in the app, but it's the only one I could find. Will raise further PRs as/when I see more of these.