### PR TITLE
Refactor: Remove RubyTree gem and restore tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem 'kaminari-sequel'
 gem "simple_form", "~> 3.5"
 gem "jbuilder"
 gem "enumerize"
-gem "rubytree"
 
 # Decorators & Exposing named methods
 gem 'draper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -491,7 +491,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    structured_warnings (0.3.0)
     temple (0.8.0)
     thor (0.19.4)
     thread_safe (0.3.6)
@@ -585,7 +584,6 @@ DEPENDENCIES
   responders (~> 2.1, >= 2.1.0)
   rspec-rails
   rspec_junit_formatter
-  rubytree
   rubyzip (~> 1.2.2)
   sass-rails (= 5.0.6)
   selectize-rails

--- a/app/services/nomenclature_tree_service.rb
+++ b/app/services/nomenclature_tree_service.rb
@@ -30,22 +30,22 @@ class NomenclatureTreeService
     root_node = nil
     current_path = []
     Sequel::Model.db.fetch(nomenclature_children_sql, "#{nomenclature_code[0..3]}______").each do |nomenclature|
-      new_node = Tree::TreeNode.new(nomenclature[:goods_nomenclature_item_id], nomenclature)
+      new_node = TreeNode.new(nomenclature[:goods_nomenclature_item_id], nomenclature)
       if root_node == nil
         root_node = new_node
         current_path = [root_node]
       elsif (nomenclature[:number_indents] -1 == current_path[-1].content[:number_indents])
         # new_node is a child of the current path end
-        current_path[-1] << new_node
+        current_path[-1].children << new_node
         current_path << new_node
       elsif (nomenclature[:number_indents] == current_path[-1].content[:number_indents])
         # new_node is a sibling of the current path end
-        current_path[-2] << new_node
+        current_path[-2].children << new_node
         current_path[-1] = new_node
       elsif (nomenclature[:number_indents] < current_path[-1].content[:number_indents])
         # new_node is a sibling of a higher point in the current path
         jump_up = current_path[-1].content[:number_indents] - nomenclature[:number_indents]
-        current_path[-2-jump_up] << new_node
+        current_path[-2-jump_up].children << new_node
         current_path[-1-jump_up..-1] = new_node
       end
     end

--- a/lib/tree_node.rb
+++ b/lib/tree_node.rb
@@ -1,0 +1,13 @@
+class TreeNode
+  attr_accessor :name, :content, :children
+
+  def initialize(name, content)
+    @name = name
+    @content = content
+    @children = []
+  end
+
+  def has_children?
+    !children.empty?
+  end
+end

--- a/spec/integration/chief_transformer/vat_excises_spec.rb
+++ b/spec/integration/chief_transformer/vat_excises_spec.rb
@@ -114,7 +114,6 @@ describe "CHIEF: VAT and Excises" do
     end
 
     it "creates measures for 0202020200" do
-      skip
       m = Measure.where(goods_nomenclature_item_id: "0202020200", validity_start_date: DateTime.parse("2006-06-01 00:00:00")).first
       expect(m.goods_nomenclature_item_id).to eq "0202020200"
       expect(m.measure_components.first.duty_amount).to eq 22.0

--- a/spec/lib/tree_node_spec.rb
+++ b/spec/lib/tree_node_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe(TreeNode) do
+
+  describe "has_children?" do
+    it "returns false when no children" do
+      expect(described_class.new("dummy name", "dummy content").has_children?).to be false
+    end
+
+    it "returns true when children are added" do
+      root_node = described_class.new("dummy name", "dummy content")
+      root_node.children << described_class.new("child name", "a child node")
+
+      expect(root_node.has_children?).to be true
+    end
+  end
+end

--- a/spec/unit/tariff_synchronizer/base_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_spec.rb
@@ -62,7 +62,6 @@ describe TariffSynchronizer::BaseUpdate do
     end
 
     it "logs and send email about several missing updates in a row" do
-      skip
       create :chief_update, :missing, issue_date: 1.day.ago
       create :chief_update, :missing, issue_date: 2.days.ago
       create :chief_update, :missing, issue_date: 3.days.ago

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -23,7 +23,6 @@ describe TariffSynchronizer::Logger, truncation: true do
     }
 
     it 'logs a warn event' do
-      skip
       expect(@logger.logged(:warn).size).to be > 1
       expect(@logger.logged(:warn).to_s).to match /Missing/
     end
@@ -45,7 +44,6 @@ describe TariffSynchronizer::Logger, truncation: true do
     }
 
     it 'logs a warn event' do
-      skip
       expect(@logger.logged(:warn).size).to be >= 1
       expect(@logger.logged(:warn).first.to_s).to match /acquire Redis lock/
     end
@@ -61,7 +59,6 @@ describe TariffSynchronizer::Logger, truncation: true do
     }
 
     it 'logs a warn event' do
-      skip
       expect(@logger.logged(:warn).size).to be >= 1
       expect(@logger.logged(:warn).first.to_s).to match /acquire Redis lock/
     end

--- a/spec/unit/tariff_synchronizer/taric_update_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_downloader_spec.rb
@@ -68,7 +68,6 @@ describe TariffSynchronizer::TaricUpdateDownloader do
       end
 
       it "Logs the creating of the TaricUpdate record with missing state" do
-        skip
         tariff_synchronizer_logger_listener
         described_class.new(example_date).perform
         expect(@logger.logged(:warn).size).to eq 1
@@ -95,7 +94,6 @@ describe TariffSynchronizer::TaricUpdateDownloader do
       end
 
       it "Logs the creating of the TaricUpdate record with failed state" do
-        skip
         tariff_synchronizer_logger_listener
         described_class.new(example_date).perform
         expect(@logger.logged(:warn).size).to eq 1

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -131,7 +131,6 @@ describe TariffSynchronizer::TariffDownloader do
           end
 
           it "Logs the creating of the ChiefUpdate record with missing state" do
-skip
             tariff_synchronizer_logger_listener
             tariff_downloader.perform
             expect(@logger.logged(:warn).size).to eq 1
@@ -158,7 +157,6 @@ skip
           end
 
           it "Logs the creating of the ChiefUpdate record with failed state" do
-            skip
             tariff_synchronizer_logger_listener
             tariff_downloader.perform
             expect(@logger.logged(:warn).size).to eq 1


### PR DESCRIPTION
Prior to this change, we used a gem that clashed with some other
features.

This change removes the gem and restores the tests that were temporarily
removed.