### PR TITLE
Fix: Bulk edit measures bulk action table

### DIFF
--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -6,14 +6,14 @@ table {
 
 .records-table.measures,
 .measures-table {
-  min-width: 1700px !important;
+  min-width: 1800px !important;
   .locked-column {
     min-width: 50px !important;
     max-width: 50px !important;
   }
   .select-all-column {
-    min-width: 60px !important;
-    max-width: 60px !important;
+    min-width: 20px !important;
+    max-width: 20px !important;
   }
   .measure_type_id-column {
     min-width: 50px !important;
@@ -63,8 +63,8 @@ table {
     max-width: 160px !important;
   }
   .footnotes-column {
-    min-width: 100px !important;
-    max-width: 100px !important;
+    min-width: 70px !important;
+    max-width: 70px !important;
   }
   .last_updated-column {
     min-width: 140px;


### PR DESCRIPTION
There are too many columns to fit in the current max-width of 1700px

This change adds 100px width to fit all columns

This change does not relate directly to any Trello ticket, however, it is broadly part of https://trello.com/c/kbLZ7DMa/755-tables

Before:

![image](https://user-images.githubusercontent.com/6898065/55627362-e8e43100-57a5-11e9-86e1-1495dc2db310.png)


After:

![image](https://user-images.githubusercontent.com/6898065/55627258-9dca1e00-57a5-11e9-90a6-fb13122b2636.png)
