### PR TITLE
Fix disabled radio button on Edit geographical area

### DIFF
--- a/app/assets/javascripts/components/workbaskets/edit-geographical-area.js
+++ b/app/assets/javascripts/components/workbaskets/edit-geographical-area.js
@@ -28,15 +28,12 @@ $(document).ready(function() {
 
         area_code = data.geographical_area.geographical_code;
 
-        if (area_code.length > 0) {
-          setTimeout(function setAreaCode() {
-            radion_button = $(".geographical-area-type .multiple-choice[data-type-value='" + area_code + "'] label");
-            radion_button.trigger('click');
+        // disable radio buttons
+        $(".radio-inline-group").attr('disabled', 'disabled');
 
-            setTimeout(function disableRadioButtons() {
-              $(".multiple-choice.disabled_area").addClass('disabled');
-            }, 300);
-          }, 300);
+        if (area_code.length > 0) {
+          radion_button = $(".geographical-area-type .multiple-choice[data-type-value='" + area_code + "'] input");
+          radion_button.attr('checked', true);
         }
       } else {
         data.geographical_area = this.emptyGeographicalArea();

--- a/app/views/workbaskets/edit_geographical_area/steps/main/_type.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/steps/main/_type.html.slim
@@ -7,7 +7,7 @@ fieldset
       .controls
         .geographical-area-type
           .multiple-choice data-type-value="0"
-            input#geographical-area-type-country.radio-inline-group.js-geographical-area-type disabled="disabled" name="geographical_area[geographical_code]" type="radio" value="country"
+            input#geographical-area-type-country.radio-inline-group.js-geographical-area-type name="geographical_area[geographical_code]" type="radio" value="country"
 
             label.with_bigger_font-size for="geographical-area-type-country"
               | A country
@@ -15,7 +15,7 @@ fieldset
 
         .geographical-area-type
           .multiple-choice data-type-value="2"
-            input#geographical-area-type-region.radio-inline-group.js-geographical-area-type disabled="disabled" name="geographical_area[geographical_code]" type="radio" value="region"
+            input#geographical-area-type-region.radio-inline-group.js-geographical-area-type name="geographical_area[geographical_code]" type="radio" value="region"
 
             label.with_bigger_font-size for="geographical-area-type-region"
               | A region
@@ -23,7 +23,7 @@ fieldset
 
         .geographical-area-type
           .multiple-choice data-type-value="1"
-            input#geographical-area-type-group.radio-inline-group.js-geographical-area-type disabled="disabled" name="geographical_area[geographical_code]" type="radio" value="group"
+            input#geographical-area-type-group.radio-inline-group.js-geographical-area-type name="geographical_area[geographical_code]" type="radio" value="group"
 
             label.with_bigger_font-size for="geographical-area-type-group"
               | A group


### PR DESCRIPTION
Prior to this change, it was not visible which option was selected

This change uses JS in order to mimic read only for radio buttons, as
by default radio buttons do not support readonly attribute

See: [https://uktrade.atlassian.net/browse/TARIFFS-251](https://uktrade.atlassian.net/browse/TARIFFS-251)

**Before:**
<img width="792" alt="Screenshot 2019-07-01 at 12 28 51" src="https://user-images.githubusercontent.com/6704411/60425751-e1dd8b00-9bfb-11e9-83ce-1b7d40342a1c.png">

**After:**
<img width="790" alt="Screenshot 2019-07-01 at 12 22 21" src="https://user-images.githubusercontent.com/6704411/60425759-e6a23f00-9bfb-11e9-9594-53fa53f37968.png">


