### PR TITLE
Create measures details table width correction

### DIFF
--- a/app/assets/stylesheets/components/create-measures.scss
+++ b/app/assets/stylesheets/components/create-measures.scss
@@ -32,6 +32,7 @@ span.create-measures-sub_header {
 .create-measures-details-table {
   margin-bottom: 60px;
   overflow: hidden;
+  width: 640px;
 
   td {
     font-size: 16px;


### PR DESCRIPTION
Sets table width to 640px (50% of 1280px)

![image](https://user-images.githubusercontent.com/6898065/54925245-cd576b80-4f05-11e9-8ff0-c8b2d0423777.png)
