### PR TITLE
Add geo memberships

### DIFF
--- a/spec/features/workbasket/geographical_area/geographical_area_creation_spec.rb
+++ b/spec/features/workbasket/geographical_area/geographical_area_creation_spec.rb
@@ -43,9 +43,16 @@ RSpec.describe "adding geographical areas", :js do
     click_on "Submit for cross-check"
 
     expect(page).to have_content "Geographical area submitted"
+    expect_memberships_to_have_been_persisted(group)
   end
 
   private
+
+  def expect_memberships_to_have_been_persisted(group)
+    country = GeographicalArea.find(geographical_area_id: "GE")
+    membership_sids = country.member_of_following_geographical_areas.map { |geo_area| geo_area.geographical_area_sid }
+    membership_sids.include?(group.geographical_area_sid)
+  end
 
   def area_membership_codes
     memberships_table.all("tbody tr td:first-of-type").map(&:text)


### PR DESCRIPTION
New: Add group membership functionality

Prior to this change, we could not persist group memberships in our database.
The UI would make it look like the membership functionality was executed
successfully but it was not.

This change persists group memberships.

Trello card: https://trello.com/c/OGda243E/906-investigate-assigning-geographical-area-memberships