### PR TITLE
Fix: rejecting an additional code Approval caused exception

### DIFF
--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/status_pages/_approval_rejected.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/status_pages/_approval_rejected.html.slim
@@ -1,0 +1,13 @@
+.panel.panel--confirmation
+  h1.heading-xlarge
+    | Additional Codes approval rejected
+
+  h3.heading-medium
+    | You indicated that the Additional Codes in workbasket
+    =<> "'#{workbasket.title}'"
+    | have problems.
+    br
+
+    | The author has been notified.
+
+= render "workbaskets/create_measures/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"


### PR DESCRIPTION
Prior to this change, an exception was thrown due to missing partial.

This change added the partial

https://uktrade.atlassian.net/browse/TARIFFS-230