### PR TITLE
Fix error summary links

### DIFF
--- a/app/assets/javascripts/components/workbaskets/validation_errors_handler.js.coffee
+++ b/app/assets/javascripts/components/workbaskets/validation_errors_handler.js.coffee
@@ -48,7 +48,7 @@ window.WorkbasketBaseValidationErrorsHandler =
       group_block.removeClass('hidden')
       list_block = group_block.find("ul")
       $.each errors_collection, (key, value) ->
-        list_block.append("<li><div class='workbasket-error-block with_left_margin'>" + value + "</div></li>")
+        list_block.append('<li><div class="workbasket-error-block with_left_margin"><a href="#'+key+'">' + value + '</a></div></li>')
 
   customErrorHtml: (error) ->
     text = error[0]

--- a/app/assets/stylesheets/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_overrides.scss
@@ -26,14 +26,3 @@ body { padding-top: 0; }
 a[disabled] {
   pointer-events: none;
 }
-
-.form-label, .form-hint {
-  font-size: 16px !important;
-}
-.heading-large {
-  font-size: 30px !important;
-}
-
-.heading-medium {
-  font-size: 20px !important;
-}

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -13,12 +13,6 @@ input.date-picker {
   background-size: 10%;
 }
 
-.error-summary {
-  p {
-    font-size: 16px;
-  }
-}
-
 .error-message {
   font-weight: 600;
   margin-bottom: 15px;

--- a/app/views/workbaskets/create_additional_code/_form.html.slim
+++ b/app/views/workbaskets/create_additional_code/_form.html.slim
@@ -11,6 +11,12 @@
     p
       | See individual fields for details.
 
+    ul.error-summary-list
+        li v-for="(error, key) in errors"
+          a :href="['#' + key]"
+            | {{ error }}
+
+
   - if workbasket.submitted?
     = render "workbaskets/create_additional_code/steps/main/details"
 

--- a/app/views/workbaskets/create_additional_code/steps/main/_additional_codes.html.slim
+++ b/app/views/workbaskets/create_additional_code/steps/main/_additional_codes.html.slim
@@ -1,5 +1,5 @@
 fieldset
-  h3.heading-medium
+  h3.heading-medium id="additional_codes"
     | Define the new additional code(s)
 
   form-group :errors="errors" error-key="additional_codes"

--- a/app/views/workbaskets/create_additional_code/steps/main/_start_end_dates.html.slim
+++ b/app/views/workbaskets/create_additional_code/steps/main/_start_end_dates.html.slim
@@ -1,6 +1,6 @@
 fieldset
   h3.heading-medium
-    label for="additional_code_valid_from"
+    label for="additional_code_valid_from" id="validity_start_date"
       | When are these new codes valid from?
 
   form-group :errors="errors" error-key="validity_start_date"
@@ -13,7 +13,7 @@ fieldset
 
 fieldset
   h3.heading-medium
-    label for="additional_code_valid_until"
+    label for="additional_code_valid_until" id="validity_end_date"
       | When are these new codes valid until?
 
   form-group :errors="errors" error-key="validity_end_date"

--- a/app/views/workbaskets/create_additional_code/steps/main/_workbasket_name.html.slim
+++ b/app/views/workbaskets/create_additional_code/steps/main/_workbasket_name.html.slim
@@ -5,7 +5,7 @@ fieldset
 
   form-group :errors="errors" error-key="workbasket_name"
     template slot-scope="slotProps"
-      label.form-label
+      label.form-label id="workbasket_name"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_certificate/_errors_summary.html.slim
+++ b/app/views/workbaskets/create_certificate/_errors_summary.html.slim
@@ -5,3 +5,8 @@
 
   p
     | {{errorsSummary}}
+
+  ul.error-summary-list
+    li v-for="(error, key) in errors"
+      a :href="['#' + key]"
+        | {{ error }}

--- a/app/views/workbaskets/create_certificate/steps/main/_certificate_code.html.slim
+++ b/app/views/workbaskets/create_certificate/steps/main/_certificate_code.html.slim
@@ -4,7 +4,7 @@ fieldset
 
   form-group.without_bottom_margin :errors="errors" error-key="certificate_code"
     template slot-scope="slotProps"
-      label.form-label
+      label.form-label id="certificate_code"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_certificate/steps/main/_certificate_type_code.html.slim
+++ b/app/views/workbaskets/create_certificate/steps/main/_certificate_type_code.html.slim
@@ -4,7 +4,7 @@ fieldset
 
   form-group :errors="errors" error-key="certificate_type_code"
     template slot-scope="slotProps"
-      label.form-label
+      label.form-label id="certificate_type_code"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
 

--- a/app/views/workbaskets/create_certificate/steps/main/_description.html.slim
+++ b/app/views/workbaskets/create_certificate/steps/main/_description.html.slim
@@ -4,7 +4,7 @@ fieldset
 
   form-group.without_bottom_margin :errors="errors" error-key="description"
     template slot-scope="slotProps"
-      label.form-label
+      label.form-label id="description"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
 

--- a/app/views/workbaskets/create_certificate/steps/main/_operation_date.html.slim
+++ b/app/views/workbaskets/create_certificate/steps/main/_operation_date.html.slim
@@ -4,7 +4,7 @@ fieldset
 
   form-group :errors="errors" error-key="operation_date"
     template slot-scope="slotProps"
-      label.form-label
+      label.form-label id="operation_date"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_certificate/steps/main/_validity_period.html.slim
+++ b/app/views/workbaskets/create_certificate/steps/main/_validity_period.html.slim
@@ -4,7 +4,7 @@ fieldset
 
   form-group :errors="errors" error-key="validity_start_date"
     template slot-scope="slotProps"
-      label.form-label
+      label.form-label id="validity_start_date"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint
@@ -19,7 +19,7 @@ fieldset
 
   form-group :errors="errors" error-key="validity_end_date"
     template slot-scope="slotProps"
-      label.form-label
+      label.form-label id="validity_end_date"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_footnote/_errors_summary.html.slim
+++ b/app/views/workbaskets/create_footnote/_errors_summary.html.slim
@@ -5,3 +5,8 @@
 
   p
     | {{errorsSummary}}
+
+  ul.error-summary-list
+    li v-for="(error, key) in errors"
+      a :href="['#' + key]"
+        | {{ error }}

--- a/app/views/workbaskets/create_footnote/steps/main/_description.html.slim
+++ b/app/views/workbaskets/create_footnote/steps/main/_description.html.slim
@@ -5,7 +5,7 @@ fieldset
         label for="footnote_description"
           | What is the footnote description?
 
-      label.form-label
+      label.form-label id="description"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_footnote/steps/main/_footnote_type_id.html.slim
+++ b/app/views/workbaskets/create_footnote/steps/main/_footnote_type_id.html.slim
@@ -4,7 +4,7 @@ fieldset
       h3.heading-medium
         | What type of footnote is this?
 
-      label.form-label
+      label.form-label id="footnote_type_id"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_footnote/steps/main/_operation_date.html.slim
+++ b/app/views/workbaskets/create_footnote/steps/main/_operation_date.html.slim
@@ -5,7 +5,7 @@ fieldset
         label for="footnote_operation_date"
           | Specify the operation date
 
-      label.form-label
+      label.form-label id="operation_date"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_footnote/steps/main/_validity_period.html.slim
+++ b/app/views/workbaskets/create_footnote/steps/main/_validity_period.html.slim
@@ -5,7 +5,7 @@ fieldset
         label for="footnote_validity_date"
           | When is the footnote valid from?
 
-      label.form-label
+      label.form-label id="validity_start_date"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint
@@ -20,7 +20,7 @@ fieldset
       h3.heading-medium
         | When is the footnote valid until?
 
-      label.form-label
+      label.form-label id="validity_end_date"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_geographical_area/_errors_summary.html.slim
+++ b/app/views/workbaskets/create_geographical_area/_errors_summary.html.slim
@@ -5,3 +5,8 @@
 
   p
     | {{errorsSummary}}
+
+  ul.error-summary-list
+    li v-for="(error, key) in errors"
+      a :href="['#' + key]"
+        | {{ error }}

--- a/app/views/workbaskets/create_geographical_area/steps/main/_code.html.slim
+++ b/app/views/workbaskets/create_geographical_area/steps/main/_code.html.slim
@@ -1,11 +1,11 @@
 fieldset
-  form-group :errors="errors" error-key="geographical_area_id"
+  form-group :errors="errors" error-key="geographical_code"
     template slot-scope="slotProps"
       h3.heading-medium
         label for="geographical_area_id"
          | What code will identify this area?
 
-      label.form-label
+      label.form-label id="geographical_code"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_geographical_area/steps/main/_description.html.slim
+++ b/app/views/workbaskets/create_geographical_area/steps/main/_description.html.slim
@@ -5,7 +5,7 @@ fieldset
         label for="workbasket_forms_create_geographical_area_form_description"
           | What is the area description?
 
-      label.form-label
+      label.form-label id="description"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_geographical_area/steps/main/_operation_date.html.slim
+++ b/app/views/workbaskets/create_geographical_area/steps/main/_operation_date.html.slim
@@ -5,7 +5,7 @@ fieldset
         label for="geographical_area_operation_date"
           | Specify the operation date
 
-      label.form-label
+      label.form-label id="operation_date"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_geographical_area/steps/main/_type.html.slim
+++ b/app/views/workbaskets/create_geographical_area/steps/main/_type.html.slim
@@ -1,10 +1,10 @@
 fieldset
-  form-group :errors="errors" error-key="geographical_code"
+  form-group :errors="errors" error-key="geographical_area_id"
     template slot-scope="slotProps"
       h3.heading-medium
         | What type of geographical area are you creating?
 
-      label.form-label
+      label.form-label id="geographical_area_id"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
 

--- a/app/views/workbaskets/create_geographical_area/steps/main/_validity_period.html.slim
+++ b/app/views/workbaskets/create_geographical_area/steps/main/_validity_period.html.slim
@@ -5,7 +5,7 @@ fieldset
         label for="geographical_area_validity_start_date"
           | When is the area valid from?
 
-      label.form-label
+      label.form-label id="validity_start_date"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint
@@ -23,7 +23,7 @@ fieldset
         label for="geographical_area_validity_end_date"
           | When is the area valid until?
 
-      label.form-label
+      label.form-label id="validity_end_date"
         span.error-message v-if="slotProps.hasError" v-cloak=""
           | {{slotProps.error}}
         span.form-hint

--- a/app/views/workbaskets/create_regulation/steps/main/_regulation_identifier.html.slim
+++ b/app/views/workbaskets/create_regulation/steps/main/_regulation_identifier.html.slim
@@ -1,5 +1,5 @@
 fieldset
-  h3.heading-medium
+  h3.heading-medium id="base_regulation_id"
     = f.label :base_regulation_id, 'What is the regulation identifier'
 
   .bootstrap-row

--- a/app/views/workbaskets/create_regulation/steps/main/_regulation_name.html.slim
+++ b/app/views/workbaskets/create_regulation/steps/main/_regulation_name.html.slim
@@ -1,5 +1,5 @@
 fieldset
-  h3.heading-medium
+  h3.heading-medium id="legal_id"
     | Legal Id
   .bootstrap-row
     .col-lg-6.col-md-8.col-sm-12.col-xs-12
@@ -7,7 +7,7 @@ fieldset
         span.error-message v-if="errors.legal_id" v-html="errors.legal_id"
         = f.input :legal_id, label: false, as: :string, input_html: { "v-model" => "regulation.legal_id" }
 fieldset
-  h3.heading-medium
+  h3.heading-medium id="description"
     | Description
   .bootstrap-row
     .col-lg-6.col-md-8.col-sm-12.col-xs-12
@@ -15,7 +15,7 @@ fieldset
         span.error-message v-if="errors.description" v-html="errors.description"
         = f.input :description, label: false, as: :text, input_html: { "v-model" => "regulation.description" }
 fieldset
-  h3.heading-medium
+  h3.heading-medium id="reference_url"
     | Reference URL
   .bootstrap-row
     .col-lg-6.col-md-8.col-sm-12.col-xs-12

--- a/app/views/workbaskets/create_regulation/steps/main/_validity_period.html.slim
+++ b/app/views/workbaskets/create_regulation/steps/main/_validity_period.html.slim
@@ -5,7 +5,7 @@ fieldset
   = f.input :validity_start_date, as: :hidden, input_html: { "v-model" => "regulation.validity_start_date" }
   = f.input :validity_end_date, as: :hidden, input_html: { "v-model" => "regulation.validity_end_date" }
   .form-group v-bind:class="{ 'form-group-error': errors.validity_start_date }"
-    label.form-label for="start_date"
+    label.form-label for="start_date" id="validity_start_date"
       | Start date
     span.error-message v-if="errors.validity_start_date" v-html="errors.validity_start_date"
     = content_tag "date-select", "",
@@ -13,7 +13,7 @@ fieldset
         id: "start_date" }
 
   .form-group v-bind:class="{ 'form-group-error': errors.validity_end_date }"
