### PR TITLE
Fix: Show start date instead of operation date in quota summary

### DIFF
--- a/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -24,9 +24,9 @@ table.create-measures-details-table
 
     tr
       td.heading_column
-        | Operation date
+        | Start date
       td
-        = attributes_parser.operation_date_formatted
+        = attributes_parser.start_date
 
     tr
       td.heading_column


### PR DESCRIPTION
Prior to this change, we showed operation date in the quota summar of
configuration. We should instead be using start date as operation date
is no longer relevant.

This change switches operation date for start date.

trello card: https://trello.com/c/ZDkum6VE/863-update-review-submit-summary-information