### PR TITLE
TST: Trial error setting in prod environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application


### PR DESCRIPTION
Prior to this change, we are not getting full error messages on prod

This change adjusts the setting config.consider_all_requests_local to
see if we can get more informative errors. This should be reverted
before live.

https://trello.com/c/TKQh7QiK/875-for-trail-testing-to-try-and-understand-the-502-error-we-have-changed-a-setting-in-production