### PR TITLE
Fix: Scrolls to search results

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,14 @@
 //= require ./components/utils
 //= require_tree .
 
+$(function () {
+  if (window.__pagination_metadata) {
+    if(window.__pagination_metadata.total_count) {
+      setTimeout(function () {
+        $(window).scrollTop($('.records-table-wrapper').offset().top);
+      }, 1000);
+    } else if ($('.loading-indicator').length > 0) {
+      $(window).scrollTop($('.search__results').offset().top);
+    }
+  }
+});


### PR DESCRIPTION
Auto-scrolling was previously implemented but is hit and miss, or doesn't work at all

This change resolves the issue by waiting for the page to load, and scrolling to the results table or the results loading section, whichever is present.