### PR TITLE
Fix: increases size of date picker icon in IE11

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,4 @@
 @import "simple-grid";
 @import "variables";
 @import "components/*";
+@import "ie11";

--- a/app/assets/stylesheets/ie11.scss
+++ b/app/assets/stylesheets/ie11.scss
@@ -1,0 +1,8 @@
+// Styles for IE11
+@media all and (-ms-high-contrast: none),
+(-ms-high-contrast: active) {
+  input.datepicker, input.date-picker {
+    background-size:40% !important;    
+    background-position: 115% !important;
+  }
+}


### PR DESCRIPTION
Date picker icon is rendered tiny in IE11
This change applies IE11-specific styles to render the date picker icon correctly

Trello link: https://trello.com/c/X545cirN/907-ie11-browser-compatibility-issues (issue 7)

**NOTE** https://github.com/uktrade/trade-tariff-management/pull/199 merge to master required in order to test this PR.

Before:
![image](https://user-images.githubusercontent.com/6898065/57611783-7e27d180-756b-11e9-888f-2dcc5bb14b50.png)

After:
![image](https://user-images.githubusercontent.com/6898065/57611794-83851c00-756b-11e9-9f04-6a08c0a2b0ef.png)

