### PR TITLE
Fix: Display correct Additional Code description

### DIFF
--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -62,7 +62,9 @@ class AdditionalCode < Sequel::Model
   end
 
   def additional_code_description
-    additional_code_descriptions(reload: true).first
+    TimeMachine.at(validity_start_date) do
+      additional_code_descriptions(reload: true).last
+    end
   end
 
   one_to_one :export_refund_nomenclature, key: :export_refund_code,

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -7,14 +7,14 @@ describe AdditionalCode do
       let!(:additional_code_description1)   {
         create :additional_code_description, :with_period,
                                                             additional_code_sid: additional_code.additional_code_sid,
-                                                            valid_at: 2.years.ago,
+                                                            valid_at: Date.today.ago(2.years),
                                                             valid_to: nil
       }
       let!(:additional_code_description2) {
         create :additional_code_description, :with_period,
                                                             additional_code_sid: additional_code.additional_code_sid,
-                                                            valid_at: 5.years.ago,
-                                                            valid_to: 3.years.ago
+                                                            valid_at: Date.today.ago(5.years),
+                                                            valid_to: Date.today.ago(3.years)
       }
 
       context 'direct loading' do
@@ -36,7 +36,7 @@ describe AdditionalCode do
           TimeMachine.at(4.years.ago) do
             expect(
               additional_code.reload.additional_code_description.pk
-            ).to eq additional_code_description2.pk
+            ).to eq additional_code_description1.pk
           end
         end
       end
@@ -63,16 +63,6 @@ describe AdditionalCode do
                           .first
                           .additional_code_description.pk
             ).to eq additional_code_description1.pk
-          end
-
-          TimeMachine.at(4.years.ago) do
-            expect(
-              described_class.where(additional_code_sid: additional_code.additional_code_sid)
-                          .eager(:additional_code_descriptions)
-                          .all
-                          .first
-                          .additional_code_description.pk
-            ).to eq additional_code_description2.pk
           end
         end
       end


### PR DESCRIPTION
Prior to this change, the Additional Code will display the description
based on it's validaity dates compared to the current time. So when
examining a new code in the future it would not display the correct
description.

This change retrieves the correct description by setting time machine to
use the validity start date of the additionanl code and retrieve the
last one it finds.

https://uktrade.atlassian.net/browse/TARIFFS-60