### PR TITLE
Fix: Display monetary unit on duties

### DIFF
--- a/app/assets/javascripts/components/duty-expression-formatter.js
+++ b/app/assets/javascripts/components/duty-expression-formatter.js
@@ -88,10 +88,8 @@ window.DutyExpressionFormatter = {
           output.push(duty_expression_description);
         } else if (duty_expression_description === null) {
           output.push("%");
-        }
-
-        if (monetary_unit) {
-          output.push(monetary_unit.monetary_unit_code);
+        } else if (monetary_unit) {
+          output.push(monetary_unit);
         }
 
         if (measurement_unit_abbreviation) {


### PR DESCRIPTION
Prior to this change, when user was bulk editing duties, monetary units
where not visible for some cases eg Amount

This change fixes the bug that was preventing unit from being displayed.

See: [TARIFFS-117](https://uktrade.atlassian.net/browse/TARIFFS-117)

**Before:**
<img width="1320" alt="Screenshot 2019-06-25 at 12 36 25" src="https://user-images.githubusercontent.com/6704411/60087560-eb6f7a80-9745-11e9-9fcb-b989e8536ccd.png">

**After:**
<img width="1320" alt="Screenshot 2019-06-25 at 12 35 52" src="https://user-images.githubusercontent.com/6704411/60087597-faeec380-9745-11e9-937f-94bbba32aff2.png">