-    label.form-label for="end_date"
+    label.form-label for="end_date" id="validity_end_date"
       | End date
       span.form-hint
         | Optional - leave blank if the regulation will remain in force indefinitely.
@@ -23,7 +23,7 @@ fieldset
         id: "end_date" }
 
 fieldset
-  h3.heading-medium
+  h3.heading-medium id="regulation_group_id"
     | Specify the regulation group
 
   .row

--- a/app/views/workbaskets/shared/_custom_errors_block.html.slim
+++ b/app/views/workbaskets/shared/_custom_errors_block.html.slim
@@ -1,45 +1,46 @@
-.js-workbasket-errors-container.js-custom-errors-block.alert.alert-danger.hidden
-  h3.workbasket-form-errors-header
+.error-summary.js-workbasket-errors-container.js-custom-errors-block.alert.alert-danger.hidden role="alert" aria-labelledby="workbasket-errors" tabindex="-1"
+
+  h2.heading-medium.error-summary-heading
     | Please, review the following errors:
 
   .js-workbasket-custom-errors.hidden data-errors-container="general"
     h3.create-measures-custom-errors-header
       | General:
 
-    ul
+    ul.error-summary-list
 
   .js-workbasket-custom-errors.hidden data-errors-container="measure"
     h3.create-measures-custom-errors-header
       | Measures:
 
