### PR TITLE
Fix: Add/Remove memberships in geo area frontend

### DIFF
--- a/app/assets/javascripts/components/workbaskets/edit-geographical-area.js
+++ b/app/assets/javascripts/components/workbaskets/edit-geographical-area.js
@@ -19,7 +19,8 @@ $(document).ready(function() {
         editingMembership: null,
         sortBy: "geographical_area_id",
         sortDir: "desc",
-        parentGroupsList: window.__geographical_area_groups_json
+        parentGroupsList: window.__geographical_area_groups_json,
+        removed_memberships: []
       };
 
       if (!$.isEmptyObject(window.__geographical_area_json)) {
@@ -269,7 +270,7 @@ $(document).ready(function() {
           validity_start_date: payload.validity_start_date,
           validity_end_date: payload.validity_end_date,
           remove_parent_group_association: payload.remove_parent_group_association,
-          geographical_area_memberships: objectToArray(payload.geographical_area_memberships)
+          geographical_area_memberships: payload.geographical_area_memberships
         };
       },
       emptyGeographicalArea: function() {
@@ -307,7 +308,9 @@ $(document).ready(function() {
           parent_geographical_area_group_id: $("select[name='geographical_area[parent_geographical_area_group_id]']").val(),
           validity_start_date: this.geographical_area.validity_start_date,
           validity_end_date: this.geographical_area.validity_end_date,
-          remove_parent_group_association: remove_parent_group_association
+          remove_parent_group_association: remove_parent_group_association,
+          geographical_area_memberships: this.geographical_area.geographical_area_memberships,
+          removed_memberships: this.removed_memberships,
         };
       },
       triggerAddMemberships: function() {
@@ -346,7 +349,16 @@ $(document).ready(function() {
       },
       editMembership: function(membership) {
         this.editingMembership = membership;
-      }
+      },
+      removeMembership: function(membership) {
+        var ids = this.geographical_area.geographical_area_memberships.map( m => m.geographical_area_id )
+
+        var index = ids.indexOf(membership.geographical_area_id)
+        if (index !== -1) {
+          this.removed_memberships.push(this.geographical_area.geographical_area_memberships[index])
+          this.geographical_area.geographical_area_memberships.splice(index, 1);
+        }
+      },
     }
   });
 });

--- a/app/models/workbaskets/edit_geographical_area_settings.rb
+++ b/app/models/workbaskets/edit_geographical_area_settings.rb
@@ -32,8 +32,18 @@ module Workbaskets
 
       res[:geographical_code] = original_geographical_area.geographical_code
       res[:geographical_area_id] = original_geographical_area.geographical_area_id
-
+      res[:geographical_area_memberships] = memberships
       res
+    end
+
+    def memberships
+      original_geographical_area.member_of_following_geographical_areas.map do |area|
+        hash = area.to_hash
+        hash[:geographical_area] = {
+          'description' => area.description
+        }
+        hash
+      end
     end
 
     def prepare_collection(list, data_field_name)

--- a/app/views/workbaskets/edit_geographical_area/edit.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/edit.html.slim
@@ -1,4 +1,7 @@
 = render "workbaskets/shared/edit_base", subheader: link_to("(add a new one instead)", new_create_geographical_area_url)
+= render "shared/vue_templates/add_geo_areas_to_group_popup"
+= render "shared/vue_templates/add_geo_areas_to_country_region_popup"
+= render "shared/vue_templates/edit_geographical_area_membership_popup"
 
 script
   == "window.__original_geographical_area_description = '#{j(form.original_geographical_area_description)}';"


### PR DESCRIPTION
Prior to this change, memberships are not being displayed
when we go to edit an existing geographical area and there
is no way to add or remove memberships.

This change allows the user to view memberships and view
the memberships that they are adding or removing in the ui.

Note: This is a front end fix only. Users cannot successfully submit
these changes. Commits to follow to add that functionality.