### PR TITLE
Fix: Show membership details to reviewers

### DIFF
--- a/app/decorators/geographical_area_decorator.rb
+++ b/app/decorators/geographical_area_decorator.rb
@@ -42,6 +42,14 @@ class GeographicalAreaDecorator < ApplicationDecorator
     false # TODO
   end
 
+  def memberships
+    if type == "Group"
+      object.currently_contains.map {|country| "#{country.geographical_area_id} - #{country.geographical_area_description.description}" }.join(' ')
+    else
+      object.currently_member_of.map {|group| "#{group.geographical_area_id} - #{group.geographical_area_description.description}" }.join(' ')
+    end
+  end
+
 private
 
   def to_date(value)

--- a/app/views/workbaskets/create_geographical_area/steps/review_and_submit/_geographical_areas.html.slim
+++ b/app/views/workbaskets/create_geographical_area/steps/review_and_submit/_geographical_areas.html.slim
@@ -6,6 +6,7 @@
       .table__column.validity_start_date-column
         a
           | Start date
+          - g_area = GeographicalArea.find(geographical_area_id: workbasket.title)
           div.sort-arrow
             svg#arrow_down.arrow-down enable-background=("new 0 0 96 96") height="16px" version="1.1" viewbox=("0 0 96 96") width="16px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
               path d="M44,12v62.344L22.543,52.888c-1.561-1.562-4.094-1.562-5.656-0.001c-1.562,1.562-1.562,4.096,0,5.658l28.284,28.283l0,0  c0.186,0.186,0.391,0.352,0.609,0.498c0.101,0.067,0.21,0.114,0.315,0.172c0.124,0.066,0.242,0.142,0.373,0.195  c0.135,0.057,0.275,0.089,0.415,0.129c0.111,0.033,0.216,0.076,0.331,0.099C47.474,87.973,47.737,88,48,88l0,0  c0.003,0,0.006-0.001,0.009-0.001c0.259-0.001,0.519-0.027,0.774-0.078c0.12-0.024,0.231-0.069,0.348-0.104  c0.133-0.039,0.268-0.069,0.397-0.123c0.139-0.058,0.265-0.136,0.396-0.208c0.098-0.054,0.198-0.097,0.292-0.159  c0.221-0.146,0.427-0.314,0.614-0.501l28.281-28.282c1.562-1.562,1.562-4.095,0.001-5.657c-1.562-1.562-4.095-1.562-5.657,0  L52,74.343V12c0-2.209-1.791-4-4-4S44,9.791,44,12z"
@@ -22,6 +23,9 @@
       .table__column.area-type-column
         a Area type
 
+      .table__column.area-type-column
+        a Memberships
+
     .virtual-scroller
       .item-container
         .items style=("margin-top: 0px;")
@@ -32,16 +36,19 @@
               /   input data-v-caa2d078="" name="measures[]" type="checkbox" value="-485562"
 
               .table__column.validity_start_date-column
-                = workbasket.settings.validity_start_date
+                = g_area.validity_start_date
 
               .table__column.validity_end_date-column
-                = workbasket.settings.validity_end_date
+                = g_area.validity_end_date
 
               .table__column.name-column
-                = workbasket.settings.description
+                = workbasket.settings.main_step_settings['description']
 
               .table__column.code-column
-                = workbasket.settings.geographical_area_id
+                = g_area.geographical_area_id
 
               .table__column.area-type-column
-                = workbasket.settings.geographical_code
+                = g_area.decorate.type
+
+              .table__column.area-type-column
+                = g_area.decorate.memberships

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_area_details.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_area_details.html.slim
@@ -49,6 +49,13 @@ h3.heading-medium Geographical area details
   .bootstrap-row
     .col-md-6.heading_column.pull-left
       | Description valid to
+      - byebug
+    .col-md-6
+      = g_area.current_description_valid_to
+
+  .bootstrap-row
+    .col-md-6.heading_column.pull-left
+      | Description valid to
     .col-md-6
       = g_area.current_description_valid_to
 

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_area_details.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_area_details.html.slim
@@ -49,7 +49,6 @@ h3.heading-medium Geographical area details
   .bootstrap-row
     .col-md-6.heading_column.pull-left
       | Description valid to
-      - byebug
     .col-md-6
       = g_area.current_description_valid_to
 

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_approval_rejected.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_approval_rejected.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited geographical area has been rejected. The approver gave the reasons detailed below.

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_awaiting_approval.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_awaiting_approval.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited geographical area shown below has been submitted for approval and is waiting for response. If you need to re-edit it, first withdraw the workbasket from workflow.

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited geographical area shown below has been submitted for cross-check and is waiting for response. If you need to re-edit it, first withdraw the workbasket from workflow.

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_ready_for_export.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_ready_for_export.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited geographical area has been approved, but has not yet been sent through to CDS and has not been scheduled for export.


### PR DESCRIPTION
Prior to this change, when reviewing geographical area related
workbaskets the approver/cross checker could not see membership
details.

This change shows these details to reviewers.