### PR TITLE
Fix: remove double display of quota periods

### DIFF
--- a/app/views/workbaskets/create_quota/steps/_review_and_submit.html.slim
+++ b/app/views/workbaskets/create_quota/steps/_review_and_submit.html.slim
@@ -9,7 +9,6 @@
 
   = render "workbaskets/create_quota/steps/review_and_submit/message", read_only: read_only
   = render "workbaskets/create_quota/steps/review_and_submit/details", read_only: read_only
-  = render "workbaskets/create_quota/steps/review_and_submit/quota_periods", read_only: read_only
   = render "workbaskets/shared/steps/review_and_submit/quotas", read_only: read_only, record_type: 'create_quota'
 
   - if read_only


### PR DESCRIPTION
Prior to this change, the create quota review and submit page displayed
the quota periods twice

This change removes one of the quota periods.

https://trello.com/c/saGQODtx/868-review-and-submit-page-of-quota-creation-is-showing-two-identical-quota-periods-instead-of-one-with-one-measure-created