### PR TITLE
Fix: searches for Additional Codes

### DIFF
--- a/db/migrate/20190603135337_replace_all_additional_codes_view.rb
+++ b/db/migrate/20190603135337_replace_all_additional_codes_view.rb
@@ -1,0 +1,99 @@
+Sequel.migration do
+  up do
+    run %Q{
+DROP VIEW all_additional_codes;
+CREATE OR REPLACE VIEW all_additional_codes AS
+ SELECT meursing_additional_codes.meursing_additional_code_sid AS additional_code_sid,
+    '7'::character varying AS additional_code_type_id,
+    meursing_additional_codes.additional_code,
+    NULL::text AS description,
+    NULL::character varying AS language_id,
+    meursing_additional_codes.validity_start_date,
+    meursing_additional_codes.validity_end_date,
+    meursing_additional_codes.operation_date,
+    meursing_additional_codes.status,
+    meursing_additional_codes.workbasket_id,
+    meursing_additional_codes.added_by_id,
+    meursing_additional_codes.added_at,
+    meursing_additional_codes."national"
+   FROM public.meursing_additional_codes
+UNION
+ SELECT additional_codes.additional_code_sid,
+       additional_codes.additional_code_type_id,
+       additional_codes.additional_code,
+       additional_code_descriptions.description,
+       additional_code_descriptions.language_id,
+       additional_codes.validity_start_date,
+       additional_codes.validity_end_date,
+       additional_codes.operation_date,
+       additional_codes.status,
+       additional_codes.workbasket_id,
+       additional_codes.added_by_id,
+       additional_codes.added_at,
+       additional_codes."national"
+FROM additional_codes
+
+INNER JOIN (
+    SELECT *
+    FROM additional_code_description_periods
+    WHERE additional_code_description_period_sid IN (
+        SELECT MAX(additional_code_description_period_sid)
+        FROM additional_code_description_periods
+        GROUP BY (additional_code_type_id, additional_code)
+    )) as additional_code_description_periods
+
+    ON ((additional_code_description_periods.additional_code_sid = additional_codes.additional_code_sid) AND
+           ((additional_code_description_periods.additional_code_type_id) :: text =
+            (additional_codes.additional_code_type_id) :: text) AND
+           ((additional_code_description_periods.additional_code) :: text =
+            (additional_codes.additional_code) :: text))
+
+INNER JOIN additional_code_descriptions
+           ON additional_code_descriptions.additional_code_description_period_sid = additional_code_description_periods.additional_code_description_period_sid
+    }
+  end
+
+  down do
+    run %Q{
+DROP VIEW all_additional_codes;
+CREATE OR REPLACE VIEW all_additional_codes AS
+SELECT
+  meursing_additional_codes.meursing_additional_code_sid additional_code_sid,
+  '7' additional_code_type_id,
+  meursing_additional_codes.additional_code additional_code,
+  null description,
+  null language_id,
+  meursing_additional_codes.validity_start_date validity_start_date,
+  meursing_additional_codes.validity_end_date validity_end_date,
+  meursing_additional_codes.operation_date operation_date,
+  meursing_additional_codes.status status,
+  meursing_additional_codes.workbasket_id workbasket_id,
+  meursing_additional_codes.added_by_id added_by_id,
+  meursing_additional_codes.added_at added_at,
+  meursing_additional_codes."national" "national"
+FROM meursing_additional_codes
+UNION
+SELECT
+  additional_codes.additional_code_sid additional_code_sid,
+  additional_codes.additional_code_type_id additional_code_type_id,
+  additional_codes.additional_code additional_code,
+  additional_code_descriptions.description description,
+  additional_code_descriptions.language_id language_id,
+  additional_codes.validity_start_date validity_start_date,
+  additional_codes.validity_end_date validity_end_date,
+  additional_codes.operation_date operation_date,
+  additional_codes.status status,
+  additional_codes.workbasket_id workbasket_id,
+  additional_codes.added_by_id added_by_id,
+  additional_codes.added_at added_at,
+  additional_codes."national" "national"
+FROM additional_codes,
+additional_code_description_periods,
+additional_code_descriptions
+WHERE additional_code_description_periods.additional_code_sid = additional_codes.additional_code_sid
+AND additional_code_description_periods.additional_code_type_id = additional_codes.additional_code_type_id
+AND additional_code_description_periods.additional_code = additional_codes.additional_code
+AND additional_code_descriptions.additional_code_description_period_sid = additional_code_description_periods.additional_code_description_period_sid
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -543,10 +543,27 @@ UNION
     additional_codes.added_by_id,
     additional_codes.added_at,
     additional_codes."national"
-   FROM public.additional_codes,
-    public.additional_code_description_periods,
-    public.additional_code_descriptions
-  WHERE ((additional_code_description_periods.additional_code_sid = additional_codes.additional_code_sid) AND ((additional_code_description_periods.additional_code_type_id)::text = (additional_codes.additional_code_type_id)::text) AND ((additional_code_description_periods.additional_code)::text = (additional_codes.additional_code)::text) AND (additional_code_descriptions.additional_code_description_period_sid = additional_code_description_periods.additional_code_description_period_sid));
+   FROM ((public.additional_codes
+     JOIN ( SELECT additional_code_description_periods_1.additional_code_description_period_sid,
+            additional_code_description_periods_1.additional_code_sid,
+            additional_code_description_periods_1.additional_code_type_id,
+            additional_code_description_periods_1.additional_code,
+            additional_code_description_periods_1.validity_start_date,
+            additional_code_description_periods_1.validity_end_date,
+            additional_code_description_periods_1.oid,
+            additional_code_description_periods_1.operation,
+            additional_code_description_periods_1.operation_date,
+            additional_code_description_periods_1.status,
+            additional_code_description_periods_1.workbasket_id,
+            additional_code_description_periods_1.workbasket_sequence_number,
+            additional_code_description_periods_1.added_by_id,
+            additional_code_description_periods_1.added_at,
+            additional_code_description_periods_1."national"
+           FROM public.additional_code_description_periods additional_code_description_periods_1
+          WHERE (additional_code_description_periods_1.additional_code_description_period_sid IN ( SELECT max(additional_code_description_periods_2.additional_code_description_period_sid) AS max
+                   FROM public.additional_code_description_periods additional_code_description_periods_2
+                  GROUP BY additional_code_description_periods_2.additional_code_type_id, additional_code_description_periods_2.additional_code))) additional_code_description_periods ON (((additional_code_description_periods.additional_code_sid = additional_codes.additional_code_sid) AND ((additional_code_description_periods.additional_code_type_id)::text = (additional_codes.additional_code_type_id)::text) AND ((additional_code_description_periods.additional_code)::text = (additional_codes.additional_code)::text))))
+     JOIN public.additional_code_descriptions ON ((additional_code_descriptions.additional_code_description_period_sid = additional_code_description_periods.additional_code_description_period_sid)));
 
 
 --
@@ -12576,3 +12593,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20190131153106_remove_unne
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190201161401_change_xml_export_from_dates_to_workbasket.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190212163200_add_user_id_to_xml_export_files.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190320142706_create_session_audits.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20190603135337_replace_all_additional_codes_view.rb');


### PR DESCRIPTION
Prior to this change, the view all_additional_code would return
all historical discriptions for a code.

This change limits the search to just the latest description.

https://uktrade.atlassian.net/browse/TARIFFS-194