### PR TITLE
Fix: pre-populate fields in bulk edit pop up

### DIFF
--- a/app/views/shared/vue_templates/_condition.html.erb
+++ b/app/views/shared/vue_templates/_condition.html.erb
@@ -58,7 +58,7 @@
           <label class="form-label" v-if="index == 0">
             Certificate type(s)
           </label>
-          <custom-select :id="'measure-condition-' + index + '-certificate-type'" url="/certificate_types" v-model="condition.certificate_type_code" codeField="certificate_type_code" valueField="certificate_type_code" labelField="description" date-sensitive="true" code-class-name="prefix--certificate-type" :on-change="onCertificateTypeSelected" :compact="true"></custom-select>
+          <custom-select :id="'measure-condition-' + index + '-certificate-type'" url="/certificate_types" v-model="condition.certificate_type.certificate_type_code" codeField="certificate_type_code" valueField="certificate_type_code" labelField="description" date-sensitive="true" code-class-name="prefix--certificate-type" :on-change="onCertificateTypeSelected" :compact="true"></custom-select>
         </form-group>
         <form-group v-else>
           <label class="form-label" v-if="index == 0">
@@ -72,7 +72,7 @@
           <label class="form-label" v-if="index == 0">
             Certificate
           </label>
-          <custom-select :id="'measure-condition-' + index + '-certificate'" url="/certificates" v-model="condition.certificate_code" codeField="certificate_code" valueField="certificate_code" labelField="description" date-sensitive="true" drilldown-name="certificate_type_code" :drilldown-value="condition.certificate_type_code" :drilldown-required="showCertificateType" code-class-name="prefix--certificate" :on-change="onCertificateSelected" :compact="true"></custom-select>
+          <custom-select :id="'measure-condition-' + index + '-certificate'" url="/certificates" v-model="condition.certificate.certificate_code" codeField="certificate_code" valueField="certificate_code" labelField="description" date-sensitive="true" drilldown-name="certificate_type_code" :drilldown-value="condition.certificate_type_code" :drilldown-required="showCertificateType" code-class-name="prefix--certificate" :on-change="onCertificateSelected" :compact="true"></custom-select>
         </form-group>
         <form-group v-else>
           <label class="form-label" v-if="index == 0">


### PR DESCRIPTION
Prior to this change, the change conditions popup for bulk edit measures did not populate the certificate type and id.

This change uses the correct field and prepopulates the fields.

https://trello.com/c/k3D7Wc21/794-certificate-type-and-id-not-pre-populated-when-editing-measure-conditions