### PR TITLE
Fix: Tweak info on Review and Submit page

### DIFF
--- a/app/value_objects/workbasket_value_objects/create_measures/attributes_parser.rb
+++ b/app/value_objects/workbasket_value_objects/create_measures/attributes_parser.rb
@@ -16,6 +16,10 @@ module WorkbasketValueObjects
         end
       end
 
+    def measure_type_id
+      ops['measure_type_id']
+    end
+
     private
 
       def prepare_ops

--- a/app/views/workbaskets/create_measures/steps/review_and_submit/_details.html.slim
+++ b/app/views/workbaskets/create_measures/steps/review_and_submit/_details.html.slim
@@ -10,12 +10,6 @@ table.create-measures-details-table
 
     tr
       td.heading_column
-        | Operation date
-      td
-        = attributes_parser.operation_date_formatted
-
-    tr
-      td.heading_column
         | Regulation
       td
         = attributes_parser.regulation
@@ -36,7 +30,7 @@ table.create-measures-details-table
       td.heading_column
         | Type
       td
-        = attributes_parser.measure_type
+        = "#{attributes_parser.measure_type_id} - #{attributes_parser.measure_type}"
 
     tr
       td.heading_column

--- a/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
+++ b/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
@@ -20,13 +20,7 @@ table.create-measures-details-table
       td.heading_column
         | Type
       td
-        = "#{first_measure.measure_type_id} #{attributes_parser.measure_type}" if first_measure
-
-    tr
-      td.heading_column
-        | Operation date
-      td
-        = attributes_parser.operation_date_formatted
+        = "#{first_measure.measure_type_id} - #{attributes_parser.measure_type}" if first_measure
 
     tr
       td.heading_column


### PR DESCRIPTION
Fix: Tweak info on `Review and Submit` page

Prior to this change, we had some unhelpful or unnecessary info on
the review and submit measures/quotas pagse.

This change removes operation date, which we no longer use, and adds
the  type id to the measure type field in the details table in order to
help users more easily understand which type they selected.

Trello card: https://trello.com/c/ZDkum6VE/863-update-review-submit-summary-information