### PR TITLE
Fix: display quota correctly when status is sent_to_cds

### DIFF
--- a/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_sent_to_cds.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_sent_to_cds.html.slim
@@ -1,0 +1,4 @@
+p
+  | The workbasket has been sent to CDS. It contains
+  =<> pluralize(workbasket_settings.measure_sids.count, "measure", "measures")
+  | .


### PR DESCRIPTION
Prior to this change, it would throw an exception.

This change adds a partial that matched the sent_to_cds status.

https://trello.com/c/2Fssk309/886-view-quota-page-crashed