### PR TITLE
feat: display semantic version in footer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,6 +28,6 @@ module ApplicationHelper
   end
 
   def application_version_identifier
-    ENV["GIT_COMMIT"]&.slice(0..6)
+    ENV["GIT_TAG"] || ENV["GIT_COMMIT"]&.slice(0..6)
   end
 end

--- a/spec/features/version_identifier_spec.rb
+++ b/spec/features/version_identifier_spec.rb
@@ -5,8 +5,20 @@ RSpec.describe "version identifier" do
 
   before { create(:user) }
 
-  context "is available" do
-    it "is displayed in the footer" do
+  context "git tag is available" do
+    it "git tag is displayed in the footer" do
+      version_identifier = "v0.0.1"
+
+      with_environment("GIT_TAG" => version_identifier) do
+        visit root_path
+      end
+
+      expect(find("footer")).to have_content "Version v0.0.1"
+    end
+  end
+
+  context "no tag, but commit is available" do
+    it "git sha is displayed in the footer" do
       version_identifier = "772d3ac400befb2787516b93df42bc2ba73abf8d"
 
       with_environment("GIT_COMMIT" => version_identifier) do


### PR DESCRIPTION
Prior to this change, the commit sha was always shown

This change will display a tag if found or fallback to the commit sha

https://trello.com/c/znxn2sf4/825-ensure-gitcommit-environment-variable-is-used-in-healthcheck-response