### PR TITLE
Fix: Prevent app crash when viewing published workbaskets

### DIFF
--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/view/_published.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/view/_published.html.slim
@@ -1,0 +1,2 @@
+p
+  | The measures detailed below have been published to HMRC.

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_cds_error.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_cds_error.html.slim
@@ -1,5 +1,2 @@
 p
   | The measures group was not imported by CDS because of error.
-  =<> link_to "View error details"
-  | .
-

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_published.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_published.html.slim
@@ -1,0 +1,2 @@
+p
+  | The measures detailed below have been published to HMRC.

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_cds_error.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_cds_error.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota was not imported by CDS because of error.

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_published.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_published.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota detailed below has been published to HMRC.

--- a/app/views/workbaskets/events/_cds_error.html.slim
+++ b/app/views/workbaskets/events/_cds_error.html.slim
@@ -1,0 +1,5 @@
+tr
+  td.heading_column
+    | Rejected by CDS on
+  td
+    = workbasket_event_date(event)

--- a/app/views/workbaskets/events/_published.html.slim
+++ b/app/views/workbaskets/events/_published.html.slim
@@ -1,0 +1,5 @@
+tr
+  td.heading_column
+    | Published on
+  td
+    = workbasket_event_date(event)


### PR DESCRIPTION
Prior to this change, the app would crash when viewing a workbasket that
has a status of `published` or `cds_error`.

This change adds the appropriate view for a `published` or `cds_error` workbasket that is
needed to prevent the crash.

Trello card: https://trello.com/c/LzOXuABS/862-clicking-on-view-on-a-published-workbasket-crashes