### PR TITLE
Fix: Add validation around date overlap in create quota

### DIFF
--- a/app/interactors/workbasket_interactions/settings_saver_base.rb
+++ b/app/interactors/workbasket_interactions/settings_saver_base.rb
@@ -106,6 +106,11 @@ module WorkbasketInteractions
       ops
     end
 
+    def dates_of_periods
+      periods = settings.configure_quota_step_settings['quota_periods'].map {|period| period.last['periods'].values}
+      periods.flatten.map {|p| { start_date:p['start_date'], end_date: p['end_date'] }}
+    end
+
     ATTRS_PARSER_METHODS.map do |option|
       define_method(option) do
         attrs_parser.public_send(option)
@@ -202,6 +207,10 @@ module WorkbasketInteractions
 
         unless quota_ordernumber.present?
           general_errors[:quota_ordernumber] = errors_translator(:quota_ordernumber)
+        end
+
+        if DatesService.overlap?(dates_of_periods)
+          general_errors[:quota_period_dates] = "The dates of the quota periods cannot overlap!"
         end
       end
 

--- a/app/interactors/workbasket_interactions/settings_saver_base.rb
+++ b/app/interactors/workbasket_interactions/settings_saver_base.rb
@@ -106,6 +106,10 @@ module WorkbasketInteractions
       ops
     end
 
+    def quota_period_type
+      settings.configure_quota_step_settings['quota_periods'].values.first['type']
+    end
+
     def dates_of_periods
       periods = settings.configure_quota_step_settings['quota_periods'].map {|period| period.last['periods'].values}
       periods.flatten.map {|p| { start_date:p['start_date'], end_date: p['end_date'] }}
@@ -209,8 +213,8 @@ module WorkbasketInteractions
           general_errors[:quota_ordernumber] = errors_translator(:quota_ordernumber)
         end
 
-        if DatesService.overlap?(dates_of_periods)
-          general_errors[:quota_period_dates] = "The dates of the quota periods cannot overlap!"
+        if quota_period_type == "custom"
+          general_errors[:quota_period_dates] = "The dates of the quota periods cannot overlap!" if DatesService.overlap?(dates_of_periods)
         end
       end
 

--- a/app/services/dates_service.rb
+++ b/app/services/dates_service.rb
@@ -1,0 +1,12 @@
+class DatesService
+  def self.overlap?(dates)
+    overlap = []
+    dates.each do |period|
+      dates.map do |other_period|
+        next if period == other_period
+        overlap << (other_period[:start_date].to_date).between?(period[:start_date].to_date, period[:end_date].to_date)
+      end
+    end
+    overlap.include?(true)
+  end
+end

--- a/spec/services/dates_service_spec.rb
+++ b/spec/services/dates_service_spec.rb
@@ -29,8 +29,8 @@ describe DatesService do
           end_date: Date.new(2019, 2, 20)
         },
         {
-          start_date: Date.new(2019, 2, 20),
-          end_date: Date.new(2019, 2, 21)
+          start_date: Date.new(2019, 2, 21),
+          end_date: Date.new(2019, 2, 22)
         }
       ]
     end

--- a/spec/services/dates_service_spec.rb
+++ b/spec/services/dates_service_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe DatesService do
+  describe '#overlap?' do
+    let(:overlapping_dates) do
+      [
+        {
+          start_date: Date.new(2019, 1, 1),
+          end_date: Date.new(2019, 1, 31)
+        },
+        {
+          start_date: Date.new(2019, 1, 31),
+          end_date: Date.new(2019, 2, 20)
+        },
+        {
+          start_date: Date.new(2019, 2, 21),
+          end_date: Date.new(2019, 2, 24)
+        }
+      ]
+    end
+    let(:valid_dates) do
+      [
+        {
+          start_date: Date.new(2019, 1, 1),
+          end_date: Date.new(2019, 1, 31)
+        },
+        {
+          start_date: Date.new(2019, 2, 1),
+          end_date: Date.new(2019, 2, 20)
+        },
+        {
+          start_date: Date.new(2019, 2, 20),
+          end_date: Date.new(2019, 2, 21)
+        }
+      ]
+    end
+    it 'returns true if there is some overlap of dates' do
+      expect(DatesService.overlap?(overlapping_dates)).to eq true
+    end
+
+    it 'returns false if there is no overlap of dates' do
+      expect(DatesService.overlap?(valid_dates)).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Prior to this change, a user could create a quota with custom periods
that overlapped and no error was raised.

This change checks for overlaps in the dates and raises an error if it finds one.

Trello card: https://trello.com/c/Jg5oJb5t/880-quota-period-should-not-overlap-with-date-selector