### PR TITLE
Fix: couldn't view published basket with Additional Code

### DIFF
--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_published.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_published.slim
@@ -1,0 +1,2 @@
+p
+  | The new additional codes have been published to HMRC.


### PR DESCRIPTION
Prior to this change, Exception was thrown when viewing a published workbasket for Additional Codes.

This change adds the missing partial.

https://uktrade.atlassian.net/browse/TARIFFS-75