### PR TITLE
Fix: blank start date causing infinite spinning.

### DIFF
--- a/app/value_objects/workbasket_value_objects/shared/commodity_codes_analyzer.rb
+++ b/app/value_objects/workbasket_value_objects/shared/commodity_codes_analyzer.rb
@@ -25,7 +25,7 @@ module WorkbasketValueObjects
     private
 
       def get_start_date(ops)
-        ops[:start_date].to_date rescue Date.today
+        ops[:start_date].present? ? (ops[:start_date].to_date rescue Date.today) : Date.today
       end
 
       def setup_collection!


### PR DESCRIPTION
Prior to this change, a blank start date when creating a measure caused an exception.

This change defaults the start date to today's date for the purpose of checking for valid commodity codes.

https://trello.com/c/nLOYvMnv/396-dit-tq-54-changes-to-validation-and-conformance-error-handling-40