### PR TITLE
Fix page error message typo

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,7 +153,7 @@ en:
     summary_minimal_required_fields: "The footnote could not be submitted because one or more required fields are missing."
     summary_invalid_fields: "The footnote could not be submitted because invalid data has been entered for one or more fields."
     summary_conformance_rules: "The footnote could not be submitted because there are conformance errors."
-    nothing_changed: "The footnote could not be submitted because you have to change change something!"
+    nothing_changed: "The footnote could not be submitted because you have to change something!"
 
   edit_certificate:
     reason_for_changes_blank: "Reason cannot be left blank and must comprise at least one word."
@@ -172,7 +172,7 @@ en:
     summary_minimal_required_fields: "The certificate could not be submitted because one or more required fields are missing."
     summary_invalid_fields: "The certificate could not be submitted because invalid data has been entered for one or more fields."
     summary_conformance_rules: "The certificate could not be submitted because there are conformance errors."
-    nothing_changed: "The certificate could not be submitted because you have to change change something!"
+    nothing_changed: "The certificate could not be submitted because you have to change something!"
 
   edit_geographical_area:
     reason_for_changes_blank: "Reason cannot be left blank and must comprise at least one word."
@@ -191,4 +191,4 @@ en:
     summary_minimal_required_fields: "The geographical area could not be submitted because one or more required fields are missing."
     summary_invalid_fields: "The geographical area could not be submitted because invalid data has been entered for one or more fields."
     summary_conformance_rules: "The geographical area could not be submitted because there are conformance errors."
-    nothing_changed: "The geographical area could not be submitted because you have to change change something!"
+    nothing_changed: "The geographical area could not be submitted because you have to change something!"


### PR DESCRIPTION
Prior to this change, there was an error message typo to
'Edit geographical area' page

This change fixes that typo

See: [https://uktrade.atlassian.net/browse/TARIFFS-253](https://uktrade.atlassian.net/browse/TARIFFS-253)