### PR TITLE
Fix: 'Create quota' view template compatibility with IE11

### DIFF
--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -31,7 +31,7 @@
                     <input value="January" disabled class='form-control string'>
                   </div>
                   <div class="col-md-4">
-                    <input :value="section.start_date && section.start_date.split('/')[2]" @input="section.start_date = `01/01/${$event.target.value}`" class='form-control string' id='quota-period-year'>
+                    <input :value="section.start_date && section.start_date.split('/')[2]" @input="section.start_date = '01/01/'+$event.target.value;" class='form-control string' id='quota-period-year'>
                   </div>
                 </div>
             </div>


### PR DESCRIPTION
The view template uses JS template literals, which are not supported in IE11

This change replaces template literals with string concatenation for IE11

Trello link: https://trello.com/c/X545cirN/907-ie11-browser-compatibility-issues (issue 19)

Before: The form in the 'Create quota' view did not display in IE11
After: The form in the 'Create quota' view does display in IE11