### PR TITLE
Fix: Crash when viewing cross checker new geo area page

### DIFF
--- a/app/views/workbaskets/create_geographical_area/steps/review_and_submit/_geographical_areas.html.slim
+++ b/app/views/workbaskets/create_geographical_area/steps/review_and_submit/_geographical_areas.html.slim
@@ -6,7 +6,10 @@
       .table__column.validity_start_date-column
         a
           | Start date
-          - g_area = GeographicalArea.find(geographical_area_id: workbasket.settings.settings[:geographical_area_id])
+          - if workbasket.type == "edit_geographical_area"
+            - g_area = GeographicalArea.find(geographical_area_id: workbasket.settings.settings[:geographical_area_id])
+          - else
+            - g_area = GeographicalArea.find(workbasket_id: workbasket.id)
           div.sort-arrow
             svg#arrow_down.arrow-down enable-background=("new 0 0 96 96") height="16px" version="1.1" viewbox=("0 0 96 96") width="16px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
               path d="M44,12v62.344L22.543,52.888c-1.561-1.562-4.094-1.562-5.656-0.001c-1.562,1.562-1.562,4.096,0,5.658l28.284,28.283l0,0  c0.186,0.186,0.391,0.352,0.609,0.498c0.101,0.067,0.21,0.114,0.315,0.172c0.124,0.066,0.242,0.142,0.373,0.195  c0.135,0.057,0.275,0.089,0.415,0.129c0.111,0.033,0.216,0.076,0.331,0.099C47.474,87.973,47.737,88,48,88l0,0  c0.003,0,0.006-0.001,0.009-0.001c0.259-0.001,0.519-0.027,0.774-0.078c0.12-0.024,0.231-0.069,0.348-0.104  c0.133-0.039,0.268-0.069,0.397-0.123c0.139-0.058,0.265-0.136,0.396-0.208c0.098-0.054,0.198-0.097,0.292-0.159  c0.221-0.146,0.427-0.314,0.614-0.501l28.281-28.282c1.562-1.562,1.562-4.095,0.001-5.657c-1.562-1.562-4.095-1.562-5.657,0  L52,74.343V12c0-2.209-1.791-4-4-4S44,9.791,44,12z"


### PR DESCRIPTION
Prior to this change, when a cross checker viewed cross check new
geo area page it crashed due to the partial being shared between
cross check edit geo area and create new geo area and the differences
between the two workbaskets in how they identify the geo area in
question

This change finds the instance of geo area in different ways depening
on whether it is edit or create to fix this issue.