### PR TITLE
Fix: Remove reference to scheduling export to cds

### DIFF
--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/_actions_allowed.html.slim
@@ -4,15 +4,6 @@
       = link_to "Withdraw workbasket from workflow", "#", data: { target_url: withdraw_workbasket_from_workflow_bulk_edit_of_measure_url(workbasket.id) }, class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 
-    - if current_user.approver?
-      - if workbasket.ready_for_export?
-        = link_to "Schedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"
-        br
-
-      - elsif workbasket.operation_date_can_be_rescheduled?
-        = link_to "Reschedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"
-        br
-
 = render "workbaskets/main_menu_parts/schedule_export_to_cds_popup"
 = render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "delete_confirmation_popup", title: "You are going to delete workbasket"
 = render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "withdraw_confirmation_popup", title: "You are going to withdraw workbasket"

--- a/app/views/workbaskets/create_geographical_area/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/create_geographical_area/workflow_screens_parts/_actions_allowed.html.slim
@@ -4,15 +4,6 @@
       = link_to "Withdraw workbasket from workflow", "#", data: { target_url: withdraw_workbasket_from_workflow_create_geographical_area_url(workbasket.id) }, class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 
-    - if current_user.approver?
-      - if workbasket.ready_for_export?
-        = link_to "Schedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"
-        br
-
-      - elsif workbasket.operation_date_can_be_rescheduled?
-        = link_to "Reschedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"
-        br
-
 = render "workbaskets/main_menu_parts/schedule_export_to_cds_popup"
 = render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "delete_confirmation_popup", title: "You are going to delete workbasket"
 = render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "withdraw_confirmation_popup", title: "You are going to withdraw workbasket"

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/_actions_allowed.html.slim
@@ -4,15 +4,6 @@
       = link_to "Withdraw workbasket from workflow", "#", data: { target_url: withdraw_workbasket_from_workflow_create_measure_url(workbasket.id) }, class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 
-    - if current_user.approver?
-      - if workbasket.ready_for_export?
-        = link_to "Schedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"
-        br
-
-      - elsif workbasket.operation_date_can_be_rescheduled?
-        = link_to "Reschedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"
-        br
-
 = render "workbaskets/main_menu_parts/schedule_export_to_cds_popup"
 = render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "delete_confirmation_popup", title: "You are going to delete workbasket"
 = render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "withdraw_confirmation_popup", title: "You are going to withdraw workbasket"

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/_actions_allowed.html.slim
@@ -4,15 +4,6 @@
       = link_to "Withdraw workbasket from workflow", "#", data: { target_url: withdraw_workbasket_from_workflow_create_measure_url(workbasket.id) }, class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 
-    - if current_user.approver?
-      - if workbasket.ready_for_export?
-        = link_to "Schedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"
-        br
-
-      - elsif workbasket.operation_date_can_be_rescheduled?
-        = link_to "Reschedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true, class: "button js-schedule-export-to-cds"
-        br
-
 = render "workbaskets/main_menu_parts/schedule_export_to_cds_popup"
 = render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "delete_confirmation_popup", title: "You are going to delete workbasket"
 = render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "withdraw_confirmation_popup", title: "You are going to withdraw workbasket"

--- a/app/views/workbaskets/main_menu_parts/_actions.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_actions.html.slim
@@ -18,11 +18,3 @@
   - if workbasket.awaiting_approval?
     | &nbsp;|&nbsp;
     = link_to "Review for approval", new_approve_url(workbasket.id)
-
-  - elsif workbasket.ready_for_export?
-    | &nbsp;|&nbsp;
-    = link_to "Schedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true
-
-  - elsif workbasket.operation_date_can_be_rescheduled?
-    | &nbsp;|&nbsp;
-    = link_to "Reschedule export to CDS", new_schedule_export_to_cds_url(workbasket.id), remote: true


### PR DESCRIPTION
Prior to this change, we had links to schedule and reschedule export
to cds despite no longer exporting on a schedule.

This change removes links to schedule exports to cds.

Trello: https://trello.com/c/XyVTXwIQ/888-remove-reschedule-export-to-cds-feature