### PR TITLE
Fix: Remove last updated field from bulk edit pages

### DIFF
--- a/app/assets/javascripts/components/additional-codes-show-page.js
+++ b/app/assets/javascripts/components/additional-codes-show-page.js
@@ -14,8 +14,7 @@ $(document).ready(function() {
           {enabled: true, title: "Code", field: "additional_code", sortable: true, type: "string" },
           {enabled: true, title: "Description", field: "description", sortable: true, type: "string" },
           {enabled: true, title: "Valid from", field: "validity_start_date", sortable: true, type: "date" },
-          {enabled: true, title: "Valid to", field: "validity_end_date", sortable: true, type: "date" },
-          {enabled: true, title: "Last updated", field: "last_updated", sortable: true, type: "string" }
+          {enabled: true, title: "Valid to", field: "validity_end_date", sortable: true, type: "date" }
         ],
         raw_codes: window.additional_codes
       };

--- a/app/assets/javascripts/components/bulk-edit-additional-codes.js
+++ b/app/assets/javascripts/components/bulk-edit-additional-codes.js
@@ -16,7 +16,6 @@ $(document).ready(function() {
           {enabled: true, title: "Description", field: "description", sortable: true, type: "string", changeProp: "description" },
           {enabled: true, title: "Valid from", field: "validity_start_date", sortable: true, type: "date", changeProp: "validity_start_date" },
           {enabled: true, title: "Valid to", field: "validity_end_date", sortable: true, type: "date", changeProp: "validity_end_date" },
-          {enabled: true, title: "Last updated", field: "last_updated", sortable: true, type: "string" },
           {enabled: true, title: "Status", field: "status", sortable: true, type: "string", changeProp: "status" }
         ],
         actions: [

--- a/app/assets/javascripts/components/bulk/measures/columns.js
+++ b/app/assets/javascripts/components/bulk/measures/columns.js
@@ -12,6 +12,5 @@ window.BulkEditing.Measures.Columns = [
   {enabled: true, title: "Duties", field: "duties", sortable: true, type: "duties", changeProp: "duties" },
   {enabled: true, title: "Conditions", field: "conditions", sortable: true, type: "comma_string", changeProp: "conditions" },
   {enabled: true, title: "Footnotes", field: "footnotes", sortable: true, type: "comma_string", changeProp: "footnotes" },
-  {enabled: true, title: "Last updated", field: "last_updated", sortable: true, type: "date", changeProp: "last_updated" },
   {enabled: true, title: "Status", field: "status", sortable: true, type: "string", changeProp: "status" }
 ];

--- a/app/assets/javascripts/components/find-measures.js
+++ b/app/assets/javascripts/components/find-measures.js
@@ -47,7 +47,6 @@ $(document).ready(function() {
           {enabled: true, title: "Duties", field: "duties"},
           {enabled: true, title: "Conditions", field: "conditions"},
           {enabled: true, title: "Footnotes", field: "footnotes"},
-          {enabled: true, title: "Last updated", field: "last_updated"},
           {enabled: true, title: "Status", field: "status"}
         ],
 

--- a/app/assets/javascripts/components/find-quotas.js
+++ b/app/assets/javascripts/components/find-quotas.js
@@ -50,7 +50,6 @@ $(document).ready(function() {
           {enabled: true, title: "Additional code(s)", field: "additional_code_ids"},
           {enabled: true, title: "Origin", field: "origin"},
           {enabled: true, title: "Origin exclusions", field: "origin_exclusions"},
-          {enabled: true, title: "Last updated", field: "last_updated"},
           {enabled: true, title: "Status", field: "status"}
         ],
 


### PR DESCRIPTION
Prior to this change, the user would see a blank last updated field
when viewing a bulk edit workbasket.

This change removes this column.