### PR TITLE
New: Allow persisting of edited geo area memberships

### DIFF
--- a/app/assets/javascripts/components/workbaskets/edit-geographical-area.js
+++ b/app/assets/javascripts/components/workbaskets/edit-geographical-area.js
@@ -157,13 +157,13 @@ $(document).ready(function() {
         return Object.keys(this.conformanceErrors).length > 0;
       },
       isGroup: function() {
-        return this.geographical_area.geographical_code === 'group';
+        return (this.geographical_area.geographical_code === 'group' || this.geographical_area.geographical_code === '1');
       },
       isRegion: function() {
-        return this.geographical_area.geographical_code === 'region';
+        return (this.geographical_area.geographical_code === 'region' || this.geographical_area.geographical_code === '2');
       },
       isCountry: function() {
-        return this.geographical_area.geographical_code === 'country';
+        return (this.geographical_area.geographical_code === 'country' || this.geographical_area.geographical_code === '0');
       },
       sortedMemberships: function() {
         var memberships = this.geographical_area.geographical_area_memberships.slice(0);

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -76,6 +76,11 @@ class GeographicalArea < Sequel::Model
     geographical_code == GEOGRAPHICAL_REGION_CODE
   end
 
+  def currently_member_of
+    group_sids = GeographicalAreaMembership.started_memberships.not_end_dated.where(geographical_area_sid: geographical_area_sid).pluck(:geographical_area_group_sid)
+    GeographicalArea.where(geographical_area_sid: group_sids).all
+  end
+
   dataset_module do
     def by_id(id)
       where(geographical_area_id: id)

--- a/app/models/geographical_area_membership.rb
+++ b/app/models/geographical_area_membership.rb
@@ -21,4 +21,14 @@ class GeographicalAreaMembership < Sequel::Model
   def subrecord_code
     "15".freeze
   end
+
+  dataset_module do
+    def started_memberships
+      where{validity_start_date <= Date.today}
+    end
+
+    def not_end_dated
+      where("validity_end_date > :date or validity_end_date is NULL", date: Date.today)
+    end
+  end
 end

--- a/app/models/workbaskets/edit_geographical_area_settings.rb
+++ b/app/models/workbaskets/edit_geographical_area_settings.rb
@@ -37,7 +37,7 @@ module Workbaskets
     end
 
     def memberships
-      original_geographical_area.member_of_following_geographical_areas.map do |area|
+      original_geographical_area.currently_member_of.map do |area|
         hash = area.to_hash
         hash[:geographical_area] = {
           'description' => area.description


### PR DESCRIPTION
Prior to this change, when a user edited geographical area memberships
via edit geo area the results were not being persisted and processed by
our backend.

This change adds this functionality.