### PR TITLE
Fix: Delete bulk edit button crashing app

### DIFF
--- a/app/controllers/additional_codes/bulks_controller.rb
+++ b/app/controllers/additional_codes/bulks_controller.rb
@@ -175,9 +175,9 @@ module AdditionalCodes
     end
 
     def destroy
-      workbasket.destroy
+      workbasket.clean_up_workbasket!
 
-      render json: {}, head: :ok
+      redirect_to root_url
     end
 
     def move_to_editing_mode

--- a/app/controllers/measures/bulks_controller.rb
+++ b/app/controllers/measures/bulks_controller.rb
@@ -159,9 +159,9 @@ module Measures
     end
 
     def destroy
-      workbasket.destroy
+      workbasket.clean_up_workbasket!
 
-      render json: {}, head: :ok
+      redirect_to root_url
     end
   end
 end

--- a/app/controllers/quotas/bulks_controller.rb
+++ b/app/controllers/quotas/bulks_controller.rb
@@ -372,9 +372,9 @@ module Quotas
     end
 
     def destroy
-      workbasket.destroy
+      workbasket.clean_up_workbasket!
 
-      render json: {}, head: :ok
+      redirect_to root_url
     end
 
   private


### PR DESCRIPTION
Prior to this change, bulk edit additional codes, bulk edit
measures and bulk edit quotas workbaskets have delete links
that do not link to a valid page which crashes the app

This change corrects the way in which 'bulks' controllers handle
deleting of workbaskets to ensure they redirect to the home page
and behave in the same way as other workbaskets.