### PR TITLE
Fix: Invalid dates raising incorrect error on create/edit geo area

### DIFF
--- a/app/interactors/workbasket_interactions/create_geographical_area/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/create_geographical_area/initial_validator.rb
@@ -21,13 +21,12 @@ module WorkbasketInteractions
 
       def initialize(settings)
         @settings = settings
+        @errors = {}
 
         @type = squish_it(geographical_code)
         @area_id = squish_it(geographical_area_id)
         @start_date = parse_date(:validity_start_date)
         @end_date = parse_date(:validity_end_date)
-
-        @errors = {}
       end
 
       ALLOWED_OPS.map do |option_name|
@@ -150,6 +149,7 @@ module WorkbasketInteractions
         rescue Exception => e
           if public_send(option_name).present?
             @errors[option_name] = errors_translator("#{option_name}_wrong_format".to_sym)
+            @errors_summary = errors_translator("#{option_name}_wrong_format".to_sym)
           end
 
           nil

--- a/app/interactors/workbasket_interactions/edit_geographical_area/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/edit_geographical_area/initial_validator.rb
@@ -21,13 +21,15 @@ module WorkbasketInteractions
                     :errors,
                     :errors_summary,
                     :start_date,
-                    :end_date
+                    :end_date,
+                    :operation_date
 
       def initialize(original_geographical_area, settings)
         @errors = {}
         @original_geographical_area = original_geographical_area
         @settings = settings
 
+        @operation_date = parse_date(:operation_date)
         @start_date = parse_date(:validity_start_date)
         @end_date = parse_date(:validity_end_date)
       end
@@ -176,6 +178,7 @@ module WorkbasketInteractions
         rescue Exception => e
           if date_in_string.present?
             @errors[option_name] = errors_translator("#{option_name}_wrong_format".to_sym)
+            @errors_summary = errors_translator("#{option_name}_wrong_format".to_sym)
           end
 
           nil


### PR DESCRIPTION
Prior to this change, a user would receive an unhelpful server
error when trying to create/edit a geo area with an incorrect date.

This change raises an error showing which date field they have
entered an invalid date into.