### PR TITLE
Fix field that is showing twice

### DIFF
--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_area_details.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_area_details.html.slim
@@ -52,11 +52,5 @@ h3.heading-medium Geographical area details
     .col-md-6
       = g_area.current_description_valid_to
 
-  .bootstrap-row
-    .col-md-6.heading_column.pull-left
-      | Description valid to
-    .col-md-6
-      = g_area.current_description_valid_to
-
   = render "workbaskets/create_geographical_area/workflow_screens_parts/other_descriptions", g_area: g_area
   = render "workbaskets/create_geographical_area/workflow_screens_parts/memberships", g_area: g_area


### PR DESCRIPTION
Prior to this change, `Description valid to` field was showing twice.

This change removes duplicate code

See: [TARIFFS-270](https://uktrade.atlassian.net/browse/TARIFFS-270)