### PR TITLE
Fix: correct env variable name GIT_BRANCH

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,6 +28,6 @@ module ApplicationHelper
   end
 
   def application_version_identifier
-    ENV["GIT_TAG"] || ENV["GIT_COMMIT"]&.slice(0..6)
+    ENV["GIT_BRANCH"] || ENV["GIT_COMMIT"]&.slice(0..6)
   end
 end

--- a/spec/features/version_identifier_spec.rb
+++ b/spec/features/version_identifier_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "version identifier" do
     it "git tag is displayed in the footer" do
       version_identifier = "v0.0.1"
 
-      with_environment("GIT_TAG" => version_identifier) do
+      with_environment("GIT_BRANCH" => version_identifier) do
         visit root_path
       end
 


### PR DESCRIPTION
Prior to this change, it was assumed the new env var to hold the git
tag would be called GIT_TAG, but it was created as GIT_BRANCH

This change uses the correct env var name GIT_BRANCH

https://trello.com/c/znxn2sf4/825-ensure-gitcommit-environment-variable-is-used-in-healthcheck-response