### PR TITLE
Fix: chromedriver-helper gem is no longer supported

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ group :test do
   gem 'capybara'
   gem 'selenium-webdriver'
   gem 'launchy'
-  gem "chromedriver-helper"
+  gem 'webdrivers'
   gem 'cucumber-rails', require: false
   gem 'site_prism'
   gem 'capybara-screenshot'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,8 +54,6 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     ansi (1.5.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.4.2)
@@ -92,7 +90,7 @@ GEM
     builder (3.2.3)
     byebug (11.0.1)
     callsite (0.0.11)
-    capybara (3.13.2)
+    capybara (3.18.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -103,11 +101,8 @@ GEM
     capybara-screenshot (1.0.22)
       capybara (>= 1.0, < 4)
       launchy
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
+    childprocess (1.0.1)
+      rake (< 13.0)
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
     coderay (1.1.2)
@@ -211,14 +206,13 @@ GEM
       sass (>= 3.2.0)
     govuk_template (0.25.0)
       rails (>= 3.1)
-    hashdiff (0.3.8)
+    hashdiff (0.3.9)
     hashie (3.5.7)
     highline (2.0.0)
     holidays (7.0.0)
     htmlentities (4.3.4)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
@@ -323,7 +317,7 @@ GEM
     raabro (1.1.6)
     rabl (0.14.0)
       activesupport (>= 2.3.14)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-contrib (2.1.0)
       rack (~> 2.0)
     rack-protection (2.0.4)
@@ -380,7 +374,7 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.6.0)
       redis (>= 2.2, < 5)
-    regexp_parser (1.3.0)
+    regexp_parser (1.4.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.0)
@@ -388,7 +382,7 @@ GEM
       railties (>= 4.2.0, < 5.3)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
@@ -419,7 +413,7 @@ GEM
     rubyzip (1.2.2)
     rufus-scheduler (3.5.2)
       fugit (~> 1.1, >= 1.1.5)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     sanitize (4.6.6)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
@@ -439,8 +433,8 @@ GEM
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
     selectize-rails (0.12.6)
-    selenium-webdriver (3.141.0)
-      childprocess (~> 0.5)
+    selenium-webdriver (3.142.0)
+      childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
@@ -503,7 +497,11 @@ GEM
       json (>= 1.8.0)
     unicode-display_width (1.4.0)
     vuejs-rails (2.5.13)
-    webmock (3.0.1)
+    webdrivers (3.8.0)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
+    webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -528,7 +526,6 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
-  chromedriver-helper
   codeclimate-test-reporter
   coffee-rails (~> 4.2.2)
   connection_pool (~> 2.2)
@@ -598,6 +595,7 @@ DEPENDENCIES
   tilt
   uglifier (~> 2.7)
   vuejs-rails
+  webdrivers
   webmock
 
 RUBY VERSION

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,14 @@ require "spec_helper"
 
 require 'webmock/rspec'
 
-WebMock.disable_net_connect!(allow: "codeclimate.com", allow_localhost: true)
+allowed_sites = [
+  "https://codeclimate.com",
+  "https://chromedriver.storage.googleapis.com",
+  "https://github.com/mozilla/geckodriver/releases",
+  "https://selenium-release.storage.googleapis.com",
+  "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver"
+]
+WebMock.disable_net_connect!(allow: allowed_sites, allow_localhost: true)
 
 # SimpleCov.add_filter "vendor"
 #

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,5 @@
 require "selenium/webdriver"
+require 'webdrivers'
 
 Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome)


### PR DESCRIPTION
Prior to this change, updates of chrome caused test failures

This change replaces chromedriver-helper with webdrivers gem. And also updates some of the testing gems.