### PR TITLE
Fix: Accidental deleting of published workbaskets during editing

### DIFF
--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -321,8 +321,6 @@ module Workbaskets
             settings.collection.map do |item|
               item.move_status_to!(:editing)
             end
-
-            settings.clean_up_temporary_data!
           end
 
           def submit_for_approval!(current_admin:)


### PR DESCRIPTION
Prior to this change, if we tried to edit a published ite, and at some
point during the process withdrew the workbasket then the published
item would be deleted from our application.

This change stops the `cleaning up` of temporary data. The issue arises
from the fact that both the new item (i.e measure or quota) and the published
one are both `cleaned up`.

This change removes this step from the edit process.

Note: This will mean that both the new and the published items will
stay in an editing state and be locked on the search page until the user
makes the necessary changes.

Trello card: https://trello.com/c/I92IttdN/872-historical-measure-quota-gets-deleted-wrongly