-    ul
+    ul.error-summary-list
 
   .js-workbasket-custom-errors.hidden data-errors-container="measure_components"
     h3.create-measures-custom-errors-header
       | Duties:
 
-    ul
+    ul.error-summary-list
 
   .js-workbasket-custom-errors.hidden data-errors-container="conditions"
     h3.create-measures-custom-errors-header
       | Conditions:
 
-    ul
+    ul.error-summary-list
 
   .js-workbasket-custom-errors.hidden data-errors-container="footnotes"
     h3.create-measures-custom-errors-header
       | Footnotes:
 
-    ul
+    ul.error-summary-list
 
   .js-workbasket-custom-errors.hidden data-errors-container="parent_quota"
     h3.create-measures-custom-errors-header
       | Parent quota:
 
-    ul
+    ul.error-summary-list
 
   .js-workbasket-custom-errors.hidden data-errors-container="sub_quotas"
     h3.create-measures-custom-errors-header
       | Sub-quotas:
 
-    ul
+    ul.error-summary-list

--- a/app/views/workbaskets/shared/_errors_container.html.slim
+++ b/app/views/workbaskets/shared/_errors_container.html.slim
@@ -1,7 +1,9 @@
-.js-workbasket-errors-container.alert.alert-danger v-cloak="" v-if="hasErrors"
-  h3.workbasket-form-errors-header
+.error-summary role="alert" aria-labelledby="workbasket-errors" tabindex="-1" v-cloak="" v-if="hasErrors"
+
+  h2.heading-medium.error-summary-heading#workbasket-errors
     | Please, review the following errors:
 
-  ul
-    li v-for="error in errors"
-      .workbasket-error-block :data-error-message="error" v-html="error"
+  ul.error-summary-list
+    li v-for="(error, key) in errors"
+      a :href="['#' + key]" :data-error-message="error"
+        | {{ error }}


### PR DESCRIPTION
Prior to this change errors were not listed inside
summary at the top of the page.

This change fixes this and by rendering the errors as
links to the actual form errors inside the summary following GDS 
style guides (See: [https://govuk-elements.herokuapp.com/errors/#summarise-errors)](https://govuk-elements.herokuapp.com/errors/#summarise-errors) 

**Resolves:** [TARIFFS-125](https://uktrade.atlassian.net/browse/TARIFFS-125)

**Before:**
![errors_before](https://user-images.githubusercontent.com/6704411/60886614-5e9ae580-a24a-11e9-82d7-f3c83b0c1a51.gif)

**After:**
![errors](https://user-images.githubusercontent.com/6704411/60886632-69557a80-a24a-11e9-8be1-72cc71fbcee7.gif)
