### PR TITLE
Fix: Eager load lib directory

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,8 +13,8 @@ module TradeTariffBackend
   class Application < Rails::Application
     require 'trade_tariff_backend'
 
-    # lib directory to be autoloadable.
-    config.autoload_paths << "#{Rails.root}/lib"
+    # lib directory to be eager loaded.
+    config.eager_load_paths << Rails.root.join('lib')
 
     config.generators do |g|
       g.view_specs     false


### PR DESCRIPTION
Prior to this change, lib directory was auto-loaded, which is not the recommended practice and appeared to be causing an issue in production.

This change changes autoloading lib to eager loading (i.e. now loads up the lib directory at startup)

Tree in lib was not loading when browsing the nomenclature tree
https://uktrade.atlassian.net/browse/TARIFFS-205