### PR TITLE
Fix: Add exit to main menu links to view measure/quota

### DIFF
--- a/app/views/workbaskets/create_measures/show.html.slim
+++ b/app/views/workbaskets/create_measures/show.html.slim
@@ -28,7 +28,4 @@ header
 
     = render "workbaskets/shared/steps/review_and_submit/measures", read_only: true, record_type: 'create_measures'
 
-
-
-
-
+    = link_to "Exit (return to main menu)", root_url, class: "secondary-button js-workbasket-base-exit-button"

--- a/app/views/workbaskets/create_quota/show.html.slim
+++ b/app/views/workbaskets/create_quota/show.html.slim
@@ -27,3 +27,5 @@ header
       = render "workbaskets/create_quota/workflow_screens_parts/summary_of_configuration"
 
     = render "workbaskets/shared/steps/review_and_submit/quotas", read_only: true, record_type: 'create_quota'
+
+    = link_to "Exit (return to main menu)", root_url, class: "secondary-button js-workbasket-base-exit-button"


### PR DESCRIPTION
Prior to this change, when viewing a `create measure` or `create quota`
workbasket with the status of `awaiting_cross_check` there was no link to
exit to the main menu

This change adds `exit to main menu` link to above pages.

trello card: https://trello.com/c/66LReGRc/851-some-view-page-doesnt-have-the-exit-link