### PR TITLE
Fix: This commit adds missing validations on create measure

### DIFF
--- a/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
@@ -112,6 +112,10 @@ module WorkbasketInteractions
         settings.main_step_settings['regulation_id']
       end
 
+      def measure_type
+        settings.main_step_settings['measure_type_id']
+      end
+
       def check_required_params!
         general_errors = {}
 
@@ -164,6 +168,10 @@ module WorkbasketInteractions
 
         unless regulation_id.present?
           general_errors[:regulation] = "Regulation cannot be blank. Please enter the regulation that gives legal force to these measures."
+        end
+
+        unless measure_type.present?
+          general_errors[:measure_type] = "Measure type cannot be blank. Please enter a measure type."
         end
 
         if general_errors.present?

--- a/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
@@ -116,6 +116,10 @@ module WorkbasketInteractions
         settings.main_step_settings['measure_type_id']
       end
 
+      def geographical_area_id
+        settings.main_step_settings['geographical_area_id']
+      end
+
       def check_required_params!
         general_errors = {}
 
@@ -172,6 +176,10 @@ module WorkbasketInteractions
 
         unless measure_type.present?
           general_errors[:measure_type] = "Measure type cannot be blank. Please enter a measure type."
+        end
+
+        unless geographical_area_id.present?
+          general_errors[:geographical_area] = "Origin cannot be blank. Please enter an origin."
         end
 
         if general_errors.present?

--- a/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
@@ -108,6 +108,10 @@ module WorkbasketInteractions
         end
       end
 
+      def regulation_id
+        settings.main_step_settings['regulation_id']
+      end
+
       def check_required_params!
         general_errors = {}
 
@@ -156,6 +160,10 @@ module WorkbasketInteractions
           ) && candidates.flatten.compact.blank?
 
           @errors[:commodity_codes] = errors_translator(:commodity_codes_invalid)
+        end
+
+        unless regulation_id.present?
+          general_errors[:regulation] = "Regulation cannot be blank. Please enter the regulation that gives legal force to these measures."
         end
 
         if general_errors.present?


### PR DESCRIPTION
Prior to this change, would not see an accurate error if they tried to create a measure
without a regulation id, origin or measure type.

This change raises an error if any of these fields are missing 

Trello card: https://trello.com/c/fHudEr8Y/830-wrong-error-message-please-review-the-following-errors-general-goods-commodity-codes-can-be-empty-but-only-if-one-or-more-meursi