### PR TITLE
Fix: Add withdraw additional code link

### DIFF
--- a/app/views/workbaskets/create_additional_code/submitted_for_cross_check.html.slim
+++ b/app/views/workbaskets/create_additional_code/submitted_for_cross_check.html.slim
@@ -12,8 +12,8 @@ h3.heading-medium
 
 ul.list.next-steps
   li
-    a.disabled href="#"
-      | Withdraw submission/edit additional codes (not implemented)
+    = link_to "Withdraw submission/edit additional codes", withdraw_workbasket_from_workflow_create_additional_code_url
+
   li
     = link_to "Create more additional codes", new_create_additional_code_url
   li


### PR DESCRIPTION
Prior to this change, on the review page of create additional code
there was a 'withdraw/edit' link that did not work.

This change fixes this broken link.