### PR TITLE
Fix: If applied, this commit will make tables scroll

### DIFF
--- a/app/assets/stylesheets/components/find-items.scss
+++ b/app/assets/stylesheets/components/find-items.scss
@@ -131,7 +131,7 @@ $find-item-gutter: 5px;
 .records-table-wrapper,
 .measures-table-wrapper {
   width: 100%;
-
+  overflow: scroll;
   .recycle-list {
     max-height: 600px;
     overflow-y: auto;


### PR DESCRIPTION
Prior to this change, wide tables had columns that could not be viewed

This change allows table scrolling so that clipped columns are viewable