### PR TITLE
Fix: Table column withds adjusted for 'sort' arrow

### DIFF
--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -43,12 +43,12 @@ table {
   }
   .additional_code_id-column,
   .additional_code-column {
-    min-width: 70px !important;
-    max-width: 70px !important;
+    min-width: 80px !important;
+    max-width: 80px !important;
   }
   .geographical_area-column {
-    min-width: 45px !important;
-    max-width: 45px !important;
+    min-width: 90px !important;
+    max-width: 90px !important;
   }
   .excluded_geographical_areas-column {
     min-width: 100px !important;
@@ -136,8 +136,8 @@ table {
   }
 
   .justification_regulation-column {
-    min-width: 90px;
-    max-width: 90px;
+    min-width: 100px;
+    max-width: 100px;
   }
 
   .validity_end_date-column {


### PR DESCRIPTION
The sorting arrow icon was overlapping with adjacent table headings

This change adjusts table column widths to make room for the sorting arrow icon

Trello link:
https://trello.com/c/nayAOWQ6/869-table-heading-columns-not-lining-up-well-on-bulk-edit-measures-page

Before/after:

![image](https://user-images.githubusercontent.com/6898065/56124244-1ed7a100-5f6e-11e9-931e-8d4dbbb20b4d.png)
