### PR TITLE
Fix: Quota search results total not showing

### DIFF
--- a/app/views/quotas/quotas/_search_page.html.slim
+++ b/app/views/quotas/quotas/_search_page.html.slim
@@ -55,10 +55,15 @@ script
       div v-if="!isLoading"
         = simple_form_for :search, url: quotas_bulks_url(ops), method: :post do |f|
           = content_tag :input, nil, { type: "hidden", "name" => "quota_sids[]", ":value" => "selectedItem" }
-          p
+          p.clearfix
             = content_tag "button", "Work with selected quota", { class: "button", ":disabled" => "noSelectedQuota", type: :submit }
             | &nbsp
             = content_tag "button", "Clone and edit selected quota", { class: "button", ":disabled" => "noSelectedQuota", type: :submit, name: "clone", value: "true" }
+
+            span.number-of-records-badge
+              = pluralize(search_results.total_count, 'quota', 'quotas')
+              =<> "found"
+
         = render "quotas_table" if quotas_search.present?
 
       = content_tag "loading-indicator", nil, { "v-if" => "isLoading", ":metadata" => "pagination" } do


### PR DESCRIPTION
Prior to this change, when searching for a quota the user could not
see the number of results returned.

This change shows the user the number of quotas that meet the search
requirements.

Trello card: https://trello.com/c/UXT81ffC/871-quota-search-bug-not-showing-the-number-of-search-results

<img width="1170" alt="Screenshot 2019-04-05 at 15 21 48" src="https://user-images.githubusercontent.com/13124899/55634994-94e24800-57b7-11e9-8926-e735d9d91aba.png">
