### PR TITLE
Fix: better separation between drop down columns

### DIFF
--- a/app/assets/stylesheets/components/select.scss
+++ b/app/assets/stylesheets/components/select.scss
@@ -124,9 +124,9 @@
 }
 
 .abbreviation--measurement-unit {
-  flex-basis: 6.5em;
-  min-width: 6.5em;
-  width: 6.5em;
+  flex-basis: 9em;
+  min-width: 9em;
+  width: 9em;
 }
 
 .abbreviation--duty-expression {


### PR DESCRIPTION
Previously content was overlapping in the 'unit of measure' drop down

This change separates content to avoid overlap

Trello link: https://trello.com/c/dDBNxe1O/800-table-cropping-glitch-on-view-measures-workbasket

Before:

![image](https://user-images.githubusercontent.com/6898065/56127796-dfad4e00-5f75-11e9-95c9-958616f7a23e.png)

After:

![image](https://user-images.githubusercontent.com/6898065/56127799-e50a9880-5f75-11e9-85b8-c1804ab371dc.png)
