### PR TITLE
Fix: miscalculating if date in future, for validity period.

### DIFF
--- a/app/assets/javascripts/vue_components/additional_codes/change-validity-period.js
+++ b/app/assets/javascripts/vue_components/additional_codes/change-validity-period.js
@@ -67,7 +67,7 @@ Vue.component("change-additional-codes-validity-period-popup", {
 
       var self = this;
       var isValid = true;
-      var todaysDate = moment();
+      var todaysDate = moment().startOf('day');
       var startDate = moment(this.startDate, "DD/MM/YYYY", true);
       var endDate = moment(this.endDate, "DD/MM/YYYY", true);
       var makeOpenEnded = this.makeOpenEnded;


### PR DESCRIPTION
Prior to this change, the code was comparing a date against a time, so if tomorrow's date was used as the start date it would throw an error that's it's not in the future as it was less than 24 hours away.

This change sets todaysDate to be a date instead of a datetime. So we are comparing like to like (i.e. now comparing date to date instead of to a datetime).
https://uktrade.atlassian.net/browse/TARIFFS-250