### PR TITLE
New: Add delete link for workbaskets that are not in cc/approval stages

### DIFF
--- a/app/controllers/workbaskets/base_controller.rb
+++ b/app/controllers/workbaskets/base_controller.rb
@@ -10,7 +10,7 @@ module Workbaskets
     before_action :clean_up_persisted_data_on_update!,
                   :handle_submit_for_cross_check!, only: [:update]
 
-    before_action :require_workbasket_to_be_new_in_progress!, only: [:destroy]
+    before_action :require_workbasket_to_be_with_creator!, only: [:destroy]
 
     expose(:workbasket_settings) do
       workbasket.settings
@@ -115,6 +115,10 @@ module Workbaskets
         redirect_to root_url
         false
       end
+    end
+
+    def require_workbasket_to_be_with_creator!
+      workbasket.new_in_progress? || workbasket.new_in_progress? || workbasket.cross_check_rejected? || workbasket.approval_rejected?
     end
 
     def status_check!

--- a/app/helpers/workbasket_helper.rb
+++ b/app/helpers/workbasket_helper.rb
@@ -343,4 +343,8 @@ module WorkbasketHelper
   def show_withdraw_edit?(workbasket)
     workbasket.can_withdraw? && @current_user.author_of_workbasket?(workbasket) && workbasket_edit_link(workbasket).present?
   end
+
+  def show_delete?(workbasket)
+     @current_user.author_of_workbasket?(workbasket) && (workbasket.editing? || workbasket.new_in_progress? || workbasket.cross_check_rejected? || workbasket.approval_rejected?)
+  end
 end

--- a/app/views/workbaskets/main_menu_parts/_actions.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_actions.html.slim
@@ -2,15 +2,14 @@
   = link_to "Continue", workbasket_continue_link_based_on_type(workbasket)
 - else
   = link_to "View", workbasket_view_link_based_on_type(workbasket)
-
 - if show_withdraw_edit?(workbasket)
   | &nbsp;|&nbsp;
   = link_to "Withdraw/edit", "#",
     data: { target_url: workbasket_edit_link(workbasket), target_modal: workbasket.id },
     class: "js-main-menu-show-withdraw-confirmation-link"
-- elsif workbasket.new_in_progress?
+- if show_delete?(workbasket)
   | &nbsp;|&nbsp;
-  = link_to "Delete", "#", data: { target_url: workbasket_view_link_based_on_type(workbasket) }, class: "js-main-menu-show-delete-confirmation-link"
+  = link_to "Delete", "#{workbasket.object.type}/#{workbasket.id}", data: { confirm: "Are you sure you want to delete this workbasket?" }, method: :delete
 
 - if workbasket.can_continue_cross_check?(@current_user)
   | &nbsp;|&nbsp;


### PR DESCRIPTION
Prior to this change, users could not delete workbaskets.

This change allows users to delete workbaskets that are new, being edited,
or have been rejected by a cross checker or approver.