### PR TITLE
Fix: Makes withdraw quota link work

### DIFF
--- a/app/views/workbaskets/create_quota/submitted_for_cross_check.html.slim
+++ b/app/views/workbaskets/create_quota/submitted_for_cross_check.html.slim
@@ -15,8 +15,7 @@ h3.heading-medium
 
 ul class="list"
   li
-    a href="#"
-      | Withdraw submission/edit this quota (not implemented)
+    = link_to "Withdraw submission/edit quota", withdraw_workbasket_from_workflow_create_quotum_url(workbasket.id)
   li
     = link_to "View this quota", read_only_section_url
   li


### PR DESCRIPTION
Prior to this change, the withdraw/edit quota link was not implemented it.

This change implements it.

Trello: https://trello.com/c/4GAZ6v8F/890-withdraw-edit-quota-link-needs-to-be-updated