### PR TITLE
Fix: Make Quota Description mandatory field

### DIFF
--- a/app/interactors/workbasket_interactions/settings_saver_base.rb
+++ b/app/interactors/workbasket_interactions/settings_saver_base.rb
@@ -140,6 +140,11 @@ module WorkbasketInteractions
       end
 
       if self.class::WORKBASKET_TYPE == "CreateQuota"
+
+        if workbasket.title.blank?
+          general_errors[:quota_description] = "Quota Description can't be blank!"
+        end
+
         if geographical_area_id.present?
           if candidates.flatten.compact.blank?
             general_errors[:commodity_codes] = errors_translator(:blank_commodity_and_additional_codes)


### PR DESCRIPTION
Prior to this change, user didn't need to enter a description. The
workbasket would be created but fails to display in the list.

This change does not allow the workbasket to be created until there is
a description.

https://trello.com/c/lux0F6An/839-creating-quota-without-work-basket-name-gets-created-in-the-database-but-dont-show-up-in-the-work-basket-of-as-submitter-or-the