### PR TITLE
Fix: update display of Additional Codes basket

### DIFF
--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/_actions_allowed.html.slim
@@ -1,0 +1,9 @@
+- if workbasket_view_show_actions_allowed?
+  .view-workbasket-actions-allowed
+    - if iam_workbasket_author? && workbasket.can_withdraw?
+      = link_to "Withdraw workbasket from workflow", "#", data: { target_url: withdraw_workbasket_from_workflow_create_additional_code_url(workbasket.id) }, class: "button js-main-menu-show-withdraw-confirmation-link"
+      br
+
+= render "workbaskets/main_menu_parts/schedule_export_to_cds_popup"
+= render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "delete_confirmation_popup", title: "You are going to delete workbasket"
+= render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "withdraw_confirmation_popup", title: "You are going to withdraw workbasket"

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_approval_rejected.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_approval_rejected.html.slim
@@ -1,0 +1,2 @@
+p
+  | The new additional codes have been rejected. The approver gave the reasons detailed below.

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_awaiting_approval.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_awaiting_approval.html.slim
@@ -1,0 +1,2 @@
+p
+  | The new additional codes shown below has been submitted for approval and is waiting for response. If you need to re-edit it, first withdraw the workbasket from workflow.

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_awaiting_cds_upload_create_new.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_awaiting_cds_upload_create_new.html.slim
@@ -1,0 +1,3 @@
+p
+  | The new additional codes has/have been approved, but has not yet been sent through to CDS. It will be sent in the next batch.
+  | .

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
@@ -1,0 +1,2 @@
+p
+  | The new additional codes shown below has been submitted for cross-check and is waiting for response. If you need to re-edit it, first withdraw the workbasket from workflow.

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_cds_error.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_cds_error.html.slim
@@ -1,0 +1,5 @@
+p
+  | The new additional codes were not imported by CDS because of error.
+  =<> link_to "View error details"
+  | .
+

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_cross_check_rejected.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_cross_check_rejected.html.slim
@@ -1,0 +1,2 @@
+p
+  | The new additional codes have been rejected. The cross-checker gave the reasons detailed below.

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_ready_for_export.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_ready_for_export.html.slim
@@ -1,0 +1,2 @@
+p
+  | The new additional codes has/have been approved, but has not yet been sent through to CDS and has not been scheduled for export.

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_sent_to_cds.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_sent_to_cds.html.slim
@@ -1,0 +1,2 @@
+p
+  | The new additional codes has/have been sent to CDS.


### PR DESCRIPTION
Prior to this change, the view page did not show top notification,
withdraw from workflow button and the correct status changes

This change adds those parts of the view page.

https://trello.com/c/WgBplkgT/910-additional-codes-submitted-for-cross-check-do-not-have-description-and-submitted-for-cross-check-in-details