### PR TITLE
Fix status change bug

### DIFF
--- a/app/controllers/admin/workbasket_status_controller.rb
+++ b/app/controllers/admin/workbasket_status_controller.rb
@@ -10,7 +10,7 @@ module Admin
     def update
       workbasket = Workbaskets::Workbasket[params[:id]]
       new_status = params[:status]
-      if allowed_status(new_status) && workbasket.move_status_to!(current_user, new_status, 'Tester backdoor')
+      if allowed_status(new_status) && workbasket.testing_status_backdoor!(current_admin: current_user, status: new_status)
         flash[:notice] = "Workbasket '#{workbasket.id}' status is now '#{workbasket.status}'"
       else
         flash[:notice] = "Status was not changed!"
@@ -21,7 +21,7 @@ module Admin
     private
 
     def allowed_status(new_status)
-      ['published', 'rejected'].include? new_status
+      ['published', 'cds_error'].include? new_status
     end
   end
 end

--- a/app/interactors/workbasket_interactions/workflow/approve.rb
+++ b/app/interactors/workbasket_interactions/workflow/approve.rb
@@ -4,15 +4,11 @@ module WorkbasketInteractions
     private
 
       def post_approve_action!
-        if export_date.present?
-          workbasket.operation_date = export_date.to_date
-          workbasket.save
-        end
+        workbasket.confirm_approval!(current_admin: current_user)
       end
 
       def post_reject_action!
-        workbasket.approver_id = nil
-        workbasket.save
+        workbasket.reject_approval!(current_admin: current_user)
       end
 
       def approve_status

--- a/app/interactors/workbasket_interactions/workflow/cross_check.rb
+++ b/app/interactors/workbasket_interactions/workflow/cross_check.rb
@@ -4,15 +4,11 @@ module WorkbasketInteractions
     private
 
       def post_approve_action!
-        workbasket.move_status_to!(
-          current_user,
-          :awaiting_approval
-        )
+        workbasket.submit_for_approval!(current_admin: current_user)
       end
 
       def post_reject_action!
-        workbasket.cross_checker_id = nil
-        workbasket.save
+        workbasket.reject_cross_check!(current_admin: current_user)
       end
 
       def approve_status

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -310,11 +310,30 @@ module Workbaskets
           def reject_cross_check!(current_admin:)
             move_status_to!(current_admin, :cross_check_rejected)
 
-            workbasket.cross_checker_id = nil
-            workbasket.save
+            cross_checker_id = nil
+            save
 
             settings.collection.map do |item|
               item.move_status_to!(:cross_check_rejected)
+            end
+          end
+
+          def confirm_approval!(current_admin:)
+            move_status_to!(current_admin, possible_approved_status)
+
+            settings.collection.map do |item|
+              item.move_status_to!(possible_approved_status)
+            end
+          end
+
+          def reject_approval!(current_admin:)
+            move_status_to!(current_admin, :approval_rejected)
+
+            approver_id = nil
+            save
+
+            settings.collection.map do |item|
+              item.move_status_to!(:approval_rejected)
             end
           end
 

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -337,6 +337,14 @@ module Workbaskets
             end
           end
 
+          def testing_status_backdoor!(current_admin:, status:)
+            move_status_to!(current_admin, status, 'Tester backdoor')
+
+            settings.collection.map do |item|
+              item.move_status_to!(status)
+            end
+          end
+
           def edit_type?
             EDIT_WORKABSKETS.include?(type)
           end

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -299,6 +299,25 @@ module Workbaskets
             end
           end
 
+          def submit_for_approval!(current_admin:)
+            move_status_to!(current_admin, :awaiting_approval)
+
+            settings.collection.map do |item|
+              item.move_status_to!(:awaiting_approval)
+            end
+          end
+
+          def reject_cross_check!(current_admin:)
+            move_status_to!(current_admin, :cross_check_rejected)
+
+            workbasket.cross_checker_id = nil
+            workbasket.save
+
+            settings.collection.map do |item|
+              item.move_status_to!(:cross_check_rejected)
+            end
+          end
+
           def edit_type?
             EDIT_WORKABSKETS.include?(type)
           end


### PR DESCRIPTION
Prior to this change, when a workbasket status was changed when going through cross-check, approval or via the tester backdoor only the workbaskets status was changed but the underlying items within the workbasket did not have their status changed.

This change adds a number of methods which handle the changing of status of both the workbasket
and the objects within the workbasket to the workbasket class in order to fix this issue.

Trello card: https://trello.com/c/Ru6wqaw3/848-search-status-not-updated