### PR TITLE
Fix: Correct time format for start and end dates of memberships

### DIFF
--- a/app/models/workbaskets/edit_geographical_area_settings.rb
+++ b/app/models/workbaskets/edit_geographical_area_settings.rb
@@ -50,6 +50,8 @@ module Workbaskets
         hash[:geographical_area] = {
           'description' => area.description
         }
+        hash[:validity_start_date] = area.validity_start_date.to_date.to_formatted_s(:rfc822) if area.validity_start_date
+        hash[:validity_end_date] = area.validity_end_date.to_date.to_formatted_s(:rfc822) if area.validity_end_date
         hash
       end
     end


### PR DESCRIPTION
Prior to this change, the start and end dates of memberships were showing
the full date and time. This is confusing for users

This change changes the format of start and end dates of memberships to be
rfc822.