### PR TITLE
Fix: Shows measure type number to cross check and approver

### DIFF
--- a/app/views/workbaskets/create_measures/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -24,8 +24,8 @@ table.create-measures-details-table
       td.heading_column
         | Type
       td
-        = attributes_parser.measure_type
-
+        = "#{workbasket.settings.main_step_settings['measure_type_id']} - #{attributes_parser.measure_type}"
+        
     tr
       td.heading_column
         | Goods


### PR DESCRIPTION
Prior to this change, when cross checking a new measure, the user
could only see the description of the measure type, not the number.

This commit displays the measure type number.

Trello card: https://trello.com/c/PIlwmkkw/501-dit-tq-43-edit-measures-multiple-issues-regulation-selection-regulation-assignment-measure-id-and-date-display-no-xml-no-justifi