### PR TITLE
Fix: View quota 'awaiting approval' error

### DIFF
--- a/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_awaiting_approval.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_awaiting_approval.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota has been approved.


### PR DESCRIPTION
Prior to this change, viewing a Quota with status 'Awaiting Approval'
caused an exception and error message displayed

This change adds the missing partial.

https://trello.com/c/VmZMhVYL/740-tq-206-clicking-on-the-review-for-cross-check-on-the-workbasket-type-create-quota-is-leading-to-error-were-sorry-but-something-w