### PR TITLE
Fix: Renders dropdowns with rounded corners

### DIFF
--- a/app/assets/stylesheets/components/select.scss
+++ b/app/assets/stylesheets/components/select.scss
@@ -167,6 +167,9 @@
 
 .selectize-control {
   font-size: 1.6rem;
+  .selectize-input.has-options {
+    border-radius: 7px !important;
+  }
 }
 
 .selectize-input {


### PR DESCRIPTION
Rounded corners provide a subtle cue to differentiate against similar-looking typeahead

This fix targets selectize-input rendered with 'has-options' class (typeahead doesn't use this class)

**Note:** Border radius (rounding) pixel value has been approximated 'by eye' as the value is not specified in the UX design reference.

Trello: https://trello.com/c/PEdodUIi/756-styling-of-form-controls

Before(s):

![image](https://user-images.githubusercontent.com/6898065/55719860-35727b00-59f7-11e9-867a-522e38d72213.png)

![image](https://user-images.githubusercontent.com/6898065/55719938-6488ec80-59f7-11e9-9d43-2bf3e4a00a86.png)


After(s):

![image](https://user-images.githubusercontent.com/6898065/55719876-3b685c00-59f7-11e9-9cc3-67f8108e87d9.png)

![image](https://user-images.githubusercontent.com/6898065/55719952-7074ae80-59f7-11e9-8241-7d02b0cd2884.png)

