### PR TITLE
Fix Exception in Commodity Code Check

### DIFF
--- a/app/views/shared/_tariff_breadcrumbs.html.erb
+++ b/app/views/shared/_tariff_breadcrumbs.html.erb
@@ -4,7 +4,7 @@
     <% if @nomenclature.commodity? %>
       <ul>
         <li>
-          Section <%= @nomenclature.section.numeral %>: <%= @nomenclature.section.title %>
+          Section <%= @nomenclature.section&.numeral %>: <%= @nomenclature.section&.title %>
           <ul>
             <li class="chapter-li">
               <div class="chapter-code">
@@ -27,7 +27,7 @@
     <% elsif @nomenclature.heading? %>
       <ul>
         <li>
-          Section <%= @nomenclature.section.numeral %>: <%= @nomenclature.section.title %>
+          Section <%= @nomenclature.section&.numeral %>: <%= @nomenclature.section&.title %>
           <ul>
             <li class="chapter-li">
               <div class="chapter-code">
@@ -49,7 +49,7 @@
     <% elsif @nomenclature.chapter? %>
       <ul>
         <li>
-          Section <%= @nomenclature.section.numeral %>: <%= @nomenclature.section.title %>
+          Section <%= @nomenclature.section&.numeral %>: <%= @nomenclature.section&.title %>
           <ul>
             <li class="chapter-li">
               <div class="chapter-code">


### PR DESCRIPTION
 (due to the chapters_sections table being empty on the development server)

Not sure if this is likely on a live server, but made the code 'nil-safe' incase the table is empty.
https://trello.com/c/mumT3Fyq/827-check-a-commodity-code-description-link-is-not-working-in-create-measure-form