### PR TITLE
TST: Revert 94b3a315 - error reporting setting

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application


### PR DESCRIPTION
Prior to this change, we trialled a setting to see if we cna get better
error messages for the 502 error we sometimes get on production.
Error meesages were no different so reverting this back to false.

This change removes the 'consider_all_requests_local' setting.

https://trello.com/c/TKQh7QiK/875-for-trail-testing-to-try-and-understand-the-502-error-we-have-changed-a-setting-in-production