### PR TITLE
Fix: after cross-check, allow view of bulk edit workbasket

### DIFF
--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -16,6 +16,6 @@ ul class="list"
 
   - unless workbasket_rejected?
     li
-      = link_to "View these measures", bulk_edit_of_measure_url(workbasket.id)
+      = link_to "View these measures", bulk_edit_of_measure_url(workbasket.id, search_code: workbasket.settings.search_code)
 br
 br


### PR DESCRIPTION
Prior to this change, after cross-check of a bulk edit measures workbasket the 'view' workbasket link on the cross check summary page would not load the measures table

This change corrects the link and displays the measures grid

https://trello.com/c/RoexEncG/854-view-measures-work-basket-is-loading-and-not-displayed-any-measures-on-the-cross-checkers-confirmation-pagevia-view-these-measur