### PR TITLE
Fix: Disabled adding duties if already specified in condition

### DIFF
--- a/app/assets/javascripts/vue_components/components-coordinator.js
+++ b/app/assets/javascripts/vue_components/components-coordinator.js
@@ -1,7 +1,7 @@
 var template = [
   '<div>',
     '<div :class="classes" v-for="(component, idx) in components">',
-      '<measure-condition-component :id="\'measure-condition-\' + index + \'-measure-condition-component-\' + idx" v-if="isMeasureConditionComponent" :measure-condition-component="component" :prefix="(prefix ? prefix + \'-\' : \'\') + \'measure-condition-\' + index + \'-measure-condition-component-\' + idx + \'-\'" :index="Math.max(idx,index)" :room-duty-amount="showDutyAmount" :room-measurement-unit="showMeasurementUnit" :room-monetary-unit="showMonetaryUnit">',
+      '<measure-condition-component :id="\'measure-condition-\' + index + \'-measure-condition-component-\' + idx" v-if="isMeasureConditionComponent" :disabled="isDisabled" :measure-condition-component="component" :prefix="(prefix ? prefix + \'-\' : \'\') + \'measure-condition-\' + index + \'-measure-condition-component-\' + idx + \'-\'" :index="Math.max(idx,index)" :room-duty-amount="showDutyAmount" :room-measurement-unit="showMeasurementUnit" :room-monetary-unit="showMonetaryUnit">',
         '<div class="col-md-1 align-bottom" v-if="canRemoveComponent">',
           '<div class="form-group">',
             '<label for="" class="form-label" v-if="index == 0 && idx == 0">&nbsp;</label>',
@@ -11,7 +11,7 @@ var template = [
           '</div>',
         '</div>',
       '</measure-condition-component>',
-      '<measure-component :id="(prefix ? prefix + \'-\' : \'\') + \'measure-component-\' + idx" :prefix="(prefix ? prefix + \'-\' : \'\') + \'measure-component-\' + idx" v-if="isMeasureComponent" :measure-component="component" :index="Math.max(idx,index)" :room-monetary-unit="showMonetaryUnit" :room-duty-amount="showDutyAmount" :room-measurement-unit="showMeasurementUnit">',
+      '<measure-component :id="(prefix ? prefix + \'-\' : \'\') + \'measure-component-\' + idx" :prefix="(prefix ? prefix + \'-\' : \'\') + \'measure-component-\' + idx" v-if="isMeasureComponent" :disabled="isDisabled" :measure-component="component" :index="Math.max(idx,index)" :room-monetary-unit="showMonetaryUnit" :room-duty-amount="showDutyAmount" :room-measurement-unit="showMeasurementUnit">',
         '<div class="col-md-1 align-bottom" v-if="canRemoveComponent">',
           '<div class="form-group">',
             '<label for="" class="form-label" v-if="index == 0 && idx == 0">&nbsp;</label>',
@@ -31,6 +31,7 @@ Vue.component("components-coordinator", {
   template: template,
   props: [
     "components",
+    "conditions",
     "type",
     "classes",
     "index",
@@ -62,6 +63,17 @@ Vue.component("components-coordinator", {
     }
   },
   computed: {
+    isDisabled: function() {
+      if (this.conditions === undefined) {
+        return;
+      }
+      console.log('here')
+      console.log(this)
+      var expressions_ids = this.conditions[0].measure_condition_components.map(function(component) {
+        return component.duty_expression_id == undefined
+      })
+      return expressions_ids.includes(false);
+    },
     canRemoveComponent: function() {
       return this.components.length > 1;
     },

--- a/app/assets/javascripts/vue_components/components-coordinator.js
+++ b/app/assets/javascripts/vue_components/components-coordinator.js
@@ -67,8 +67,6 @@ Vue.component("components-coordinator", {
       if (this.conditions === undefined) {
         return;
       }
-      console.log('here')
-      console.log(this)
       var expressions_ids = this.conditions[0].measure_condition_components.map(function(component) {
         return component.duty_expression_id == undefined
       })

--- a/app/assets/javascripts/vue_components/components-coordinator.js
+++ b/app/assets/javascripts/vue_components/components-coordinator.js
@@ -60,6 +60,9 @@ Vue.component("components-coordinator", {
         measurement_unit_code: null,
         measurement_unit_qualifier_code: null
       });
+    },
+    flattenArray: function(arrays) {
+      return [].concat.apply([], arrays)
     }
   },
   computed: {
@@ -67,10 +70,12 @@ Vue.component("components-coordinator", {
       if (this.conditions === undefined) {
         return;
       }
-      var expressions_ids = this.conditions[0].measure_condition_components.map(function(component) {
-        return component.duty_expression_id == undefined
+      var conditions_allow_duty = this.conditions.map(function(condition) {
+        return condition.measure_condition_components.map(function (component) {
+          return (component.duty_expression_id == undefined || component.duty_expression_id == "")
+        })
       })
-      return expressions_ids.includes(false);
+      return this.flatten_array(conditions_allow_duty).includes(false);
     },
     canRemoveComponent: function() {
       return this.components.length > 1;

--- a/app/assets/javascripts/vue_components/conditions-coordinator.js
+++ b/app/assets/javascripts/vue_components/conditions-coordinator.js
@@ -20,7 +20,7 @@ var template = [
 
 Vue.component("conditions-coordinator", {
   template: template,
-  props: ["conditions", "hideHelp"],
+  props: ["conditions", "hideHelp", "components"],
   data: function() {
     return {
 

--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -22,8 +22,7 @@ Vue.component('custom-select', {
     "disabled",
     "compact",
     "showCompactAbbreviation",
-    "scopeDate",
-    "disabled"
+    "scopeDate"
   ],
   data: function() {
     return {

--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -22,7 +22,8 @@ Vue.component('custom-select', {
     "disabled",
     "compact",
     "showCompactAbbreviation",
-    "scopeDate"
+    "scopeDate",
+    "disabled"
   ],
   data: function() {
     return {

--- a/app/assets/javascripts/vue_components/measure-components.js
+++ b/app/assets/javascripts/vue_components/measure-components.js
@@ -64,7 +64,8 @@ Vue.component("measure-component", $.extend({}, {
     "roomDutyAmount",
     "roomMonetaryUnit",
     "roomMeasurementUnit",
-    "prefix"
+    "prefix",
+    "disabled"
   ],
   data: function() {
     return {
@@ -99,7 +100,8 @@ Vue.component("measure-condition-component", $.extend({}, {
     "roomDutyAmount",
     "roomMonetaryUnit",
     "roomMeasurementUnit",
-    "prefix"
+    "prefix",
+    "disabled"
   ],
   data: function() {
     return {

--- a/app/views/shared/vue_templates/_measure_component.html.erb
+++ b/app/views/shared/vue_templates/_measure_component.html.erb
@@ -6,7 +6,7 @@
           Duty expression
         </label>
 
-        <custom-select data-test="duty-expression" url="/duty_expressions" label-field="description" value-field="duty_expression_id" code-field="duty_expression_code" v-model="measureComponent.duty_expression_id" date-sensitive="true" code-class-name="prefix--duty-expression" abbreviation-class-name="abbreviation--duty-expression" :options-filter="expressionsFriendlyDuplicate" :on-change="onDutyExpressionSelected" :compact="true" :showCompactAbbreviation="true" placeholder="―" :id="(prefix ? prefix : '') + '-duty-expression'"></custom-select>
+        <custom-select data-test="duty-expression" url="/duty_expressions" label-field="description" value-field="duty_expression_id" code-field="duty_expression_code" v-model="measureComponent.duty_expression_id" date-sensitive="true" code-class-name="prefix--duty-expression" abbreviation-class-name="abbreviation--duty-expression" :options-filter="expressionsFriendlyDuplicate" :on-change="onDutyExpressionSelected" :compact="true" :showCompactAbbreviation="true" placeholder="―" :disabled="disabled" :id="(prefix ? prefix : '') + '-duty-expression'"></custom-select>
       </form-group>
     </div>
 
@@ -15,7 +15,7 @@
         <label class="form-label" v-if="index === 0">
           Duty amount
         </label>
-        <input class="form-control" data-test="duty-amount" v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001" :id="(prefix ? prefix : '') + '-amount'">
+        <input class="form-control" data-test="duty-amount" v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001" :disabled="disabled" :id="(prefix ? prefix : '') + '-amount'">
       </form-group>
       <form-group v-else="">
         <label class="form-label" v-if="index === 0">
@@ -29,7 +29,7 @@
         <label class="form-label" v-if="index === 0">
           Monetary unit
         </label>
-        <custom-select url="/monetary_units" label-field="description" value-field="monetary_unit_code" code-field="monetary_unit_code" v-model="measureComponent.monetary_unit_code" date-sensitive="true" code-class-name="prefix--monetary-unit" :on-change="onMonetaryUnitSelected" :compact="true" placeholder="―" :id="(prefix ? prefix : '') + '-monetary-unit'"></custom-select>
+        <custom-select url="/monetary_units" label-field="description" value-field="monetary_unit_code" code-field="monetary_unit_code" v-model="measureComponent.monetary_unit_code" date-sensitive="true" code-class-name="prefix--monetary-unit" :on-change="onMonetaryUnitSelected" :compact="true" placeholder="―" :disabled="disabled" :id="(prefix ? prefix : '') + '-monetary-unit'"></custom-select>
       </form-group>
       <form-group v-else="">
         <label class="form-label" v-if="index === 0">
@@ -43,7 +43,7 @@
         <label class="form-label" v-if="index === 0">
           Unit of measure
         </label>
-        <custom-select url="/measurement_units" label-field="description" value-field="measurement_unit_code" code-field="measurement_unit_code" v-model="measureComponent.measurement_unit_code" date-sensitive="true" code-class-name="prefix--measurement-unit" abbreviation-class-name="abbreviation--measurement-unit" :on-change="onMeasurementUnitSelected" :compact="true" placeholder="―" :id="(prefix ? prefix : '') + '-measurement-unit'"></custom-select>
+        <custom-select url="/measurement_units" label-field="description" value-field="measurement_unit_code" code-field="measurement_unit_code" v-model="measureComponent.measurement_unit_code" date-sensitive="true" code-class-name="prefix--measurement-unit" abbreviation-class-name="abbreviation--measurement-unit" :on-change="onMeasurementUnitSelected" :compact="true" placeholder="―" :disabled="disabled" :id="(prefix ? prefix : '') + '-measurement-unit'"></custom-select>
       </form-group>
       <form-group v-else="">
         <label class="form-label" v-if="index === 0">
@@ -57,7 +57,7 @@
         <label class="form-label" v-if="index === 0">
           Qualifier
         </label>
-        <custom-select url="/measurement_unit_qualifiers" label-field="description" value-field="measurement_unit_qualifier_code" code-field="measurement_unit_qualifier_code" v-model="measureComponent.measurement_unit_qualifier_code" date-sensitive="true" code-class-name="prefix--measurement-unit-qualifier" :on-change="onMeasurementUnitQualifierSelected" :compact="true" placeholder="―" :id="(prefix ? prefix : '') + '-measurement-unit-qualifier'"></custom-select>
+        <custom-select url="/measurement_unit_qualifiers" label-field="description" value-field="measurement_unit_qualifier_code" code-field="measurement_unit_qualifier_code" v-model="measureComponent.measurement_unit_qualifier_code" date-sensitive="true" code-class-name="prefix--measurement-unit-qualifier" :on-change="onMeasurementUnitQualifierSelected" :compact="true" placeholder="―" disabled="disabled" :id="(prefix ? prefix : '') + '-measurement-unit-qualifier'"></custom-select>
       </form-group>
       <form-group v-else="">
         <label class="form-label" v-if="index === 0">

--- a/app/views/shared/vue_templates/_measure_condition_component.html.erb
+++ b/app/views/shared/vue_templates/_measure_condition_component.html.erb
@@ -6,7 +6,7 @@
           Duty expression
         </label>
 
-        <custom-select url="/duty_expressions" label-field="description" value-field="duty_expression_id" code-field="duty_expression_code" v-model="measureConditionComponent.duty_expression_id" placeholder="―" code-class-name="prefix--duty-expression" abbreviation-class-name="abbreviation--duty-expression" :options-filter="expressionsFriendlyDuplicate" :on-change="onDutyExpressionSelected" :compact="true" :showCompactAbbreviation="true" :id="prefix + 'duty-expression'"></custom-select>
+        <custom-select url="/duty_expressions" label-field="description" value-field="duty_expression_id" code-field="duty_expression_code" v-model="measureConditionComponent.duty_expression_id" placeholder="―" code-class-name="prefix--duty-expression" abbreviation-class-name="abbreviation--duty-expression" :options-filter="expressionsFriendlyDuplicate" :on-change="onDutyExpressionSelected" :compact="true" :showCompactAbbreviation="true" :disabled="disabled" :id="prefix + 'duty-expression'"></custom-select>
       </form-group>
     </div>
 
@@ -30,7 +30,7 @@
         <label class="form-label" v-if="index == 0">
           Monetary unit
         </label>
-        <custom-select url="/monetary_units" label-field="description" value-field="monetary_unit_code" code-field="monetary_unit_code" v-model="measureConditionComponent.monetary_unit_code" placeholder="―" date-sensitive="true" code-class-name="prefix--monetary-unit" :on-change="onMonetaryUnitSelected" :compact="true" :id="prefix + 'monetary-unit'"></custom-select>
+        <custom-select url="/monetary_units" label-field="description" value-field="monetary_unit_code" code-field="monetary_unit_code" v-model="measureConditionComponent.monetary_unit_code" placeholder="―" date-sensitive="true" code-class-name="prefix--monetary-unit" :on-change="onMonetaryUnitSelected" :compact="true" :disabled="disabled" :id="prefix + 'monetary-unit'"></custom-select>
       </form-group>
       <form-group v-else="">
         <label class="form-label" v-if="index == 0">

--- a/app/views/shared/vue_templates/_selectize.html.slim
+++ b/app/views/shared/vue_templates/_selectize.html.slim
@@ -1,4 +1,4 @@
 script type="text/x-template" id="selectize-template"
   div
     slot
-      select v-model="value" :name="name" :class="{ allowClear: allowClear }"
+      select v-model="value" :name="name" :class="{ allowClear: allowClear }" :disabled="disabled"

--- a/app/views/workbaskets/create_measures/steps/_duties_conditions_footnotes.html.slim
+++ b/app/views/workbaskets/create_measures/steps/_duties_conditions_footnotes.html.slim
@@ -1,3 +1,3 @@
-= render "workbaskets/create_measures/steps/duties_conditions_footnotes/duty_expression", f: f, record_type: 'measures'
 = render "workbaskets/shared/steps/duties_conditions_footnotes/conditions", f: f, record_type: 'measures'
+= render "workbaskets/create_measures/steps/duties_conditions_footnotes/duty_expression", f: f, record_type: 'measures'
 = render "workbaskets/shared/steps/duties_conditions_footnotes/footnotes", f: f, record_type: 'measures'

--- a/app/views/workbaskets/create_measures/steps/duties_conditions_footnotes/_duty_expression.html.slim
+++ b/app/views/workbaskets/create_measures/steps/duties_conditions_footnotes/_duty_expression.html.slim
@@ -16,4 +16,4 @@ fieldset
         | them with the same duties initially and then use bulk-editing to make the necessary changes.
 
   .measure-components
-    = content_tag "components-coordinator", nil, { ":components" => "measure.measure_components", "type" => "measure_component", "classes" => "measure-component", ":hide-help" => "false", ":index" => "0" }
+    = content_tag "components-coordinator", nil, { ":components" => "measure.measure_components", ":conditions" => "measure.conditions", "type" => "measure_component", "classes" => "measure-component", ":hide-help" => "false", ":index" => "0" }

--- a/app/views/workbaskets/shared/steps/duties_conditions_footnotes/_conditions.html.slim
+++ b/app/views/workbaskets/shared/steps/duties_conditions_footnotes/_conditions.html.slim
@@ -4,4 +4,4 @@ fieldset
     =<> record_type
 
   .conditions-target
-    = content_tag "conditions-coordinator", nil, { ":conditions" => "measure.conditions", "type" => "measure_condition_component", "classes" => "measure-condition-component" }
+    = content_tag "conditions-coordinator", nil, { ":conditions" => "measure.conditions", ":components" => "measure.measure_components", "type" => "measure_condition_component", "classes" => "measure-condition-component" }


### PR DESCRIPTION
This PR disables the duty expression fields if duties already expressed
in conditions.

Trello: https://trello.com/c/sOyrFqSj/768-need-to-swap-order-of-duty-expression-and-conditions-mechanics-in-create-measure