### PR TITLE
Fix: Do not show parent group dropdown if select to orphan

### DIFF
--- a/app/views/workbaskets/edit_geographical_area/steps/main/_type.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/steps/main/_type.html.slim
@@ -63,4 +63,4 @@ fieldset
 
               .parent-group-target
                 .parent-group-select
-                  = content_tag "custom-select", "", { ":options" => "groups_list" , "allow-clear" => true, "code-field" => "geographical_area_id", "label-field" => "description", "value-field" => "geographical_area_id", "v-model" => "geographical_area.parent_geographical_area_group_id", placeholder: "― select group ―", "name" => "geographical_area[parent_geographical_area_group_id]", "code-class-name" => "prefix--country" }
+                  = content_tag "custom-select", "", { "v-if" => "!geographical_area.remove_parent_group_association", ":options" => "groups_list" , "allow-clear" => true, "code-field" => "geographical_area_id", "label-field" => "description", "value-field" => "geographical_area_id", "v-model" => "geographical_area.parent_geographical_area_group_id", placeholder: "― select group ―", "name" => "geographical_area[parent_geographical_area_group_id]", "code-class-name" => "prefix--country" }


### PR DESCRIPTION
Prior to this change, a user could select to orphan a group, i.e
leave it with no parent group but still be given the option to select
a parent group which makes no sense

This change removes the dropdown from which a user can select
a parent group if they choose to orphan the group they are editing.