### PR TITLE
Fix: Regulation description and URL mixed up

### DIFF
--- a/app/value_objects/workbasket_value_objects/create_regulation/attributes_parser.rb
+++ b/app/value_objects/workbasket_value_objects/create_regulation/attributes_parser.rb
@@ -30,8 +30,8 @@ module WorkbasketValueObjects
       }.freeze
 
       SUB_FIELD_LEGAL_ID = 0
-      SUB_FIELD_REFERENCE_URL = 1
-      SUB_FIELD_DESCRIPTION = 2
+      SUB_FIELD_DESCRIPTION = 1
+      SUB_FIELD_REFERENCE_URL = 2
 
       attr_accessor :ops,
                     :normalized_params,


### PR DESCRIPTION
Prior to this change, on the review and submit page for a newly
created regulation the description and the url would be displayed
the incorrect way around.

This change fixes the indexes of the data to show the data in the
correct place for the end user.