### PR TITLE
Fix select all bug

### DIFF
--- a/app/services/measure_service/fetch_measure_sids.rb
+++ b/app/services/measure_service/fetch_measure_sids.rb
@@ -17,9 +17,8 @@ module MeasureService
       when 'all'
         #
         # if selection_type is `all`, then `measure_sids` contains exclusions
-        #
-
-        all_measure_sids - measure_sids
+        # cannot select locked measures.
+        unlocked_measure_sids - measure_sids.map(&:to_i)
       when 'none'
         #
         # if selection_type is `none` then `measure_sids` contains selection
@@ -33,6 +32,10 @@ module MeasureService
 
     def all_measure_sids
       Rails.cache.read(search_code)
+    end
+
+    def unlocked_measure_sids
+      Measure.where(measure_sid: all_measure_sids).where("status = 'published'").pluck(:measure_sid)
     end
   end
 end


### PR DESCRIPTION
Users currently experience a bug when selecting measures which means that all measures
(even those which are locked) are selected when they tick the `select all` checkbox.

This commit fixes this issue. It changes all_measure_sids to unlocked_measure_sids meaning
that locked measures can never be selected.

Note: measure_sids need to be integers in order to subtract them from the unlocked_measure_sids
hence them being mapped to integer.