### PR TITLE
Fix 'Search' buttons

### DIFF
--- a/app/views/certificates/certificates/search/_form.html.slim
+++ b/app/views/certificates/certificates/search/_form.html.slim
@@ -60,7 +60,8 @@
         .col-lg-6.col-md-7.col-sm-10.col-xs-12
           .form-actions
             .submit_group_for_cross_check_block
-              = link_to "Search", "#", name: "save_progress", class: "button js-validate-certificate-search-form js-workbasket-base-continue-button js-workbasket-base-submit-button"
+              button type="submit" name="save_progress" class="button js-validate-certificate-search-form js-workbasket-base-continue-button js-workbasket-base-submit-button"
+                | Search
 
               .js-workbasket-base-continue-spinner.spinner_block.hidden
                 = render "measures/bulks/loading_spinner", message: "Loading..."

--- a/app/views/footnotes/footnotes/search/_form.html.slim
+++ b/app/views/footnotes/footnotes/search/_form.html.slim
@@ -99,7 +99,8 @@
         .col-lg-6.col-md-7.col-sm-10.col-xs-12
           .form-actions
             .submit_group_for_cross_check_block
-              = link_to "Search", "#", name: "save_progress", class: "button js-validate-footnotes-search-form js-workbasket-base-continue-button js-workbasket-base-submit-button"
+              button type="submit" name="save_progress" class="button js-validate-footnotes-search-form js-workbasket-base-continue-button js-workbasket-base-submit-button"
+                | Search
 
               .js-workbasket-base-continue-spinner.spinner_block.hidden
                 = render "measures/bulks/loading_spinner", message: "Loading..."

--- a/app/views/geo_areas/geo_areas/search/_form.html.slim
+++ b/app/views/geo_areas/geo_areas/search/_form.html.slim
@@ -90,7 +90,8 @@
         .col-lg-6.col-md-7.col-sm-10.col-xs-12
           .form-actions
             .submit_group_for_cross_check_block
-              = link_to "Search", "#", name: "save_progress", class: "button js-validate-geographical-areas-search-form js-workbasket-base-continue-button js-workbasket-base-submit-button"
+              button type="submit" name="save_progress" class="button js-validate-geographical-areas-search-form js-workbasket-base-continue-button js-workbasket-base-submit-button"
+                | Search
 
               .js-workbasket-base-continue-spinner.spinner_block.hidden
                 = render "measures/bulks/loading_spinner", message: "Loading..."


### PR DESCRIPTION
Prior to this change user could not submit form by
pressing Enter key.

This change fixes this issue by changing the html of 
 Search buttons from `a` to `button` 

**Relates to:** [https://uktrade.atlassian.net/browse/TARIFFS-285](https://uktrade.atlassian.net/browse/TARIFFS-285)