### PR TITLE
Fix bug that stopped users seeing reject reasons

### DIFF
--- a/app/views/workbaskets/create_quota/show.html.slim
+++ b/app/views/workbaskets/create_quota/show.html.slim
@@ -1,1 +1,28 @@
-= render "workbaskets/shared/show_base"
+.breadcrumbs
+  ol
+    li
+      = link_to "Tariff Management", root_url
+
+    li
+      = link_to "Measures", measures_url
+
+    li aria-current="page"
+      | View quota workbasket
+
+header
+  h1.heading-large
+    | View quota workbasket
+
+  .view-workbasket-container
+    = render "workbaskets/create_quota/workflow_screens_parts/notifications/block", screen_type: :view
+    = render "workbaskets/create_quota/workflow_screens_parts/actions_allowed"
+    = render "workbaskets/create_quota/workflow_screens_parts/workbasket_details"
+
+    - if iam_workbasket_author? && workbasket_rejected?
+      = link_to "Edit quota", move_to_editing_mode_create_quotum_url(workbasket.id),
+                                 class: "secondary-button view-workbasket-edit-measures-link"
+
+    - if workbasket_awaiting_cross_check_or_rejected?
+      = render "workbaskets/create_quota/workflow_screens_parts/summary_of_configuration"
+
+    = render "workbaskets/shared/steps/review_and_submit/quotas", read_only: true, record_type: 'create_measures'

--- a/app/views/workbaskets/create_quota/steps/_review_and_submit.html.slim
+++ b/app/views/workbaskets/create_quota/steps/_review_and_submit.html.slim
@@ -10,7 +10,7 @@
   = render "workbaskets/create_quota/steps/review_and_submit/message", read_only: read_only
   = render "workbaskets/create_quota/steps/review_and_submit/details", read_only: read_only
   = render "workbaskets/create_quota/steps/review_and_submit/quota_periods", read_only: read_only
-  = render "workbaskets/shared/steps/review_and_submit/measures", read_only: read_only, record_type: 'create_quota'
+  = render "workbaskets/shared/steps/review_and_submit/quotas", read_only: read_only, record_type: 'create_quota'
 
   - if read_only
     .form-actions

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_approval_rejected.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_approval_rejected.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota has been rejected. The approver gave the reasons detailed below.

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_cross_check_rejected.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_cross_check_rejected.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota detailed below has been cross-checked and rejected. The cross-checker gave the reasons detailed below.

--- a/app/views/workbaskets/shared/steps/review_and_submit/_quotas.html.slim
+++ b/app/views/workbaskets/shared/steps/review_and_submit/_quotas.html.slim
@@ -1,5 +1,5 @@
 h3.heading-medium Quota periods to be created after cross-check
-= render "workbaskets/#{record_type}/steps/review_and_submit/quota_periods_table"
+= render "workbaskets/create_quota/steps/review_and_submit/quota_periods_table"
 
 h3.heading-medium Measures to be created after cross-check
-= render "workbaskets/#{record_type}/steps/review_and_submit/measures_table"
+= render "workbaskets/create_quota/steps/review_and_submit/measures_table"


### PR DESCRIPTION
Users cannot see the reasons that their quotas have been rejected from
cross-check or approve due to the views that are being rendered in the workflow
process. This PR fixes this issue. (See before and after screenshots below).

# Before:
![Screenshot 2019-03-18 at 12 41 12](https://user-images.githubusercontent.com/13124899/54530624-3164b780-497b-11e9-90e5-6b730e05a6d5.png)
![Screenshot 2019-03-18 at 12 41 28](https://user-images.githubusercontent.com/13124899/54530627-33c71180-497b-11e9-948f-42c6c81fc4bd.png)

# After:
![Screenshot 2019-03-18 at 12 28 40](https://user-images.githubusercontent.com/13124899/54530234-25c4c100-497a-11e9-87e6-e51bcadbf36e.png)
![Screenshot 2019-03-18 at 12 28 54](https://user-images.githubusercontent.com/13124899/54530239-29584800-497a-11e9-90cd-8610c4092584.png)
