### PR TITLE
Fix: Groups adding other groups as members

### DIFF
--- a/app/interactors/workbasket_interactions/edit_geographical_area/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/edit_geographical_area/initial_validator.rb
@@ -69,7 +69,7 @@ module WorkbasketInteractions
         end
       end
 
-      if original_geographical_area.geographical_code == "group"
+      if original_geographical_area.geographical_code == "group" || original_geographical_area.geographical_code == "1"
         if members_are_groups.include?(true)
           @errors[:memberships] = "A group cannot be a member of another group!"
           @errors_summary = "A group cannot be a member of another group!"


### PR DESCRIPTION
Prior to this change, groups could add another geo area group
as a member.

This change stops this bug occuring by checking for "1" as well as
"group" as the value of geographical_code.