### PR TITLE
Fix: prevent duplicate Additional Codes in basket

### DIFF
--- a/app/interactors/workbasket_interactions/create_additional_code/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_additional_code/settings_saver.rb
@@ -107,6 +107,7 @@ module WorkbasketInteractions
 
       def validate_additional_codes!
         additional_code_errors = {}
+        additional_code_errors.merge!(check_duplicates_in_basket)
         records.each_with_index do |record, index|
           validator = validator(record)
           if validator.present?
@@ -133,6 +134,21 @@ module WorkbasketInteractions
         "#{record.class.name}Validator".constantize
       rescue StandardError
         nil
+      end
+
+      def check_duplicates_in_basket
+        type_codes = Set.new
+        records.each do |record|
+          if record.class == AdditionalCode
+            combined_key = [record.additional_code_type_id, record.additional_code]
+            if type_codes.include?(combined_key)
+              return {"0": "ACN10: The combination of additional code type + additional code + start date must be unique."}
+            else
+              type_codes << combined_key
+            end
+          end
+        end
+        {}
       end
     end
   end


### PR DESCRIPTION
Prior to this change, You could create 2 identical Additional Codes in a workbasket

This change checks the basket for duplicates.

https://trello.com/c/vVUslwBT/911-we-can-create-same-additional-codes-with-same-type-and-code-and-description-no-errors-displayed