### PR TITLE
Fix: 'Additional code' table layout

### DIFF
--- a/app/assets/stylesheets/components/additional-code-show-page.scss
+++ b/app/assets/stylesheets/components/additional-code-show-page.scss
@@ -4,6 +4,16 @@
 
 .records-table.additional-codes-table,
 .records-table.additional_codes {
+  .locked-column {
+    min-width: 50px !important;
+    max-width: 50px !important;
+  }
+
+  .select-all-column {
+    min-width: 40px !important;
+    max-width: 40px !important;
+  }
+
   .type_id-column {
     min-width: 60px !important;
     max-width: 60px !important;
@@ -35,7 +45,7 @@
   }
 
   .status-column {
-    min-width: 250px !important;
-    max-width: 250px !important;
+    min-width: 150px !important;
+    max-width: 150px !important;
   }
 }


### PR DESCRIPTION
The table heading and body had incorrect column widths

This change applies correct column widths, in line with the quotas table styling.

Before:
![image](https://user-images.githubusercontent.com/6898065/55613817-7e21fe00-5783-11e9-9da0-4bd153fc53ba.png)

After:
![image](https://user-images.githubusercontent.com/6898065/55613789-706c7880-5783-11e9-9f16-e9650ec31b0e.png)
