### PR TITLE
Allow select all even if some items are locked

### DIFF
--- a/app/assets/javascripts/vue_components/records-grid.js
+++ b/app/assets/javascripts/vue_components/records-grid.js
@@ -53,14 +53,6 @@ Vue.component("records-grid", {
     locked: function(item) {
       return(item.status !== 'Published')
     },
-    oneOrMoreLockedItems: function() {
-      var lockedStatusOfItems;
-      lockedStatusOfItems = this.data.map(item => this.locked(item));
-      return(lockedStatusOfItems.includes(true))
-    },
-    showSelectAll: function() {
-      return(this.disableSelectAll !== true && this.oneOrMoreLockedItems() === false)
-    },
     selectSorting: function(column) {
       var f = column.field;
 

--- a/app/views/shared/vue_templates/_records_grid.html.erb
+++ b/app/views/shared/vue_templates/_records_grid.html.erb
@@ -2,7 +2,7 @@
   <div class="records-table-wrapper">
     <div :class="classes">
       <div class="table__header">
-        <div class="table__column select-all-column" v-if="disableSelection !== true && oneOrMoreLockedItems() !== true">
+        <div class="table__column select-all-column" v-if="disableSelection !== true">
           <input type="checkbox" class="select-all" value='1' v-model="selectAll" :checked="selectionType == 'all'" v-if="disableSelectAll !== true" />
         </div>
         <div v-for="column in enabledColumns" v-bind:class="'table__column ' + column.field + '-column'">


### PR DESCRIPTION
Select all functionality is currently unavailable if some of the items
in the search list are locked. This commit allows select all to work for
all but the locked items even when both locked and unlocked items
are shown in the list of items.