### PR TITLE
Fix: viewing a bulk edit measure after crosscheck

### DIFF
--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -16,6 +16,6 @@ ul class="list"
 
   - unless workbasket_rejected?
     li
-      = link_to "View these measures", bulk_edit_of_measure_url(workbasket.id)
+      = link_to "View these measures", bulk_edit_of_measure_url(workbasket.id, search_code: workbasket.settings.search_code)
 br
 br


### PR DESCRIPTION
Prior to this change, an incorrect url was being used to view the
workbasket. As it didn't include the search reference

This change adds in the search reference to allow the page to display
correctly.

https://trello.com/c/qNLokHF8/887-view-cross-check-measure-page-not-loading