### PR TITLE
Fix: add confirmation message for withdrawal

### DIFF
--- a/app/views/workbaskets/bulk_edit_of_measures/show.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/show.html.slim
@@ -19,8 +19,9 @@ header
     = render "workbaskets/bulk_edit_of_measures/workflow_screens_parts/workbasket_details"
 
     - if iam_workbasket_author? && workbasket_rejected?
-      = link_to "Edit measures", move_to_editing_mode_bulk_edit_of_measure_url(workbasket.id),
-                                 class: "secondary-button view-workbasket-edit-measures-link"
+      = link_to "Edit measures", '#',
+              data: {target_url: move_to_editing_mode_bulk_edit_of_measure_url(workbasket.id)},
+              class: "secondary-button view-workbasket-edit-measures-link js-main-menu-show-withdraw-confirmation-link"
 
     h3.heading-medium Measures to be updated after cross-check
 

--- a/app/views/workbaskets/create_geographical_area/show.html.slim
+++ b/app/views/workbaskets/create_geographical_area/show.html.slim
@@ -19,6 +19,8 @@ header
     = render "workbaskets/create_geographical_area/workflow_screens_parts/workbasket_details"
 
     - if iam_workbasket_author? && workbasket_rejected?
-      = link_to "Edit geographical area", move_to_editing_mode_create_geographical_area_url(workbasket.id), class: "secondary-button view-workbasket-edit-measures-link"
+      = link_to "Edit  geographical area", '#',
+              data: {target_url: move_to_editing_mode_create_geographical_area_url(workbasket.id)},
+              class: "secondary-button view-workbasket-edit-measures-link js-main-menu-show-withdraw-confirmation-link"
 
     = render "workbaskets/create_geographical_area/workflow_screens_parts/area_details"

--- a/app/views/workbaskets/create_measures/show.html.slim
+++ b/app/views/workbaskets/create_measures/show.html.slim
@@ -19,8 +19,9 @@ header
     = render "workbaskets/create_measures/workflow_screens_parts/workbasket_details"
 
     - if iam_workbasket_author? && workbasket_rejected?
-      = link_to "Edit measures", move_to_editing_mode_create_measure_url(workbasket.id),
-                                 class: "secondary-button view-workbasket-edit-measures-link"
+      = link_to "Edit measures", '#',
+              data: {target_url: move_to_editing_mode_create_measure_url(workbasket.id)},
+              class: "secondary-button view-workbasket-edit-measures-link js-main-menu-show-withdraw-confirmation-link"
 
     - if workbasket_awaiting_cross_check_or_rejected?
       = render "workbaskets/create_measures/workflow_screens_parts/summary_of_configuration"

--- a/app/views/workbaskets/create_quota/show.html.slim
+++ b/app/views/workbaskets/create_quota/show.html.slim
@@ -19,8 +19,9 @@ header
     = render "workbaskets/create_quota/workflow_screens_parts/workbasket_details"
 
     - if iam_workbasket_author? && workbasket_rejected?
-      = link_to "Edit quota", move_to_editing_mode_create_quotum_url(workbasket.id),
-                                 class: "secondary-button view-workbasket-edit-measures-link"
+      = link_to "Edit quota", '#',
+              data: {target_url: move_to_editing_mode_create_quotum_url(workbasket.id)},
+              class: "secondary-button view-workbasket-edit-measures-link js-main-menu-show-withdraw-confirmation-link"
 
     - if workbasket_awaiting_cross_check_or_rejected?
       = render "workbaskets/create_quota/workflow_screens_parts/summary_of_configuration"


### PR DESCRIPTION
Prior to this change, when viewing a rejected workbasket the link to
edit on the show page did not ask for confirmation before withdrawing

This change now requires a confirmation message before withdrawing
and allowing editing.

https://trello.com/c/nMQVP7xn/843-withdraw-workbasket