### PR TITLE
Fix: Correctly find original geographical area

### DIFF
--- a/app/models/workbaskets/edit_geographical_area_settings.rb
+++ b/app/models/workbaskets/edit_geographical_area_settings.rb
@@ -69,7 +69,6 @@ module Workbaskets
 
     def original_geographical_area
       @original_geographical_area ||= GeographicalArea.where(
-        geographical_area_sid: original_geographical_area_sid,
         geographical_area_id: original_geographical_area_id
       ).first
     end


### PR DESCRIPTION
Prior to this change, we searched for original geographical area by
sid and id. This is unnecessary and occasionally causes issues

This change finds original geographical area by id only.