### PR TITLE
Fix: Rejection reason not showing up

### DIFF
--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -300,38 +300,24 @@ module Workbaskets
           end
 
           def submit_for_approval!(current_admin:)
-            move_status_to!(current_admin, :awaiting_approval)
-
             settings.collection.map do |item|
               item.move_status_to!(:awaiting_approval)
             end
           end
 
           def reject_cross_check!(current_admin:)
-            move_status_to!(current_admin, :cross_check_rejected)
-
-            cross_checker_id = nil
-            save
-
             settings.collection.map do |item|
               item.move_status_to!(:cross_check_rejected)
             end
           end
 
           def confirm_approval!(current_admin:)
-            move_status_to!(current_admin, possible_approved_status)
-
             settings.collection.map do |item|
               item.move_status_to!(possible_approved_status)
             end
           end
 
           def reject_approval!(current_admin:)
-            move_status_to!(current_admin, :approval_rejected)
-
-            approver_id = nil
-            save
-
             settings.collection.map do |item|
               item.move_status_to!(:approval_rejected)
             end

--- a/app/views/workbaskets/create_quota/show.html.slim
+++ b/app/views/workbaskets/create_quota/show.html.slim
@@ -25,4 +25,4 @@ header
     - if workbasket_awaiting_cross_check_or_rejected?
       = render "workbaskets/create_quota/workflow_screens_parts/summary_of_configuration"
 
-    = render "workbaskets/shared/steps/review_and_submit/quotas", read_only: true, record_type: 'create_measures'
+    = render "workbaskets/shared/steps/review_and_submit/quotas", read_only: true, record_type: 'create_quota'


### PR DESCRIPTION
Prior to this change, if a workbasket is rejected from approval or cross
check it does not show why it was rejected.

This change fixes this issue by stopping multiple events being created
after cross-check or approval. The reason that the rejection reason is not
showing is because we were creating 2 events everytime we reject or approve
a workbasket.

The first event has the rejection reason included but the second
does not and is overriding the first when shown on page. This commit
stops 2 calls to `move_status_to!` for every reject or approve.

It also has a side benefit of cleaning up the event history.

Trello card: https://trello.com/c/yHV2NLL0/819-submitter-cannot-see-the-the-approval-rejected-reason-for-quota