### PR TITLE
Fix JS  disableLeaveDate ReferenceError

### DIFF
--- a/app/views/shared/vue_templates/_edit_geographical_area_membership_popup.html.slim
+++ b/app/views/shared/vue_templates/_edit_geographical_area_membership_popup.html.slim
@@ -43,7 +43,7 @@ script type="text/x-template" id="edit-geographical-area-membership-popup-templa
           span.error-message v-if="slotProps.hasError" v-cloak=""
             | {{slotProps.error}}
 
-        date-select :value.sync="leave_date" :disabled="disableLeaveDate"
+        date-select :value.sync="leave_date"
 
     .form-actions
       button.button @click.prevent="updateMembership" :disabled="processing"


### PR DESCRIPTION
Prior to this change, there was a JS reference error that was cought by
Sentry

This change remove the invalid reference

Related to : [https://uktrade.atlassian.net/browse/TARIFFS-244](https://uktrade.atlassian.net/browse/TARIFFS-244)