### PR TITLE
Fix: Display of complex duty expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ beta_server/*
 node_modules/
 
 spec/examples.txt
+.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 ## Git workflow ##
 
 - Pull requests must contain a succint, clear summary of what the user need is driving this feature change.
+- Use our git [commit template](./git_commit_msg.txt). To do that simply run `git config commit.template git_commit_msg.txt` from root path
 - Follow our [Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)
 - Make a feature branch
 - Ensure your branch contains logical atomic commits before sending a pull request - follow our [Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)

--- a/app/assets/javascripts/components/duty-expression-formatter.js
+++ b/app/assets/javascripts/components/duty-expression-formatter.js
@@ -39,9 +39,9 @@ window.DutyExpressionFormatter = {
       case "25":
       case "27":
       case "29":
-        if (duty_expression_abbreviation !== null) {
+        if (duty_expression_abbreviation) {
           output.push(duty_expression_abbreviation);
-        } else if (duty_expression_description !== null) {
+        } else if (duty_expression_description) {
           output.push(duty_expression_description);
         }
         break;
@@ -52,23 +52,23 @@ window.DutyExpressionFormatter = {
       case "19":
       case "20":
       case "36":
-        if (duty_expression_abbreviation !== null) {
-          output.push(duty_expression_abbreviation.replace("%", "").replace("€", ""));
-        } else if (duty_expression_description !== null) {
+        if (duty_expression_abbreviation) {
+          output.push(duty_expression_abbreviation.replace("%", "").replace("€", "").replace("≤", "MAX"));
+        } else if (duty_expression_description) {
           output.push(duty_expression_description);
         }
 
-        if (duty_amount !== null) {
+        if (duty_amount) {
           output.push(this.prettify(duty_amount));
         }
 
-        if (monetary_unit !== null) {
+        if (monetary_unit) {
           output.push(monetary_unit);
         } else {
           output.push("%");
         }
 
-        if (measurement_unit_abbreviation !== null) {
+        if (measurement_unit_abbreviation) {
           if (opts.formatted) {
             output.push("/ <abbr title='" + measurement_unit.description + "'>" + measurement_unit_abbreviation + "</abbr>");
           } else {
@@ -78,13 +78,13 @@ window.DutyExpressionFormatter = {
 
         break;
       default:
-        if (duty_amount !== null) {
+        if (duty_amount) {
           output.push(this.prettify(duty_amount));
         }
 
-        if (duty_expression_abbreviation !== null && !monetary_unit) {
+        if (duty_expression_abbreviation && !monetary_unit) {
           output.push(duty_expression_abbreviation);
-        } else if (duty_expression_description !== null && !monetary_unit) {
+        } else if (duty_expression_description && !monetary_unit) {
           output.push(duty_expression_description);
         } else if (duty_expression_description === null) {
           output.push("%");

--- a/app/views/shared/vue_templates/_bulk_edit_records.html.erb
+++ b/app/views/shared/vue_templates/_bulk_edit_records.html.erb
@@ -1,4 +1,5 @@
-<script type="text/x-template" id="bulk-edit-records-template">
+<script type="text/x-template"
+        id="bulk-edit-records-template">
   <div class="bulk-edit-records">
     <%= render "shared/bulks/table_top" %>
 

--- a/git_commit_msg.txt
+++ b/git_commit_msg.txt
@@ -1,0 +1,10 @@
+# Fix/New/Test: If applied, this commit will...----|
+
+# Why is this change needed?-------------------------------------------|
+Prior to this change,
+
+# How does it address the issue?
+This change
+
+# Provide links to any relevant tickets, articles or other resources
+


### PR DESCRIPTION
Prior to this change, there was a bug in the frontend at duty
expressions formatter which resulted to some duties not to be displayed.
Further more I have extended the abbreviation formatter logic to render
`MAX`. A bug related to the story still exists in the BE or it is a
data issue.

Ameneded duty-expression-formatter.js file

See: (TARIFFS-117)[https://uktrade.atlassian.net/browse/TARIFFS-117]

<img width="444" alt="Screenshot 2019-05-22 at 15 16 26" src="https://user-images.githubusercontent.com/6704411/58235991-db750d00-7d39-11e9-9411-7afcd87ced18.png">
