### PR TITLE
Fix: Clicking back after withdraw/edit bug

### DIFF
--- a/app/views/workbaskets/create_measures/show.html.slim
+++ b/app/views/workbaskets/create_measures/show.html.slim
@@ -18,6 +18,9 @@ header
     = render "workbaskets/create_measures/workflow_screens_parts/actions_allowed"
     = render "workbaskets/create_measures/workflow_screens_parts/workbasket_details"
 
+    - if workbasket.status == 'editing'
+      = controller.redirect_to edit_create_measure_path
+
     - if iam_workbasket_author? && workbasket_rejected?
       = link_to "Edit measures", '#',
               data: {target_url: move_to_editing_mode_create_measure_url(workbasket.id)},

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The measure is being edited.

--- a/app/views/workbaskets/create_quota/show.html.slim
+++ b/app/views/workbaskets/create_quota/show.html.slim
@@ -18,6 +18,9 @@ header
     = render "workbaskets/create_quota/workflow_screens_parts/actions_allowed"
     = render "workbaskets/create_quota/workflow_screens_parts/workbasket_details"
 
+    - if workbasket.status == 'editing'
+      = controller.redirect_to edit_create_quotum_path
+
     - if iam_workbasket_author? && workbasket_rejected?
       = link_to "Edit quota", '#',
               data: {target_url: move_to_editing_mode_create_quotum_url(workbasket.id)},

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota is being edited.


### PR DESCRIPTION
Prior to this change, if user withdrew a create quota or create measure
workbasket, then clicked the back button, then clicked view to inspect the
workbasket the page would crash.

This change redirects the user to the editing page if the status of
a workbasket is 'editing' even if the user has gone back a page.

Trello card: https://trello.com/c/upz1iBzA/845-back-button-not-refreshing-causing-page-to-crash