### PR TITLE
Fix: auto scroll page to search results

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,10 +16,19 @@
 
 $(function () {
   if (window.__pagination_metadata) {
-    if(window.__pagination_metadata.total_count) {
-      setTimeout(function () {
-        $(window).scrollTop($('.records-table-wrapper').offset().top);
-      }, 1000);
+    if (window.__pagination_metadata.total_count) {
+      function startTimer() {
+        var timer = window.setTimeout(function () {
+          try {
+            $(window).scrollTop($('.records-table-wrapper').offset().top);
+            window.clearTimeout(timer);
+          } catch {
+            window.clearTimeout(timer);
+            startTimer();
+          }
+        }, 500);
+      };
+      startTimer();
     } else if ($('.loading-indicator').length > 0) {
       $(window).scrollTop($('.search__results').offset().top);
     }


### PR DESCRIPTION
Previous implementation used a timer to wait a fixed number of seconds
This approach fails whenever the page takes longer to load than the prescribed time

This change resets the timer periodically (every 500ms), allowing the auto-scroll functionality to wait indefinitely until there are search results to scroll to. Recursion FTW!

Before/After screen shots: none