### PR TITLE
Fix: If applied, will allow edit of measure conditions

### DIFF
--- a/app/assets/javascripts/vue_components/change-conditions-popup.js
+++ b/app/assets/javascripts/vue_components/change-conditions-popup.js
@@ -178,12 +178,14 @@ Vue.component("change-conditions-popup", {
             if (!condition.condition_code) {
               return;
             }
-
+            
             condition.original_measure_condition_code = condition.condition_code.slice(0);
             condition.condition_code = condition.condition_code.substring(0, 1);
 
             condition.measure_condition_components.forEach(function(mcc) {
-              mcc.original_duty_expression_id = mcc.duty_expression_id.slice(0);
+              if (mcc.original_duty_expression_id) {
+                mcc.original_duty_expression_id = mcc.duty_expression_id.slice(0);
+              }
               mcc.duty_expression_id = mcc.duty_expression_id.substring(0,2);
               mcc.duty_expression.duty_expression_id = mcc.duty_expression.duty_expression_id.substring(0,2);
             });


### PR DESCRIPTION
Prior to this change, users trying to edit measures by changing conditions
would not be able to.

This change allows users to do this.

Trello card: https://trello.com/c/3iSvx6lC/876-bulk-edit-measure-with-change-conditions-light-box-popup-with-changing-conditions-update-selected-measures-button-is-not-working