### PR TITLE
Fix: view page 2 of additional code search results

### DIFF
--- a/app/assets/javascripts/components/find-additional-codes.js
+++ b/app/assets/javascripts/components/find-additional-codes.js
@@ -233,7 +233,10 @@ $(document).ready(function() {
           params.order_col = change_selector;
         }
 
-        var newQueryString = "?search_code=" + params.search_code + "&page=" + params.page + "&order_col=" + params.order_col + "&order_dir=" + params.order_dir;
+        var newQueryString = "?search_code=" + params.search_code + "&page=" + params.page;
+        if (params.order_col) {
+          newQueryString += "&order_col=" + params.order_col + "&order_dir=" + params.order_dir;
+        }
 
         window.history.pushState(params, "Find and edit additional codes - Page " + params.page, newQueryString);
 


### PR DESCRIPTION
Prior to this change, if the search results did not have an ordering set by clicking a column then viewing page 2 (or any other pages) threw an exception.

This change the column ordering parameters are only added to the url if an ordering has been specified.

https://uktrade.atlassian.net/browse/TARIFFS-240