### PR TITLE
Fix: This commit removes operation date from create quota form

### DIFF
--- a/app/interactors/workbasket_interactions/settings_saver_base.rb
+++ b/app/interactors/workbasket_interactions/settings_saver_base.rb
@@ -2,7 +2,6 @@ module WorkbasketInteractions
   class SettingsSaverBase
     REQUIRED_PARAMS = %w(
       start_date
-      operation_date
     ).freeze
 
     ATTRS_PARSER_METHODS = %w(

--- a/app/views/workbaskets/create_quota/steps/_main.html.slim
+++ b/app/views/workbaskets/create_quota/steps/_main.html.slim
@@ -3,10 +3,8 @@
 = render "workbaskets/create_quota/steps/main/quota_precision", f: f, record_type: 'quota'
 = render "workbaskets/shared/steps/main/measure_type", f: f, record_type: 'quota'
 = render "workbaskets/create_quota/steps/main/order_number_description", f: f, record_type: 'quota'
-= render "workbaskets/shared/steps/main/operation_date", f: f, record_type: 'quota'
 = render "workbaskets/create_quota/steps/main/licensed_block", f: f, record_type: 'quota'
 = render "workbaskets/shared/steps/main/goods_commodity_codes", f: f, record_type: 'quota'
 = render "workbaskets/shared/steps/main/additional_codes", f: f, record_type: 'quota'
 = render "workbaskets/shared/steps/main/reduction_indicator", f: f, record_type: 'quota'
 = render "workbaskets/shared/steps/main/geographical_area", f: f, multiple_countries: true, record_type: 'quota'
-

--- a/spec/features/workbasket/quota/quota_creation_validations_spec.rb
+++ b/spec/features/workbasket/quota/quota_creation_validations_spec.rb
@@ -60,8 +60,6 @@ RSpec.describe "adding quotas", :js do
 
     fill_in :quota_description, with: workbasket_description
 
-    input_date('operation_date', Date.today.beginning_of_year)
-
     fill_in("Goods commodity codes", with: "Bananas, #{commodity.goods_nomenclature_item_id}, Widgets")
 
     fill_in("Additional codes", with: "Ninja, Samurai")

--- a/spec/features/workbasket/quota/quota_spec.rb
+++ b/spec/features/workbasket/quota/quota_spec.rb
@@ -96,8 +96,6 @@ RSpec.describe "quotas", :js do
 
     fill_in :quota_description, with: workbasket_description
 
-    input_date('operation_date', Date.today.beginning_of_year)
-
     fill_in("Goods commodity codes", with: commodity.goods_nomenclature_item_id)
     select_radio("Erga Omnes")
     click_button('Continue')


### PR DESCRIPTION
Prior to this change, the user had to specify an operation date when
creating a quota, however this operation date is not necessary.

This change removes the need for an operation date to be specified to
create a quota and removes the section of the form relating to it.

Trello: https://trello.com/c/BEusDZPW/881-create-quota-operation-date