### PR TITLE
Fix: Return XML strings in hash

### DIFF
--- a/app/services/xml_generation/download.rb
+++ b/app/services/xml_generation/download.rb
@@ -24,7 +24,7 @@ module XmlGeneration
 
     def get_xml_from_objects(objects)
       objects.map do |object_summary|
-        object_summary.object.get.body.string
+        { object_summary.key => object_summary.object.get.body.string }
       end
     end
 


### PR DESCRIPTION
Prior to this change, the download job returned an array of xml strings.
This makes it difficult to identify which file is a mainfile and which is a
metadata file.

This change returns a hash of filename/xml string pairs to make it
easy to identify which file is which.