### PR TITLE
Fix: JS error when displaying components in measure

### DIFF
--- a/app/assets/javascripts/vue_components/components-coordinator.js
+++ b/app/assets/javascripts/vue_components/components-coordinator.js
@@ -75,7 +75,7 @@ Vue.component("components-coordinator", {
           return (component.duty_expression_id == undefined || component.duty_expression_id == "")
         })
       })
-      return this.flatten_array(conditions_allow_duty).includes(false);
+      return this.flattenArray(conditions_allow_duty).includes(false);
     },
     canRemoveComponent: function() {
       return this.components.length > 1;


### PR DESCRIPTION
Prior to this change, a syntax error was preventing any duty expressions being displayed.

This change fixes the syntax.