### PR TITLE
Fix: Reinstate the workbasket details for approval/cc

### DIFF
--- a/app/helpers/cross_check_helper.rb
+++ b/app/helpers/cross_check_helper.rb
@@ -13,7 +13,7 @@ module CrossCheckHelper
     elsif workbasket.type == 'create_quota'
       "workbaskets/shared/steps/review_and_submit/quotas"
     elsif workbasket.type == 'bulk_edit_of_measures'
-      "workbaskets/shared/steps/review_and_submit/measures"
+      "workbaskets/shared/steps/review_and_submit/bulk_edit_measures"
     end
   end
 

--- a/app/views/workbaskets/shared/steps/review_and_submit/_bulk_edit_measures.html.slim
+++ b/app/views/workbaskets/shared/steps/review_and_submit/_bulk_edit_measures.html.slim
@@ -1,0 +1,9 @@
+.review-bulk-edit-measures.submitted-for-cross-check-view
+  review-bulk-edit-records workbasket_id="#{workbasket.id}" primary-key="measure_sid" initial-sort-key="measure_sid" :bulk-actions="bulkActions" thing="measures" :columns="columns" :actions="actions" :record-table-processing="recordTableProcessing" :preprocess-record="preprocessRecord"
+= render "shared/vue_templates/review_bulk_edit_records.html.erb"
+
+script
+  == "window.__workbasket_id = #{workbasket.id};"
+  == "window.__pagination_metadata = {page: 1, total_count: 1, per_page: 1000};"
+  == "window.all_settings = #{workbasket_settings.settings.to_json};"
+  == "window.current_step_settings = {};"

--- a/app/views/workbaskets/workflows/approves/new.html.slim
+++ b/app/views/workbaskets/workflows/approves/new.html.slim
@@ -18,15 +18,5 @@ header
     = render "workbaskets/#{workbasket.type}/workflow_screens_parts/workbasket_details"
     = render "workbaskets/#{workbasket.type}/workflow_screens_parts/summary_of_configuration"
 
-    - if workbasket.is_bulk_edit?
-      .review-bulk-edit-measures.submitted-for-cross-check-view
-        review-bulk-edit-records workbasket_id="#{workbasket.id}" primary-key="measure_sid" initial-sort-key="measure_sid" :bulk-actions="bulkActions" thing="measures" :columns="columns" :actions="actions" :record-table-processing="recordTableProcessing" :preprocess-record="preprocessRecord"
-      = render "shared/vue_templates/review_bulk_edit_records.html.erb"
-
-      script
-        == "window.__workbasket_id = #{workbasket.id};"
-        == "window.__pagination_metadata = {page: 1, total_count: 1, per_page: 1000};"
-        == "window.all_settings = #{workbasket_settings.settings.to_json};"
-        == "window.current_step_settings = {};"
-
+    = render table_partial(workbasket), read_only: true, record_type: workbasket.type
     = render "workbaskets/workflows/approves/form"

--- a/app/views/workbaskets/workflows/cross_checks/new.html.slim
+++ b/app/views/workbaskets/workflows/cross_checks/new.html.slim
@@ -17,16 +17,5 @@ header
     = render "workbaskets/#{workbasket.type}/workflow_screens_parts/notifications/block", screen_type: :cross_check
     = render "workbaskets/#{workbasket.type}/workflow_screens_parts/workbasket_details"
 
-    - if workbasket.is_bulk_edit?
-      .review-bulk-edit-measures.submitted-for-cross-check-view
-        review-bulk-edit-records workbasket_id="#{workbasket.id}" primary-key="measure_sid" initial-sort-key="measure_sid" :bulk-actions="bulkActions" thing="measures" :columns="columns" :actions="actions" :record-table-processing="recordTableProcessing" :preprocess-record="preprocessRecord"
-      = render "shared/vue_templates/review_bulk_edit_records.html.erb"
-
-      script
-        == "window.__workbasket_id = #{workbasket.id};"
-        == "window.__pagination_metadata = {page: 1, total_count: 1, per_page: 1000};"
-        == "window.all_settings = #{workbasket_settings.settings.to_json};"
-        == "window.current_step_settings = {};"
-
-
+    = render table_partial(workbasket), read_only: true, record_type: workbasket.type
     = render "workbaskets/workflows/cross_checks/form"


### PR DESCRIPTION
Prior to this change, the details had been removed as some types had not
had the section complete.

This change reinstates the details section and removes some duplication.

https://trello.com/c/Rn8FtExt/898-cross-check-and-approval-are-not-showing-the-basket-details