### PR TITLE
Fix: incorrect commodity code count on review pages

### DIFF
--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,5 +1,5 @@
-- commodity_codes_count = workbasket_settings.commodity_codes_covered.count
-- additional_codes_count = workbasket_settings.additional_codes_covered.count
+- commodity_codes_count = workbasket_settings.commodity_codes_covered.compact.count
+- additional_codes_count = workbasket_settings.additional_codes_covered.compact.count
 
 p
   | You are about to update

--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
@@ -1,5 +1,5 @@
-- commodity_codes_count = workbasket_settings.commodity_codes_covered.count
-- additional_codes_count = workbasket_settings.additional_codes_covered.count
+- commodity_codes_count = workbasket_settings.commodity_codes_covered.compact.count
+- additional_codes_count = workbasket_settings.additional_codes_covered.compact.count
 
 p
   | The measure(s) detailed below have not yet been cross-checked. Once cross-checked,

--- a/app/views/workbaskets/create_geographical_area/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/create_geographical_area/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,5 +1,5 @@
-- commodity_codes_count = workbasket_settings.commodity_codes_covered.count
-- additional_codes_count = workbasket_settings.additional_codes_covered.count
+- commodity_codes_count = workbasket_settings.commodity_codes_covered.compact.count
+- additional_codes_count = workbasket_settings.additional_codes_covered.compact.count
 
 p
   | You are about to create

--- a/app/views/workbaskets/create_measures/steps/review_and_submit/_message.html.slim
+++ b/app/views/workbaskets/create_measures/steps/review_and_submit/_message.html.slim
@@ -1,5 +1,5 @@
-- commodity_codes_count = workbasket_settings.commodity_codes_covered.count
-- additional_codes_count = workbasket_settings.additional_codes_covered.count
+- commodity_codes_count = workbasket_settings.commodity_codes_covered.compact.count
+- additional_codes_count = workbasket_settings.additional_codes_covered.compact.count
 
 .alert.alert--info.create-measures-message-block
   svg.icon.icon--info version="1.1" viewbox=("0 0 24 28") xmlns="http://www.w3.org/2000/svg"

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,5 +1,5 @@
-- commodity_codes_count = workbasket_settings.commodity_codes_covered.count
-- additional_codes_count = workbasket_settings.additional_codes_covered.count
+- commodity_codes_count = workbasket_settings.commodity_codes_covered.compact.count
+- additional_codes_count = workbasket_settings.additional_codes_covered.compact.count
 
 p
   | You are about to create

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
@@ -1,5 +1,5 @@
-- commodity_codes_count = workbasket_settings.commodity_codes_covered.count
-- additional_codes_count = workbasket_settings.additional_codes_covered.count
+- commodity_codes_count = workbasket_settings.commodity_codes_covered.compact.count
+- additional_codes_count = workbasket_settings.additional_codes_covered.compact.count
 
 p
   | The measure(s) detailed below have not yet been cross-checked. Once cross-checked,


### PR DESCRIPTION
Prior to this change, if a measure, quota, etc. had 0 commodity codes
the review page would always show 1, as it counted [nil] as having one
value.

This change compacts the array to remove any nil values and show the
correct count.

https://trello.com/c/hlLR7XEg/861-adding-new-measure-without-commodity-code-but-with-additional-code-info-notification