### PR TITLE
Fix: Correct description for nomenclature tree

### DIFF
--- a/app/services/nomenclature_tree_service.rb
+++ b/app/services/nomenclature_tree_service.rb
@@ -9,7 +9,7 @@ class NomenclatureTreeService
              gni.number_indents,
              (select description
               from goods_nomenclature_descriptions
-              where goods_nomenclature_item_id = gn.goods_nomenclature_item_id
+              where goods_nomenclature_sid = gn.goods_nomenclature_sid
               order by oid desc
               limit 1)
       from goods_nomenclatures gn


### PR DESCRIPTION
Prior to this change, when muliple codes and suffixs were used sometimes
the wrong description was attached to a node.

This change uses sid to link the tables instead of using item_id and
suffix.