### PR TITLE
Fix: Applies full width to details table display

### DIFF
--- a/app/assets/stylesheets/components/create-measures.scss
+++ b/app/assets/stylesheets/components/create-measures.scss
@@ -31,8 +31,7 @@ span.create-measures-sub_header {
 
 .create-measures-details-table {
   margin-bottom: 60px;
-  overflow: hidden;
-  width: 640px;
+  overflow: scroll;
 
   td {
     font-size: 16px;


### PR DESCRIPTION
Details table display was previously limited to 640px width

This change removes this restriction, and adds horizontal scrolling

In reference to https://trello.com/c/dDBNxe1O/800-table-cropping-glitch-on-view-measures-workbasket

Before:
![image](https://user-images.githubusercontent.com/6898065/55621872-9c452980-5796-11e9-9232-8921ef6abbf0.png)

After:
![image](https://user-images.githubusercontent.com/6898065/55621865-96e7df00-5796-11e9-8f09-e23661f46d2e.png)
