### PR TITLE
Fix: Confirmation panel styling

### DIFF
--- a/app/assets/stylesheets/components/panels.scss
+++ b/app/assets/stylesheets/components/panels.scss
@@ -2,7 +2,7 @@
   background: rgb(99, 155, 149);
   color: $white;
   border: none !important;
-  padding: 25px;
+  padding: 25px !important;
   max-width: 1180px;
   margin: 2em 0;
 


### PR DESCRIPTION
Fix: confirmation panel styling

Prior to this change, confirmation panels had insufficient padding
This change allows .panel--confirmation class to override existing padding

This is what it looked like:
![image](https://user-images.githubusercontent.com/6898065/55317704-f4172400-5468-11e9-842a-969f12f884a8.png)

This is what the fix looks like:
![image](https://user-images.githubusercontent.com/6898065/55317729-042f0380-5469-11e9-8b27-4a5645c82607.png)

