### PR TITLE
'Add another duty expression' link above keyline

### DIFF
--- a/app/assets/stylesheets/components/measure-components.scss
+++ b/app/assets/stylesheets/components/measure-components.scss
@@ -1,6 +1,12 @@
-.measure-component {
+.measure-components:last-child {
   border-bottom: 1px solid $border-colour;
+  a {
+    display: block;
+    margin-bottom: 1em;
+  }
+}
 
+.measure-component {
   .form-group {
     margin-bottom: 0 !important;
   }


### PR DESCRIPTION
Prior to this change, the 'Add another duty expression' links were separated by keylines, which are not part of the design spec

This change adds SCSS styling so that the keyline only appears under the last duty expression link

This is what it looks like:
![image](https://user-images.githubusercontent.com/6898065/55246722-b5515600-523d-11e9-8184-04b9b07dac59.png)

I almost gave up trying to coax the JS+Slim to behave as intended in the design. Then, in a moment of glorious inter-dimensional 3rd eye awakening, I realised it could be done with a few lines of CSS.
