### PR TITLE
Fix: No link to withdraw geo area

### DIFF
--- a/app/helpers/workbasket_helper.rb
+++ b/app/helpers/workbasket_helper.rb
@@ -333,6 +333,10 @@ module WorkbasketHelper
       withdraw_workbasket_from_workflow_create_additional_code_url(workbasket.id)
     elsif workbasket.object.type == "bulk_edit_of_additional_codes"
       withdraw_workbasket_from_workflow_additional_codes_bulk_url(workbasket.id)
+    elsif workbasket.object.type == "create_geographical_area"
+      withdraw_workbasket_from_workflow_create_geographical_area_url(workbasket.id)
+    elsif workbasket.object.type == "edit_geographical_area"
+      withdraw_workbasket_from_workflow_edit_geographical_area_url(workbasket.id)
     end
   end
 

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_actions_allowed.html.slim
@@ -2,7 +2,7 @@
   .view-workbasket-actions-allowed
     - if iam_workbasket_author? && workbasket.can_withdraw?
       = link_to "Withdraw workbasket from workflow", "#",
-      data: { target_url: withdraw_workbasket_from_workflow_create_geographical_area_url(workbasket.id), target_modal: workbasket.id },
+      data: { target_url: withdraw_workbasket_from_workflow_edit_geographical_area_url(workbasket.id), target_modal: workbasket.id },
       class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 


### PR DESCRIPTION
Prior to this change, there was not a link on the homepage to
withdraw a geo area workbasket from

This change adds the withdraw link to allow users to withdraw
geo area workbaskets from workflow.