### PR TITLE
Fix: sets assets debug flag to true

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Expands the lines which load the assets.
-  config.assets.debug = false
+  config.assets.debug = true
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
Front-end developers are unable to attribute runtime errors to the JS source code via the web browser console

This configuration change produces JS assets such that runtime errors can be attributed to the JS source code

Trello link: N/A

Before:
![image](https://user-images.githubusercontent.com/6898065/57135207-7f554380-6da0-11e9-895f-6635b9cc9391.png)


After:
![image](https://user-images.githubusercontent.com/6898065/57135168-6482cf00-6da0-11e9-82e3-f2965763d45d.png)
