### PR TITLE
New: Frontend work for nomenclature chapters page

### DIFF
--- a/app/controllers/nomenclature/section_chapters_controller.rb
+++ b/app/controllers/nomenclature/section_chapters_controller.rb
@@ -1,0 +1,15 @@
+class Nomenclature::SectionChaptersController < ApplicationController
+  respond_to :json
+  around_action :configure_time_machine
+
+  def index
+    # TODO: We will need to get section chapters here instead of serving sections
+    @sections = Section.all
+
+    if @sections.present?
+      render partial: "nomenclature/section_chapters"
+    else
+      head :not_found
+    end
+  end
+end

--- a/app/views/nomenclature/_section_chapters.erb
+++ b/app/views/nomenclature/_section_chapters.erb
@@ -1,0 +1,69 @@
+<% content_for :content do %>
+  <%= render partial: "nomenclature/sections_header" %>
+
+<div class="grid-row">
+  <div class="column-three-quarters">
+    <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt font-xsmall">
+      <nav>
+        <%= link_to "All sections", "../sections", :class => "all-sections-link"  %>
+        <div class="desktop-only">
+          <%# TODO: PP. This nested lists will be redner dynamically with the use of BE %>
+          <ul>
+            <li>
+              <a class="section-link" href="">Section VI: Products of the chemical or allied industries</a>
+              <ul>
+                <li class="chapter-li">
+                  <%# <div class="chapter-code">
+                    <div class="code-text">02</div>
+                  </div> %>
+                  <a href="/chapters/02">290000000 Organic chemicals</a>
+                  <ul>
+                    <li class="heading-li">
+                      <%# <div class="heading-code">
+                        <div class="code-text">02</div>
+                      </div> %>
+                      <h1>290000000 - Acrylic hydrocarbons</h1>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </div>
+  </div>
+</div>
+
+  <%# TODO: PP. Here we will need to render chapter details instead of sections
+    based on the clicked link in `sections`
+   %>
+  <% if @sections %>
+    <div class="grid-row">
+      <div class="column-three-quarters">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Code</th>
+              <th scope="col">Suffix</th>
+              <th scope="col">Description</th>
+              <th scope="col"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @sections.each do |section| %>
+              <tr>
+                <th scope="row">02 02 10 00 11</th>
+                <td> - </td>
+                <td><a href="#"><%= section.title %></a></td>
+                <td><a href="#">Manage</a></td>
+              </tr>
+            <%end %>
+          </tbody>
+        </table>
+      </div>
+  </div>
+  <% end %>
+<% end %>
+
+<%= render template: "layouts/application" %>

--- a/app/views/nomenclature/_sections.erb
+++ b/app/views/nomenclature/_sections.erb
@@ -1,32 +1,5 @@
 <% content_for :content do %>
-  <%= link_to "Back", root_url, :class => "link-back" %>
-
-  <h1 class="heading-xlarge">Manage good clasification</h1>
-
-
-  <div class="grid-row">
-    <div class="column-one-half">
-      <%= form_tag({}, { method: :get }) do %>
-        <div class="form-group gem-c-search gem-c-search--on-white" data-module="gem-toggle-input-class-on-focus">
-          <label for="search-commodity" class="form-label">
-            Enter commodity code you want to work with
-          </label>
-          <div class="gem-c-search__item-wrapper">
-            <input type="search" value="" id="search-commodity"title="Search" class="gem-c-search__item gem-c-search--on-white gem-c-search__input">
-            <div class="gem-c-search__item gem-c-search__submit-wrapper">
-              <button type="submit" class="gem-c-search__submit">Search</button>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="panel panel-border-wide">
-    <p>
-      You are currently viewing the good clasification for <%= Date.current.to_formatted_s(:long_ordinal) %>
-    </p>
-  </div>
+  <%= render partial: "nomenclature/sections_header" %>
 
   <% if @sections %>
     <div class="grid-row">

--- a/app/views/nomenclature/_sections_header.erb
+++ b/app/views/nomenclature/_sections_header.erb
@@ -1,0 +1,27 @@
+<%= link_to "Back", root_url, :class => "link-back" %>
+
+<h1 class="heading-xlarge">Manage good clasification</h1>
+
+<div class="grid-row">
+  <div class="column-one-half">
+    <%= form_tag({}, { method: :get }) do %>
+      <div class="form-group gem-c-search gem-c-search--on-white" data-module="gem-toggle-input-class-on-focus">
+        <label for="search-commodity" class="form-label">
+          Enter commodity code you want to work with
+        </label>
+        <div class="gem-c-search__item-wrapper">
+          <input type="search" value="" id="search-commodity"title="Search" class="gem-c-search__item gem-c-search--on-white gem-c-search__input">
+          <div class="gem-c-search__item gem-c-search__submit-wrapper">
+            <button type="submit" class="gem-c-search__submit">Search</button>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="panel panel-border-wide">
+  <p>
+    You are currently viewing the good clasification for <%= Date.current.to_formatted_s(:long_ordinal) %>
+  </p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -286,5 +286,6 @@ Rails.application.routes.draw do
 
   scope module: :nomenclature do
     resources :sections, only: [:index]
+    resources :section_chapters, only: [:index]
   end
 end


### PR DESCRIPTION
Prior to this change, a page did not exist for listig
nomenclature section chapters

This change adds the route and a mocked view for displaying
nomenclature section chapters

Front end first iteration work for: [TARIFFS-209](https://uktrade.atlassian.net/browse/TARIFFS-209)

**After:**
![localhost_3000_section_chapters_(Laptop with HiDPI screen) (2)](https://user-images.githubusercontent.com/6704411/59508981-691ac700-8eb8-11e9-8c38-d3a3667105a2.png)
