### PR TITLE
Fix: Drop-down options un-clipped in IE11

### DIFF
--- a/app/assets/stylesheets/ie11.scss
+++ b/app/assets/stylesheets/ie11.scss
@@ -5,4 +5,8 @@
     background-size:40% !important;    
     background-position: 115% !important;
   }
+
+  .selectize-control.select .selectize-input input {
+    width: auto !important;
+  }
 }

--- a/app/assets/stylesheets/ie11.scss
+++ b/app/assets/stylesheets/ie11.scss
@@ -9,4 +9,7 @@
   .selectize-control.select .selectize-input input {
     width: auto !important;
   }
+  .selectize-control .selectize-input input {
+    width: 100% !important;
+  }
 }


### PR DESCRIPTION
Drop down options are clipped if the option is wider than 138px

This change changes the styling to allow the browser to determine the correct length (auto)

Trello link: https://trello.com/c/WAcSDTnN/909-ie11-drop-down-menu-options-cropped

Before (IE11):
![image](https://user-images.githubusercontent.com/6898065/57627408-e2f52300-758f-11e9-8766-daf0b0c97ca7.png)


After (IE11):
![image](https://user-images.githubusercontent.com/6898065/57627439-eab4c780-758f-11e9-926a-8c65c3ee123a.png)
