### PR TITLE
Fix: Additional code dropdown

### DIFF
--- a/app/controllers/additional_codes/additional_code_types_controller.rb
+++ b/app/controllers/additional_codes/additional_code_types_controller.rb
@@ -10,7 +10,7 @@ module AdditionalCodes
       scope = if measure_type.present?
                 measure_type.additional_code_types
               else
-                AdditionalCodeType.actual.order(:additional_code_type_id)
+                AdditionalCodeType.actual.order(:additional_code_type_id).all
               end
 
       if params[:q].present?


### PR DESCRIPTION
Prior to this change, user was unable to use drop down to search and
select an additional code

This change fixes a bug on BE select query

See: [TARIFFS-237](https://uktrade.atlassian.net/browse/TARIFFS-237)

**Before:**
![additional-codes-2](https://user-images.githubusercontent.com/6704411/59194888-62234a00-8b82-11e9-879c-1e7adf816f0c.gif)

**After**
![additional-codes-1](https://user-images.githubusercontent.com/6704411/59194897-6a7b8500-8b82-11e9-8620-ac13ce1ffc4e.gif)


