### PR TITLE
Applies GDS error summary style

### DIFF
--- a/app/assets/stylesheets/components/measure_form.scss
+++ b/app/assets/stylesheets/components/measure_form.scss
@@ -1,8 +1,8 @@
 .js-workbasket-errors-container, .js-workbasket-base-success-message-container {
-  color: #a94442;
-  background-color: #f2dede;
-  border-color: #ebccd1;
-  padding: 15px;
+  color:black;
+  background-color: white;
+  border: 5px solid #b10e1e;
+  padding: 20px;
 
   h3.workbasket-form-errors-header {
     font-size: 24px;


### PR DESCRIPTION
Bit of a damp squib, but at least the error summaries now display more like GOVUK than before. This is still not the correct design pattern (the error summary block should contain a list of errors that link to the form elements where the validation has failed -- see https://design-system.service.gov.uk/components/error-summary/).

Also, I could not find an easy way to move the error summary block to the top of the page. In any case, here is what the style update looks like for the error summary:

![image](https://user-images.githubusercontent.com/6898065/54826497-d5b26b00-4ca7-11e9-827c-61753c10e2b9.png)
