### PR TITLE
New: Add geo group with country

### DIFF
--- a/app/interactors/workbasket_interactions/create_geographical_area/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_geographical_area/settings_saver.rb
@@ -106,6 +106,7 @@ module WorkbasketInteractions
 
       def add_membership!
         GeographicalAreaMembership.unrestrict_primary_key
+
         if memberships
           memberships.each do |m|
             membership_data = m.last['geographical_area']
@@ -116,8 +117,14 @@ module WorkbasketInteractions
       end
 
       def new_membership(membership_data)
-        group = GeographicalArea.where(geographical_area_id: membership_data['geographical_area_id']).first
-        geographical_area = GeographicalArea.find(geographical_area_id: settings.main_step_settings['geographical_area_id'])
+        if geographical_code == 'group'
+          geographical_area = GeographicalArea.where(geographical_area_id: membership_data['geographical_area_id']).first
+          group = GeographicalArea.find(geographical_area_id: settings.main_step_settings['geographical_area_id'])
+        else
+          group = GeographicalArea.where(geographical_area_id: membership_data['geographical_area_id']).first
+          geographical_area = GeographicalArea.find(geographical_area_id: settings.main_step_settings['geographical_area_id'])
+        end
+
         GeographicalAreaMembership.new(
           geographical_area_sid: geographical_area.geographical_area_sid,
           geographical_area_group_sid: group[:geographical_area_sid],

--- a/app/views/shared/vue_templates/_add_geo_areas_to_group_popup.html.slim
+++ b/app/views/shared/vue_templates/_add_geo_areas_to_group_popup.html.slim
@@ -23,7 +23,7 @@ script type="text/x-template" id="add-geo-areas-to-group-popup-template"
           span.error-message v-if="slotProps.hasError" v-cloak=""
             | {{slotProps.error}}
 
-        textarea.form-control rows="4" v-model="codes"
+        textarea.form-control rows="4" v-model="codes" id="country_codes_text"
 
     form-group :errors="errors" error-key="join_date"
       template slot-scope="slotProps"

--- a/spec/features/workbasket/geographical_area/geographical_area_creation_spec.rb
+++ b/spec/features/workbasket/geographical_area/geographical_area_creation_spec.rb
@@ -43,15 +43,50 @@ RSpec.describe "adding geographical areas", :js do
     click_on "Submit for cross-check"
 
     expect(page).to have_content "Geographical area submitted"
-    expect_memberships_to_have_been_persisted(group)
+    expect_to_be_a_member(group)
+  end
+
+  it "allows a new group to be created" do
+    create(:geographical_area, :erga_omnes)
+    create(:geographical_area, :third_countries)
+    country = create(:geographical_area, :country, geographical_area_id: 'XX')
+
+    visit(root_path)
+
+    click_on("Create a new geographical area")
+
+    select_radio("A group")
+    fill_in("What code will identify this area?", with: "0000")
+    fill_in("What is the area description?", with: "A description")
+    input_date("When is the area valid from?", 3.days.from_now)
+
+    click_on("Add memberships")
+
+    within(".modal") do
+      find("#country_codes_text").set("XX")
+      click_on("Add memberships")
+    end
+
+    expect(area_membership_codes).to include "XX"
+
+    click_on "Submit for cross-check"
+
+    expect(page).to have_content "Geographical area submitted"
+    expect_to_have_member(country)
   end
 
   private
 
-  def expect_memberships_to_have_been_persisted(group)
+  def expect_to_be_a_member(group)
     country = GeographicalArea.find(geographical_area_id: "GE")
     membership_sids = country.member_of_following_geographical_areas.map { |geo_area| geo_area.geographical_area_sid }
     membership_sids.include?(group.geographical_area_sid)
+  end
+
+  def expect_to_have_member(country)
+    group = GeographicalArea.find(geographical_area_id: "0000")
+    membership_sids = group.contained_geographical_areas.map { |geo_area| geo_area.geographical_area_sid }
+    membership_sids.include?(country.geographical_area_sid)
   end
 
   def area_membership_codes


### PR DESCRIPTION
Prior to this change, we could not persist group memberships in our database.
The UI would make it look like the membership functionality was executed
successfully but it was not.

This change persists group memberships.

Card: https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-59