### PR TITLE
Fix: Display of complex duty expressions

### DIFF
--- a/app/assets/javascripts/components/duty-expressions-parser.js
+++ b/app/assets/javascripts/components/duty-expressions-parser.js
@@ -6,98 +6,118 @@ window.DutyExpressionsParser = {
       option.duty_expression_code = option.duty_expression_id;
       var newOption = null;
 
+      /* As it is required not to render abbreviations for all duty expressions
+      *  inside selectized dropdown which is used by custom-select vue component
+      *  form elements, a default abbreviation is being used just for that purpose
+      */
+     option.showAbbreviationInDD = false;
+
       if (option.duty_expression_id === "01") {
         option.duty_expression_id = "01A";
         option.description = "% (ad valorem)";
         option.abbreviation = "%";
+        option.showAbbreviationInDD = true;
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "01B",
           description: "Amount €",
-          abbreviation: "€"
+          abbreviation: "€",
+          showAbbreviationInDD: true
         };
       } else if (option.duty_expression_id === "02") {
         option.duty_expression_id = "02A";
         option.description = "Minus %";
         option.abbreviation = "-%";
+        option.showAbbreviationInDD = true;
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "02B",
           description: "Minus amount €",
-          abbreviation: "-€"
+          abbreviation: "-€",
+          showAbbreviationInDD: true
         };
       } else if (option.duty_expression_id === "04") {
         option.duty_expression_id = "04A";
         option.description = "Plus %";
         option.abbreviation = "+%";
+        option.showAbbreviationInDD = true;
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "04B",
           description: "Plus amount €",
-          abbreviation: "+€"
+          abbreviation: "+€",
+          showAbbreviationInDD: true
         };
       } else if (option.duty_expression_id === "15") {
         option.duty_expression_id = "15A";
         option.description = "Minimum %";
         option.abbreviation = "≥%";
+        option.showAbbreviationInDD = true;
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "15B",
           description: "Minimum amount €",
-          abbreviation: "≥€"
+          abbreviation: "≥€",
+          showAbbreviationInDD: true
         };
       } else if (option.duty_expression_id === "17") {
         option.duty_expression_id = "17A";
         option.description = "Maximum %";
         option.abbreviation = "≤%";
+        option.showAbbreviationInDD = true;
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "17B",
           description: "Maximum amount €",
-          abbreviation: "≤€"
+          abbreviation: "≤€",
+          showAbbreviationInDD: true
         };
       } else if (option.duty_expression_id === "19") {
         option.duty_expression_id = "19A";
         option.description = "Plus %";
         option.abbreviation = "+%";
+        option.showAbbreviationInDD = true;
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "19B",
           description: "Plus amount €",
-          abbreviation: "+€"
+          abbreviation: "+€",
+          showAbbreviationInDD: true
         };
       } else if (option.duty_expression_id === "20") {
         option.duty_expression_id = "20A";
         option.description = "Plus %";
         option.abbreviation = "+%";
+        option.showAbbreviationInDD = true;
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "20B",
           description: "Plus amount €",
-          abbreviation: "+€"
+          abbreviation: "+€",
+          showAbbreviationInDD: true
         };
       } else if (option.duty_expression_id === "35") {
         option.duty_expression_id = "35A";
         option.description = "Maximum %";
         option.abbreviation = "≤%";
+        option.showAbbreviationInDD = true;
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "35B",
           description: "Maximum amount €",
-          abbreviation: "≤€"
+          abbreviation: "≤€",
+          showAbbreviationInDD: true
         };
       } else if (option.duty_expression_id === "36") {
         option.abbreviation = "-%";
-      } else {
-        option.abbreviation = undefined;
       }
 
       newOptions.push(option);

--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -205,10 +205,12 @@ Vue.component('custom-select', {
       if (codeField) {
         options["render"] = {
           option: function(data) {
-            var abbreviationSpan = "";
+            var abbreviationSpan = '';
 
-            if (abbreviationClassName) {
+            if (abbreviationClassName && data.showAbbreviationInDD) {
               abbreviationSpan = "<span class='abbreviation " + abbreviationClassName + "'>" + (data.abbreviation || "&nbsp;") + "</span>";
+            } else if(abbreviationClassName) {
+              abbreviationSpan = '<span class="abbreviation ' + abbreviationClassName + '">&nbsp;</span>';
             }
 
             return "<span class='selection'><span class='option-prefix " + codeClassName + "'>" + data[codeField] + "</span>" + abbreviationSpan + "<span>" + data[options.labelField] + "</span></span>";
@@ -216,7 +218,7 @@ Vue.component('custom-select', {
           item: function(data) {
             var abbreviation = "";
 
-            if (abbreviationClassName && data.abbreviation) {
+            if (abbreviationClassName && data.showAbbreviationInDD) {
               abbreviation = data.abbreviation;
             }
 


### PR DESCRIPTION
Fix: Display of complex duty expressions

Prior to this change, duty expression abbreviations where
not display at all for some duties.

With this PR I am extended slightly the logic in order to
fix the bug and keep the behaviour consistent