### PR TITLE
Fix copy glitches on Edit Geographical Area

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,5 +53,4 @@
   <%= render "application/version_identifier" %>
 <% end %>
 
-<%= render "flashes" %>
 <%= render template: "layouts/govuk_template" %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -39,6 +39,8 @@
   <body<%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %>>
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
+    <%= render "flashes" %>
+
     <%= yield :body_start %>
 
     <div id="skiplink-container">

--- a/app/views/workbaskets/edit_geographical_area/steps/main/_code.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/steps/main/_code.html.slim
@@ -1,10 +1,10 @@
-fieldset.disabled_area.disabled
+fieldset
   form-group
     template slot-scope="slotProps"
       h3.heading-medium
         | What code will identify this area?
 
-      label.form-label
+      label.form-label.disabled
         span.form-hint
           | This must be unique and either a two-letter ISO code (for a country or region) or a string of four
           br
@@ -12,4 +12,4 @@ fieldset.disabled_area.disabled
 
       .bootstrap-row
         .col-xs-2.col-md-2.col-lg-2
-          input.form-control maxlength="4" v-model="geographical_area.geographical_area_id"
+          input.form-control maxlength="4" v-model="geographical_area.geographical_area_id" disabled="disabled"

--- a/app/views/workbaskets/edit_geographical_area/steps/main/_type.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/steps/main/_type.html.slim
@@ -45,9 +45,9 @@ fieldset
                   p
                     - if original_geographical_area.parent_geographical_area_group_sid.present? && original_geographical_area.parent_geographical_area.present?
                       | This group's current parent is
-                      =<> "'#{original_geographical_area.parent_geographical_area.geographical_area_id}'"
+                      =<> "'#{original_geographical_area.parent_geographical_area.geographical_area_id}"
                       =< original_geographical_area.parent_geographical_area.description
-                      | .
+                      | '.
                     - else
                       | This group does not currently have a parent.
 


### PR DESCRIPTION
Prior to this change, there were some copy glitches on edit geographical
area.

This change just disables the input field instead of whole section and
also closes the single quote in the correct place. Also fixes a core
layout bug with flash container messing html layout

See [Trello](https://trello.com/c/MZhaDSJL/815-copy-glitches-on-edit-geographical-area)
See [TARIFFS-69](https://uktrade.atlassian.net/browse/TARIFFS-69)

**After:**
<img width="794" alt="Screenshot 2019-05-28 at 13 55 59" src="https://user-images.githubusercontent.com/6704411/58480206-c0e3cf00-8151-11e9-8a55-681d0e21f71c.png">
