### PR TITLE
Fix: Some crashes caused by missing/incorrect pages on edit geo workflow

### DIFF
--- a/app/views/workbaskets/edit_geographical_area/steps/_main.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/steps/_main.html.slim
@@ -6,4 +6,4 @@
 = render "workbaskets/edit_geographical_area/steps/main/description", f: f
 = render "workbaskets/edit_geographical_area/steps/main/description_validity_start_date", f: f
 = render "workbaskets/edit_geographical_area/steps/main/validity_period", f: f
-= render "workbaskets/create_geographical_area/steps/main/memberships", f: f
+= render "workbaskets/edit_geographical_area/steps/main/memberships", f: f

--- a/app/views/workbaskets/edit_geographical_area/steps/main/_memberships.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/steps/main/_memberships.html.slim
@@ -4,10 +4,61 @@ fieldset
 
   span.form-hint
     | If the geographical area type is country or region, optionally use this section to add it to one or more existing groups.
-    br
-    | If it is a group, optionally use this section to add countries and/or regions to it.
-    br
-    | Added items will be shown in the list below. Click an item to change its join or leave date.
+    |  If it is a group, optionally use this section to add countries and/or regions to it.
+    |  Added items will be shown in the list below. Click an item to change its join or leave date.
     br
 
-  = link_to "Add memberships", "#", class: "button js-geographical-area-manage-memberships"
+  button.button v-on:click.prevent="triggerAddMemberships" :disabled="!this.geographical_area.geographical_code"
+    | Add memberships
+
+  .bootstrap-row v-if="this.geographical_area.geographical_code"
+    .col-xs-12.col-sm-12.col-md-8.col-lg-7.col-xl-6
+      table.table
+        colgroup
+          col width="40"
+          col width="*"
+          col width="120"
+          col width="120"
+        thead
+          tr
+            th colspan="2"
+              a href="#" v-on:click.prevent="changeSorting('geographical_area_id')"
+                | {{isGroup ? "Members" : "Is a member of"}}
+                span v-if="'geographical_area_id' == sortBy"
+                  arrow-down v-if="sortDir === 'desc'"
+                  arrow-up v-if="sortDir === 'asc'"
+            th
+              a href="#" v-on:click.prevent="changeSorting('join_date')"
+                | Join date
+
+                span v-if="'join_date' == sortBy"
+                  arrow-down v-if="sortDir === 'desc'"
+                  arrow-up v-if="sortDir === 'asc'"
+            th
+              a href="#" v-on:click.prevent="changeSorting('leave_date')"
+                | Leave date
+
+                span v-if="'leave_date' == sortBy"
+                  arrow-down v-if="sortDir === 'desc'"
+                  arrow-up v-if="sortDir === 'asc'"
+        tbody
+          tr v-for="(membership, index) in sortedMemberships"
+            td
+              a href="#" role="button" v-on:click.prevent="editMembership(membership)"
+                | {{membership.geographical_area_id}}
+            td
+              a href="#" role="button" v-on:click.prevent="editMembership(membership)"
+                | {{membership.geographical_area.description}}
+            td
+              | {{membership.validity_start_date}}
+            td
+              | {{membership.validity_end_date}}
+            td
+              a href="#" role="button" v-on:click.prevent="removeMembership(membership)" id="remove-group"
+                | Remove
+
+  add-geo-areas-to-group-popup :validity-start-date="geographical_area.validity_start_date" :geographical-area="geographical_area" :on-close="closePopups" :open="true" v-if="addingMembers"
+
+  add-geo-areas-to-country-region-popup :validity-start-date="geographical_area.validity_start_date" :geographical-area="geographical_area" :on-close="closePopups" :open="true" v-if="addingToGroups"
+
+  edit-geographical-area-membership-popup :geographical-area="geographical_area" :membership="editingMembership" :on-close="closePopups" :open="true" v-if="editingMembership !== null"

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_other_descriptions.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/_other_descriptions.html.slim
@@ -1,0 +1,26 @@
+- if g_area.other_descriptions.present?
+  = link_to "Show other descriptions for this geographical area", "#", class: "js-workbasket-geographical-area-show-hide-descriptions"
+
+  .js-view-geographical-area-other-descriptions-block.hidden
+    - total_number = g_area.other_descriptions.count
+
+    - g_area.other_descriptions.map.with_index do |item, index|
+      - item = item.decorate
+
+      .bootstrap-row
+        .col-md-6.heading_column.pull-left
+          | Description
+        .col-md-6
+          = item.description
+
+      .bootstrap-row
+        .col-md-6.heading_column.pull-left
+          | Description valid from
+        .col-md-6
+          = item.start_date
+
+      .bootstrap-row class="#{'final_row' if total_number == index + 1}"
+        .col-md-6.heading_column.pull-left
+          | Description valid to
+        .col-md-6
+          = item.end_date

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_awaiting_cds_upload_edit.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_awaiting_cds_upload_edit.html.slim
@@ -1,0 +1,3 @@
+p
+  | The edited geographical area has been approved, but has not yet been sent through to CDS. It will be sent in the next batch.
+  | .

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_approval_rejected.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_approval_rejected.html.slim
@@ -12,4 +12,4 @@
     =<> "'#{workbasket.settings.main_step_settings['description'].capitalize}'"
     | has problems. It has not been approved. The submitter has been notified.
 
-= render "workbaskets/create_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "approve"
+= render "workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
@@ -14,4 +14,4 @@
     br
     | It has been submitted for approval.
 
-= render "workbaskets/create_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "approve"
+= render "workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_awaiting_cds_upload_edit.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_awaiting_cds_upload_edit.html.slim
@@ -13,4 +13,4 @@
     | has been approved. It has been scheduled for export CDS
     =< "in the next batch."
 
-= render "workbaskets/create_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "approve"
+= render "workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_cross_check_rejected.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_cross_check_rejected.html.slim
@@ -12,4 +12,4 @@
     =<> "'#{workbasket.settings.main_step_settings['description'].capitalize}'"
     | has problems. It has not passed cross-check. The submitter has been notified.
 
-= render "workbaskets/create_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"
+= render "workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -1,0 +1,21 @@
+br
+h3.heading-medium
+  | Next steps
+
+ul class="list"
+  - if mode == "cross_check" && next_cross_check.present? && workbasket.id != next_cross_check.id
+    li
+      = link_to "Cross-check next workbasket", new_cross_check_url(next_cross_check.id)
+
+  - if mode == "approve" && next_approve.present? && workbasket.id != next_approve.id
+    li
+      = link_to "Approve next workbasket", new_approve_url(next_approve.id)
+
+  li
+    = link_to "Return to main menu", root_url
+
+  - unless workbasket_rejected?
+    li
+      = link_to "View this geographical area", edit_geographical_area_url(workbasket.id)
+br
+br

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_ready_for_export.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/_ready_for_export.html.slim
@@ -1,0 +1,17 @@
+.panel.panel--confirmation
+  h1.heading-xlarge
+    | Geographical area approved
+
+  h3.heading-medium
+    | An edited
+    =<> geographical_area.decorate.type
+    | with code
+    =<> "'#{geographical_area.geographical_area_id}'"
+    | and description
+    br
+    =<> "'#{geographical_area.description}'"
+    | has been approved.
+    br
+    | It has not yet been sent through to CDS and has not been scheduled for export.
+
+= render "workbaskets/edit_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"


### PR DESCRIPTION
Prior to this change, some pages in the wedit geo workflow were missing or
had problems which caused the page to crash

This change fixes these issues/missing views.