### PR TITLE
Fix: Incorrect copy on cross-check geo area page

### DIFF
--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,2 +1,2 @@
 p
-  | You are about to edit a geographical area.
+  | Please check that the geographical area details below are as intended and correctly reflect the requirement, then either confirm or reject


### PR DESCRIPTION
Prior to this change, the copy told the user they were editing a
geo area when in fact they are cross checking it.

This change corrects this error.