### PR TITLE
Fix: Server errors when editing geo area with no memberships

### DIFF
--- a/app/interactors/workbasket_interactions/edit_geographical_area/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/edit_geographical_area/settings_saver.rb
@@ -136,11 +136,11 @@ module WorkbasketInteractions
         return false if membership_removed?
         if original_geographical_area.geographical_code == '1'
           original_member_ids = original_geographical_area.currently_contains.map { |area| area.geographical_area_id }
-          new_member_ids = settings_params["geographical_area_memberships"].values.map{|area| area['geographical_area_id']}
+          new_member_ids = settings_params["geographical_area_memberships"] ? settings_params["geographical_area_memberships"].values.map{|area| area['geographical_area_id']} : []
           original_member_ids == new_member_ids
         else
           original_membership_ids = original_geographical_area.currently_member_of.map { |area| area.geographical_area_id }
-          new_membership_ids = settings_params["geographical_area_memberships"].values.map{|area| area["geographical_area_id"]}
+          new_membership_ids = settings_params["geographical_area_memberships"] ? settings_params["geographical_area_memberships"].values.map{|area| area["geographical_area_id"]} : []
           original_membership_ids == new_membership_ids
         end
       end


### PR DESCRIPTION
Prior to this change, if a user tried to edit a geo area with no memberships,
and did not add any memberships, a server error would be raised.

This was due to settings_params['geographical_area_memberships'] being
nil and some lines in the settings saver trying to call methods on nil.

This change corrects this issue.