### PR TITLE
Fix: Delete membership box

### DIFF
--- a/app/assets/javascripts/vue_components/edit-geographical-area-membership-popup.js
+++ b/app/assets/javascripts/vue_components/edit-geographical-area-membership-popup.js
@@ -3,7 +3,6 @@ Vue.component("edit-geographical-area-membership-popup", {
   props: ["membership", "geographicalArea", "onClose", "open"],
   data: function() {
     return {
-      toDelete: false,
       valid: true,
       errors: {},
       errorSummary: "",
@@ -16,10 +15,6 @@ Vue.component("edit-geographical-area-membership-popup", {
     var start = moment(this.membership.validity_start_date, ["DD MMM YYYY", "DD/MM/YYYY"], true);
     var end = moment(this.membership.validity_end_date, ["DD MMM YYYY", "DD/MM/YYYY"], true);
 
-    if (this.membership.delete) {
-      this.toDelete = true;
-    }
-
     if (start.isValid()) {
       this.join_date = start.format("DD/MM/YYYY");
     }
@@ -30,10 +25,7 @@ Vue.component("edit-geographical-area-membership-popup", {
   },
   computed: {
     disableJoinDate: function() {
-      return this.toDelete || this.geographicalArea.sent_to_cds;
-    },
-    disableLeaveDate: function() {
-      return this.toDelete;
+      return this.geographicalArea.sent_to_cds;
     },
     isGroup: function() {
       return this.geographicalArea.geographical_code === 'group';
@@ -46,10 +38,6 @@ Vue.component("edit-geographical-area-membership-popup", {
       this.errors = {};
       this.errorSummary = "";
       this.valid = true;
-
-      if (this.toDelete) {
-        return resolve();
-      }
 
       if (moment(this.join_date, "DD/MM/YYYY", true).isValid() === false) {
         this.errors.join_date = "The join date must be valid";
@@ -76,19 +64,13 @@ Vue.component("edit-geographical-area-membership-popup", {
 
       this.validate(function() {
         var membership = self.membership;
-        
-        if (self.toDelete) {
-          self.membership.validity_start_date = null;
-          self.membership.validity_end_date = null;
-          self.membership.delete = true;
-        } else {
-          var start = moment(self.join_date, "DD/MM/YYYY", true);
-          var end = moment(self.leave_date, "DD/MM/YYYY", true);
-          
-          self.membership.delete = false;
-          self.membership.validity_start_date = start.isValid() ? start.format("DD MMMM YYYY") : null;
+
+        var start = moment(self.join_date, "DD/MM/YYYY", true);
+        var end = moment(self.leave_date, "DD/MM/YYYY", true);
+
+        self.membership.delete = false;
+        self.membership.validity_start_date = start.isValid() ? start.format("DD MMMM YYYY") : null;
           self.membership.validity_end_date = end.isValid() ? end.format("DD MMMM YYYY") : null;
-        }
 
         self.onClose();
       }, function() {

--- a/app/views/shared/vue_templates/_edit_geographical_area_membership_popup.html.slim
+++ b/app/views/shared/vue_templates/_edit_geographical_area_membership_popup.html.slim
@@ -25,11 +25,6 @@ script type="text/x-template" id="edit-geographical-area-membership-popup-templa
           span.error-message v-if="slotProps.hasError" v-cloak=""
             | {{slotProps.error}}
 
-        .multiple-choice
-          input id="delete-membership" type="checkbox" v-model="toDelete" :checked="toDelete"
-          label for="delete-membership"
-            | Delete this membership
-
     form-group :errors="errors" error-key="join_date"
       template slot-scope="slotProps"
         label.form-label


### PR DESCRIPTION
Prior to this change, there was a delete membership checkbox within
the add membership popup for geographical areas. This is not used as
there is a more obvious way to delete memberships.

This change removes the unused checkbox.

Jira card: https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-51