### PR TITLE
DO NOT MERGE: Update measures status

### DIFF
--- a/app/interactors/workbasket_interactions/workflow/approve.rb
+++ b/app/interactors/workbasket_interactions/workflow/approve.rb
@@ -8,6 +8,15 @@ module WorkbasketInteractions
           workbasket.operation_date = export_date.to_date
           workbasket.save
         end
+        workbasket.settings.measure_sids.each do |sid|
+          measure = Measure.find(measure_sid: sid)
+          measure.status = if workbasket.type == "bulk_edit_of_measures"
+            measure.status = "awaiting_cds_upload_edit"
+          else
+            measure.status = "awaiting_cds_upload_create_new"
+          end
+          measure.save
+        end
       end
 
       def post_reject_action!

--- a/app/interactors/workbasket_interactions/workflow/approve.rb
+++ b/app/interactors/workbasket_interactions/workflow/approve.rb
@@ -17,6 +17,11 @@ module WorkbasketInteractions
           end
           measure.save
         end
+        workbasket.settings.quota_period_sids.each do |sid|
+          quota = QuotaDefinition.find(quota_definition_sid: sid)
+          quota.status = "awaiting_cds_upload_create_new"
+          quota.save
+        end
       end
 
       def post_reject_action!

--- a/app/interactors/workbasket_interactions/workflow/approve.rb
+++ b/app/interactors/workbasket_interactions/workflow/approve.rb
@@ -17,16 +17,30 @@ module WorkbasketInteractions
           end
           measure.save
         end
-        workbasket.settings.quota_period_sids.each do |sid|
-          quota = QuotaDefinition.find(quota_definition_sid: sid)
-          quota.status = "awaiting_cds_upload_create_new"
-          quota.save
+        if workbasket.settings.try(:quota_period_sids)
+          workbasket.settings.quota_period_sids.each do |sid|
+            quota = QuotaDefinition.find(quota_definition_sid: sid)
+            quota.status = "awaiting_cds_upload_create_new"
+            quota.save
+          end
         end
       end
 
       def post_reject_action!
         workbasket.approver_id = nil
         workbasket.save
+        workbasket.settings.measure_sids.each do |sid|
+          measure = Measure.find(measure_sid: sid)
+          measure.status = "approval_rejected"
+          measure.save
+        end
+        if workbasket.settings.try(:quota_period_sids)
+          workbasket.settings.quota_period_sids.each do |sid|
+            quota = QuotaDefinition.find(quota_definition_sid: sid)
+            quota.status = "approval_rejected"
+            quota.save
+          end
+        end
       end
 
       def approve_status

--- a/app/interactors/workbasket_interactions/workflow/approve.rb
+++ b/app/interactors/workbasket_interactions/workflow/approve.rb
@@ -11,9 +11,9 @@ module WorkbasketInteractions
         workbasket.settings.measure_sids.each do |sid|
           measure = Measure.find(measure_sid: sid)
           measure.status = if workbasket.type == "bulk_edit_of_measures"
-            measure.status = "awaiting_cds_upload_edit"
+            "awaiting_cds_upload_edit"
           else
-            measure.status = "awaiting_cds_upload_create_new"
+            "awaiting_cds_upload_create_new"
           end
           measure.save
         end

--- a/app/interactors/workbasket_interactions/workflow/cross_check.rb
+++ b/app/interactors/workbasket_interactions/workflow/cross_check.rb
@@ -13,16 +13,30 @@ module WorkbasketInteractions
           measure.status = "awaiting_approval"
           measure.save
         end
-        workbasket.settings.quota_period_sids.each do |sid|
-          quota = QuotaDefinition.find(quota_definition_sid: sid)
-          quota.status = "awaiting_approval"
-          quota.save
+        if workbasket.settings.try(:quota_period_sids)
+          workbasket.settings.quota_period_sids.each do |sid|
+            quota = QuotaDefinition.find(quota_definition_sid: sid)
+            quota.status = "awaiting_approval"
+            quota.save
+          end
         end
       end
 
       def post_reject_action!
         workbasket.cross_checker_id = nil
         workbasket.save
+        workbasket.settings.measure_sids.each do |sid|
+          measure = Measure.find(measure_sid: sid)
+          measure.status = "cross_check_rejected"
+          measure.save
+        end
+        if workbasket.settings.try(:quota_period_sids)
+          workbasket.settings.quota_period_sids.each do |sid|
+            quota = QuotaDefinition.find(quota_definition_sid: sid)
+            quota.status = "cross_check_rejected"
+            quota.save
+          end
+        end
       end
 
       def approve_status

--- a/app/interactors/workbasket_interactions/workflow/cross_check.rb
+++ b/app/interactors/workbasket_interactions/workflow/cross_check.rb
@@ -8,6 +8,11 @@ module WorkbasketInteractions
           current_user,
           :awaiting_approval
         )
+        workbasket.settings.measure_sids.each do |sid|
+          measure = Measure.find(measure_sid: sid)
+          measure.status = "awaiting_approval"
+          measure.save
+        end
       end
 
       def post_reject_action!

--- a/app/interactors/workbasket_interactions/workflow/cross_check.rb
+++ b/app/interactors/workbasket_interactions/workflow/cross_check.rb
@@ -13,6 +13,11 @@ module WorkbasketInteractions
           measure.status = "awaiting_approval"
           measure.save
         end
+        workbasket.settings.quota_period_sids.each do |sid|
+          quota = QuotaDefinition.find(quota_definition_sid: sid)
+          quota.status = "awaiting_approval"
+          quota.save
+        end
       end
 
       def post_reject_action!


### PR DESCRIPTION
Update statuses of objects within in a workbasket to match the status of a workbasket as it goes through the cross-check/approval workflow