### PR TITLE
Fix: increases width of measure type select control

### DIFF
--- a/app/views/workbaskets/shared/steps/main/_measure_type.html.slim
+++ b/app/views/workbaskets/shared/steps/main/_measure_type.html.slim
@@ -6,12 +6,12 @@ fieldset id="record_type_dropdown"
 
   .row
     - if record_type == "measures"
-      .col-md-2
+      .col-md-3
         = content_tag "custom-select", { "url" => "/measure_type_series?quota=false", "allow-clear" => true, "code-field" => "measure_type_series_id", "label-field" => "description", "value-field" => "measure_type_series_id", "v-model" => "measure.measure_type_series_id", "code-class-name" => "prefix--l1", "date-sensitive" => true, placeholder: "― select group ―" } do
 
           = f.input :measure_type_series_id, as: :select, collection: form.measure_type_series_collection, label_method: :description, value_method: :measure_type_series_id, label: false
 
-    .col-md-2
+    .col-md-3
       = content_tag "custom-select", { "url" => "/measure_types#{record_type == 'measures' ? '?quota=false' : '?quota=true'}", "allow-clear" => true, "code-field" => "measure_type_id", "label-field" => "description", "value-field" => "measure_type_id", "v-model" => "measure.measure_type_id", "code-class-name" => "prefix--measure-type", "date-sensitive" => true, "drilldown-name" => "measure_type_series_id", ":drilldown-value" => "measure.measure_type_series_id", placeholder: "― select #{record_type == 'measures' ? 'measure' : record_type} type ―" } do
 
         = f.input :measure_type_id, as: :select, collection: form.measure_types_collection, label_method: :measure_type_description, value_method: :measure_type_id, label: false


### PR DESCRIPTION
Measures type select control default value was being clipped out of view

This change provides more space in the view layout to render the default value in full

Trello: https://trello.com/c/PEdodUIi/756-styling-of-form-controls

Before:

![image](https://user-images.githubusercontent.com/6898065/55716962-2b994980-59f0-11e9-85ad-26e6cbad152e.png)

After:

![image](https://user-images.githubusercontent.com/6898065/55716973-318f2a80-59f0-11e9-8619-9ff2d0625807.png)
