### PR TITLE
Fix: Validate presence of license if quota is licensed

### DIFF
--- a/app/interactors/workbasket_interactions/settings_saver_base.rb
+++ b/app/interactors/workbasket_interactions/settings_saver_base.rb
@@ -205,6 +205,10 @@ module WorkbasketInteractions
         end
       end
 
+      if settings.main_step_settings['quota_is_licensed'] == "true"
+        general_errors[:license] = "Please select the license that relates to this quota!" if settings.main_step_settings['quota_licence'].blank?
+      end
+
       if general_errors.present?
         if step_pointer.main_step?
           general_errors.map do |k, v|


### PR DESCRIPTION
Prior to this change, users could tick the box that indicates that the quota
has a license but could create a quota without errors without specifying the
quota.

This change raises an error if no quota is specified after user has
ticked the `quota is licensed` checkbox.

Trello card: https://trello.com/c/WHEx43aN/883-validation-failed-for-is-this-a-licensed-quota-check-box-is-checked-without-selecting-the-licence-from-drop-down