### PR TITLE
Fix: Error when displaying Meursing Additional Code

### DIFF
--- a/app/models/meursing_additional_code.rb
+++ b/app/models/meursing_additional_code.rb
@@ -9,7 +9,7 @@ class MeursingAdditionalCode < Sequel::Model
   set_primary_key [:meursing_additional_code_sid]
 
   def code
-    "7#{additional_code}"
+    "#{additional_code_type_id}#{additional_code}"
   end
 
   def record_code
@@ -18,6 +18,15 @@ class MeursingAdditionalCode < Sequel::Model
 
   def subrecord_code
     "00".freeze
+  end
+
+  def additional_code_type_id
+    "7"
+  end
+
+  def description
+    # Meursing doesn't have a description
+    ""
   end
 
   def status_title

--- a/app/views/workbaskets/create_additional_code/steps/review_and_submit/_additional_codes_details.html.slim
+++ b/app/views/workbaskets/create_additional_code/steps/review_and_submit/_additional_codes_details.html.slim
@@ -31,7 +31,6 @@
                 = item.additional_code
 
               .table__column.description-column
-                / = item.goods_nomenclature_item_id
                 = item.description
 
               .table__column.validity_start_date-column


### PR DESCRIPTION
Prior to this change, when creating a new additional code that was a
meursing type, their was an exception as the Meursing Additional Code
did not have a description or code type id

This change adds a blank description

https://uktrade.atlassian.net/browse/TARIFFS-75