### PR TITLE
Fix: Allow editing of `create quota` workbasket name

### DIFF
--- a/app/interactors/workbasket_interactions/settings_saver_base.rb
+++ b/app/interactors/workbasket_interactions/settings_saver_base.rb
@@ -71,7 +71,7 @@ module WorkbasketInteractions
 
     def save!
       if step_pointer.main_step?
-        workbasket.title = workbasket_name if workbasket.title.blank?
+        workbasket.title = workbasket_name if workbasket.title != workbasket_name
         workbasket.operation_date = operation_date.try(:to_date)
         workbasket.save
       end

--- a/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
+++ b/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
@@ -6,6 +6,12 @@ table.create-measures-details-table
   tbody
     tr
       td.heading_column
+        | Workbasket name
+      td
+        = workbasket.title
+        
+    tr
+      td.heading_column
         | Order number
       td
         = attributes_parser.quota_ordernumber


### PR DESCRIPTION
Prior to this change, a user could not change the name of a workbasket
when editing it.

This change allows users to change the name of a create quota workbasket
when editing it.

Trello card: https://trello.com/c/bB4z4ywH/852-editing-the-quota-work-basket-details-are-not-getting-changed-to-new-via-withdraw-edit-option