### PR TITLE
Fix bug on displaying full server error messages

### DIFF
--- a/app/assets/javascripts/components/validators/additional_codes.js
+++ b/app/assets/javascripts/components/validators/additional_codes.js
@@ -238,7 +238,7 @@ AdditionalCodesValidator.prototype.setLevel = function(level) {
 };
 
 AdditionalCodesValidator.prototype.parseConformanceMessage = function(message) {
-  var regex = new RegExp(/(^[\w]+)\:\s([\w\s]*)/gm);
+  var regex = new RegExp(/(^[\w]+)\:\s(.*)/gm);
   var matches = regex.exec(message);
 
   if (!matches) {


### PR DESCRIPTION
Prior to this change, if an error message was containing a special
character such as '+' then only part of string was returned.

This change fixes the match patern logic to include any character

See: [TARIFFS-74](https://uktrade.atlassian.net/browse/TARIFFS-74)

After:
<img width="912" alt="Screenshot 2019-05-28 at 12 28 34" src="https://user-images.githubusercontent.com/6704411/58475216-43b25d00-8145-11e9-8140-93344b2f45e8.png">

<img width="1317" alt="Screenshot 2019-05-28 at 12 36 29" src="https://user-images.githubusercontent.com/6704411/58475206-3dbc7c00-8145-11e9-92fe-9b7e2408f144.png">
