### PR TITLE
Allow upload xml from edit measures workbaskets

### DIFF
--- a/app/controllers/xml_generation/exports_controller.rb
+++ b/app/controllers/xml_generation/exports_controller.rb
@@ -47,7 +47,7 @@ module XmlGeneration
 
     def valid_workbasket?
       if Workbaskets::Workbasket[params[:workbasket_id]].present?
-        if Workbaskets::Workbasket[params[:workbasket_id]].status != :awaiting_cds_upload_create_new
+        unless Workbaskets::Workbasket[params[:workbasket_id]].ready_for_upload
           @form_error= "Workbasket status must be 'Awaiting CDS upload', currently it is '#{Workbaskets::Workbasket[params[:workbasket_id]].status.humanize}'."
         end
       else

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -363,6 +363,10 @@ module Workbaskets
       user.name
     end
 
+    def ready_for_upload
+      status == :awaiting_cds_upload_create_new || status == :awaiting_cds_upload_edit
+    end
+
     def ordered_events
       events.sort_by(&:created_at)
     end


### PR DESCRIPTION
We have an issue whereby the uploading of an edit measure workbasket is not
allowed despite it being approved. This is because it has a slightly different status,
i.e `awaiting_cds_upload_edit` rather than the expected `awaiting_cds_upload_create_new`.

This commit allows workbaskets with either of these statuses to be uploaded.