### PR TITLE
Adjust vertical spacings

### DIFF
--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -277,7 +277,7 @@ label abbr {
 }
 
 .remove-link {
-  color: $red;
+  color: $link-colour;
   text-decoration: underline;
 }
 

--- a/app/assets/stylesheets/components/panels.scss
+++ b/app/assets/stylesheets/components/panels.scss
@@ -22,4 +22,5 @@
 
 .panel {
   padding: 0 1em;
+  margin-bottom: 2em;
 }

--- a/app/assets/stylesheets/components/panels.scss
+++ b/app/assets/stylesheets/components/panels.scss
@@ -19,3 +19,7 @@
     margin-bottom: 2em !important;
   }
 }
+
+.panel {
+  padding: 0 1em;
+}


### PR DESCRIPTION
Brings 'Origin mechanic' styling closer to design reference*:
https://uktrade.atlassian.net/wiki/spaces/TARIFFSALPHA/pages/621346929/Mechanic+-+Origin+s+Selector

This is what this looks like:

![image](https://user-images.githubusercontent.com/6898065/54927859-e878aa00-4f0a-11e9-91a0-f670489abc3d.png)
