### PR TITLE
Fix: Show all conditions available to edit

### DIFF
--- a/app/views/shared/vue_templates/_condition.html.erb
+++ b/app/views/shared/vue_templates/_condition.html.erb
@@ -54,7 +54,7 @@
         </form-group>
       </div>
       <div class="col-xs-12 col-sm-6 col-md-2" v-if="roomCertificateType">
-        <form-group v-if="showCertificateType">
+        <form-group v-if="showCertificateType && condition.certificate_type">
           <label class="form-label" v-if="index == 0">
             Certificate type(s)
           </label>
@@ -68,7 +68,7 @@
         </form-group>
       </div>
       <div class="col-xs-12 col-sm-6 col-md-1" v-if="roomCertificate">
-        <form-group v-if="showCertificate">
+        <form-group v-if="showCertificate && condition.certificate">
           <label class="form-label" v-if="index == 0">
             Certificate
           </label>


### PR DESCRIPTION
Prior to this change, conditions without a certificate would not show
in editing pop up.

This change does not try to populate certificate fields if there is no
certificate.

Trello card: https://trello.com/c/k3D7Wc21/794-certificate-type-and-id-not-pre-populated-when-editing-measure-conditions