### PR TITLE
Fix: Add custom styling to delete confirmation pop up

### DIFF
--- a/app/assets/javascripts/components/workbaskets/main_menu_interactions.js.coffee
+++ b/app/assets/javascripts/components/workbaskets/main_menu_interactions.js.coffee
@@ -9,12 +9,12 @@ window.MainMenuInteractions =
   deleteWorkbasketConfirmationPopupInit: () ->
     $(document).on 'click', '.js-main-menu-show-delete-confirmation-link', ->
       target_url = $(this).data("target-url")
-      confirm_link = $("#main-menu-delete_confirmation_popup .js-main-menu-confirm-action")
+      confirm_link = $("#main-menu-delete_confirmation_popup_" + $(this).data("target-modal") + " .js-main-menu-confirm-action")
       confirm_link.attr('href', target_url)
       confirm_link.attr('data-method', 'delete')
 
-      MainMenuInteractions.setSpinnerText("main-menu-delete_confirmation_popup", "Deletion")
-      MainMenuInteractions.openModal('main-menu-delete_confirmation_popup')
+      MainMenuInteractions.setSpinnerText("main-menu-delete_confirmation_popup_", + $(this).data("target-modal"), "Deletion")
+      MainMenuInteractions.openModal('main-menu-delete_confirmation_popup_' + $(this).data("target-modal"))
 
       return false
 

--- a/app/views/workbaskets/main_menu_parts/_actions.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_actions.html.slim
@@ -9,7 +9,10 @@
     class: "js-main-menu-show-withdraw-confirmation-link"
 - if show_delete?(workbasket)
   | &nbsp;|&nbsp;
-  = link_to "Delete", "#{workbasket.object.type}/#{workbasket.id}", data: { confirm: "Are you sure you want to delete this workbasket?" }, method: :delete
+  = link_to "Delete", "#",
+    data: { target_url:  workbasket_view_link_based_on_type(workbasket), target_modal: workbasket.id },
+    class: "js-main-menu-show-delete-confirmation-link"
+
 
 - if workbasket.can_continue_cross_check?(@current_user)
   | &nbsp;|&nbsp;
@@ -22,5 +25,5 @@
 
 
 = render "workbaskets/main_menu_parts/schedule_export_to_cds_popup"
-= render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "delete_confirmation_popup", title: "You are going to delete workbasket"
+= render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "delete_confirmation_popup_#{workbasket.id}", title: "You are going to delete workbasket"
 = render "workbaskets/main_menu_parts/withdraw_confirmation_popup", modal_id: "withdraw_confirmation_popup_#{workbasket.id}", workbasket: workbasket


### PR DESCRIPTION
Prior to this change, the delete confirmation pop up was the browser
default, this change uses a custom style consistent with other confirmation
popups.