### PR TITLE
Fix: Save the edit nomenclature wb setting as items

### DIFF
--- a/app/interactors/workbasket_interactions/edit_nomenclature/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/edit_nomenclature/settings_saver.rb
@@ -19,7 +19,9 @@ module WorkbasketInteractions
                     :goods_nomenclature_description_period,
                     :next_goods_nomenclature_description,
                     :next_goods_nomenclature_description_period,
-                    :persist
+                    :persist,
+                    :operation_date,
+                    :records
 
       def initialize(workbasket, current_step, save_mode, settings_ops = {})
         @workbasket = workbasket
@@ -37,10 +39,49 @@ module WorkbasketInteractions
       end
 
       def save!
-
         workbasket.save
         workbasket.settings.description = @settings_params[:description]
         workbasket.settings.save
+
+        create_nomenclature_description!
+      end
+
+      private
+
+      def create_nomenclature_description!
+        @records = []
+        original_nomenclature = Commodity.find(goods_nomenclature_sid: workbasket.settings.original_nomenclature)
+
+        GoodsNomenclatureDescriptionPeriod.unrestrict_primary_key
+        goods_nomenclature_description_period = GoodsNomenclatureDescriptionPeriod.new(
+          goods_nomenclature_sid: original_nomenclature.goods_nomenclature_sid,
+          goods_nomenclature_item_id: original_nomenclature.goods_nomenclature_item_id,
+          productline_suffix: original_nomenclature.producline_suffix,
+          validity_start_date: workbasket.settings.validity_start_date
+        )
+        ::WorkbasketValueObjects::Shared::PrimaryKeyGenerator.new(goods_nomenclature_description_period).assign!
+        goods_nomenclature_description_period_sid = goods_nomenclature_description_period.goods_nomenclature_description_period_sid
+        @records << goods_nomenclature_description_period
+
+        GoodsNomenclatureDescription.unrestrict_primary_key
+        goods_nomenclature_description = GoodsNomenclatureDescription.new(
+          language_id: 'EN',
+          goods_nomenclature_sid: original_nomenclature.goods_nomenclature_sid,
+          goods_nomenclature_item_id: original_nomenclature.goods_nomenclature_item_id,
+          productline_suffix: original_nomenclature.producline_suffix,
+          description: workbasket.settings.validity_start_date
+        )
+        @records << goods_nomenclature_description
+
+        operation_date = workbasket.settings.validity_start_date
+        save_nomenclature_description!
+      end
+
+      def save_nomenclature_description!
+        records.each do |record|
+          assign_system_ops!(record)
+          record.save
+        end
       end
 
     end

--- a/app/models/workbaskets/edit_nomenclature_settings.rb
+++ b/app/models/workbaskets/edit_nomenclature_settings.rb
@@ -21,5 +21,8 @@ module Workbaskets
       '{}'
     end
 
+    def clean_up_temporary_data!
+    end
+
   end
 end

--- a/app/value_objects/workbasket_value_objects/shared/primary_key_generator.rb
+++ b/app/value_objects/workbasket_value_objects/shared/primary_key_generator.rb
@@ -14,7 +14,9 @@ module WorkbasketValueObjects
         "QuotaSuspensionPeriod" => :quota_suspension_period_sid,
         "GeographicalArea" => :geographical_area_sid,
         "GeographicalAreaDescriptionPeriod" => :geographical_area_description_period_sid,
-        "CertificateDescriptionPeriod" => :certificate_description_period_sid
+        "CertificateDescriptionPeriod" => :certificate_description_period_sid,
+        "GoodsNomenclatureDescriptionPeriod" => :goods_nomenclature_description_period_sid,
+        "GoodsNomenclatureDescription" => :goods_nomenclature_description_sid
       }.freeze
 
       attr_accessor :record,

--- a/db/migrate/20190712143348_add_workbasket_fields_goods_nomenclature_description.rb
+++ b/db/migrate/20190712143348_add_workbasket_fields_goods_nomenclature_description.rb
@@ -1,0 +1,113 @@
+Sequel.migration do
+  up do
+    add_column :goods_nomenclature_description_periods_oplog, :added_by_id, Integer
+    add_column :goods_nomenclature_description_periods_oplog, :added_at, Time
+    add_column :goods_nomenclature_description_periods_oplog, :national, :boolean
+    add_column :goods_nomenclature_descriptions_oplog, :added_by_id, Integer
+    add_column :goods_nomenclature_descriptions_oplog, :added_at, Time
+    add_column :goods_nomenclature_descriptions_oplog, :national, :boolean
+
+    run %Q{
+
+CREATE OR REPLACE VIEW public.goods_nomenclature_description_periods AS
+ SELECT goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid,
+    goods_nomenclature_description_periods1.goods_nomenclature_sid,
+    goods_nomenclature_description_periods1.validity_start_date,
+    goods_nomenclature_description_periods1.goods_nomenclature_item_id,
+    goods_nomenclature_description_periods1.productline_suffix,
+    goods_nomenclature_description_periods1.validity_end_date,
+    goods_nomenclature_description_periods1.oid,
+    goods_nomenclature_description_periods1.operation,
+    goods_nomenclature_description_periods1.operation_date,
+    goods_nomenclature_description_periods1.status,
+    goods_nomenclature_description_periods1.workbasket_id,
+    goods_nomenclature_description_periods1.workbasket_sequence_number,
+    goods_nomenclature_description_periods1.added_by_id,
+    goods_nomenclature_description_periods1.added_at,
+    goods_nomenclature_description_periods1.national
+   FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods1
+  WHERE ((goods_nomenclature_description_periods1.oid IN ( SELECT max(goods_nomenclature_description_periods2.oid) AS max
+           FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods2
+          WHERE (goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid = goods_nomenclature_description_periods2.goods_nomenclature_description_period_sid))) AND ((goods_nomenclature_description_periods1.operation)::text <> 'D'::text));
+
+CREATE OR REPLACE VIEW public.goods_nomenclature_descriptions AS
+ SELECT goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid,
+    goods_nomenclature_descriptions1.language_id,
+    goods_nomenclature_descriptions1.goods_nomenclature_sid,
+    goods_nomenclature_descriptions1.goods_nomenclature_item_id,
+    goods_nomenclature_descriptions1.productline_suffix,
+    goods_nomenclature_descriptions1.description,
+    goods_nomenclature_descriptions1.oid,
+    goods_nomenclature_descriptions1.operation,
+    goods_nomenclature_descriptions1.operation_date,
+    goods_nomenclature_descriptions1.status,
+    goods_nomenclature_descriptions1.workbasket_id,
+    goods_nomenclature_descriptions1.workbasket_sequence_number,
+    goods_nomenclature_descriptions1.added_by_id,
+    goods_nomenclature_descriptions1.added_at,
+    goods_nomenclature_descriptions1.national
+   FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions1
+  WHERE ((goods_nomenclature_descriptions1.oid IN ( SELECT max(goods_nomenclature_descriptions2.oid) AS max
+           FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions2
+          WHERE ((goods_nomenclature_descriptions1.goods_nomenclature_sid = goods_nomenclature_descriptions2.goods_nomenclature_sid) AND (goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid = goods_nomenclature_descriptions2.goods_nomenclature_description_period_sid)))) AND ((goods_nomenclature_descriptions1.operation)::text <> 'D'::text));
+    }
+
+
+  end
+
+  down do
+
+    run %Q{
+
+DROP VIEW public.goods_nomenclature_description_periods;
+
+CREATE OR REPLACE VIEW public.goods_nomenclature_description_periods AS
+ SELECT goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid,
+    goods_nomenclature_description_periods1.goods_nomenclature_sid,
+    goods_nomenclature_description_periods1.validity_start_date,
+    goods_nomenclature_description_periods1.goods_nomenclature_item_id,
+    goods_nomenclature_description_periods1.productline_suffix,
+    goods_nomenclature_description_periods1.validity_end_date,
+    goods_nomenclature_description_periods1.oid,
+    goods_nomenclature_description_periods1.operation,
+    goods_nomenclature_description_periods1.operation_date,
+    goods_nomenclature_description_periods1.status,
+    goods_nomenclature_description_periods1.workbasket_id,
+    goods_nomenclature_description_periods1.workbasket_sequence_number
+   FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods1
+  WHERE ((goods_nomenclature_description_periods1.oid IN ( SELECT max(goods_nomenclature_description_periods2.oid) AS max
+           FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods2
+          WHERE (goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid = goods_nomenclature_description_periods2.goods_nomenclature_description_period_sid))) AND ((goods_nomenclature_description_periods1.operation)::text <> 'D'::text));
+
+DROP VIEW public.goods_nomenclature_descriptions;
+
+CREATE VIEW public.goods_nomenclature_descriptions AS
+ SELECT goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid,
+    goods_nomenclature_descriptions1.language_id,
+    goods_nomenclature_descriptions1.goods_nomenclature_sid,
+    goods_nomenclature_descriptions1.goods_nomenclature_item_id,
+    goods_nomenclature_descriptions1.productline_suffix,
+    goods_nomenclature_descriptions1.description,
+    goods_nomenclature_descriptions1.oid,
+    goods_nomenclature_descriptions1.operation,
+    goods_nomenclature_descriptions1.operation_date,
+    goods_nomenclature_descriptions1.status,
+    goods_nomenclature_descriptions1.workbasket_id,
+    goods_nomenclature_descriptions1.workbasket_sequence_number
+
+   FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions1
+  WHERE ((goods_nomenclature_descriptions1.oid IN ( SELECT max(goods_nomenclature_descriptions2.oid) AS max
+           FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions2
+          WHERE ((goods_nomenclature_descriptions1.goods_nomenclature_sid = goods_nomenclature_descriptions2.goods_nomenclature_sid) AND (goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid = goods_nomenclature_descriptions2.goods_nomenclature_description_period_sid)))) AND ((goods_nomenclature_descriptions1.operation)::text <> 'D'::text));
+
+    }
+
+    drop_column :goods_nomenclature_descriptions_oplog, :added_by_id
+    drop_column :goods_nomenclature_descriptions_oplog, :added_at
+    drop_column :goods_nomenclature_descriptions_oplog, :national
+    drop_column :goods_nomenclature_description_periods_oplog, :added_by_id
+    drop_column :goods_nomenclature_description_periods_oplog, :added_at
+    drop_column :goods_nomenclature_description_periods_oplog, :national
+
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3549,7 +3549,10 @@ CREATE TABLE public.goods_nomenclature_description_periods_oplog (
     operation_date timestamp without time zone,
     status text,
     workbasket_id integer,
-    workbasket_sequence_number integer
+    workbasket_sequence_number integer,
+    added_by_id integer,
+    added_at timestamp without time zone,
+    "national" boolean
 );
 
 
@@ -3569,7 +3572,10 @@ CREATE VIEW public.goods_nomenclature_description_periods AS
     goods_nomenclature_description_periods1.operation_date,
     goods_nomenclature_description_periods1.status,
     goods_nomenclature_description_periods1.workbasket_id,
-    goods_nomenclature_description_periods1.workbasket_sequence_number
+    goods_nomenclature_description_periods1.workbasket_sequence_number,
+    goods_nomenclature_description_periods1.added_by_id,
+    goods_nomenclature_description_periods1.added_at,
+    goods_nomenclature_description_periods1."national"
    FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods1
   WHERE ((goods_nomenclature_description_periods1.oid IN ( SELECT max(goods_nomenclature_description_periods2.oid) AS max
            FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods2
@@ -3612,7 +3618,10 @@ CREATE TABLE public.goods_nomenclature_descriptions_oplog (
     operation_date timestamp without time zone,
     status text,
     workbasket_id integer,
-    workbasket_sequence_number integer
+    workbasket_sequence_number integer,
+    added_by_id integer,
+    added_at timestamp without time zone,
+    "national" boolean
 );
 
 
@@ -3632,7 +3641,10 @@ CREATE VIEW public.goods_nomenclature_descriptions AS
     goods_nomenclature_descriptions1.operation_date,
     goods_nomenclature_descriptions1.status,
     goods_nomenclature_descriptions1.workbasket_id,
-    goods_nomenclature_descriptions1.workbasket_sequence_number
+    goods_nomenclature_descriptions1.workbasket_sequence_number,
+    goods_nomenclature_descriptions1.added_by_id,
+    goods_nomenclature_descriptions1.added_at,
+    goods_nomenclature_descriptions1."national"
    FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions1
   WHERE ((goods_nomenclature_descriptions1.oid IN ( SELECT max(goods_nomenclature_descriptions2.oid) AS max
            FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions2
@@ -12638,3 +12650,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20190212163200_add_user_id
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190320142706_create_session_audits.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190603135337_replace_all_additional_codes_view.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190625152340_create_edit_nomenclature_workbasket_settings.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20190712143348_add_workbasket_fields_goods_nomenclature_description.rb');

--- a/spec/features/workbasket/goods_nomenclature/goods_nomenclature_spec.rb
+++ b/spec/features/workbasket/goods_nomenclature/goods_nomenclature_spec.rb
@@ -4,12 +4,18 @@ RSpec.describe "edit description" do
 
 
   let! (:chapter) { create(:chapter, goods_nomenclature_item_id: '1200000000')}
+  let! (:heading) { create(:heading, goods_nomenclature_item_id: '1234000000')}
   let! (:commodity) { create(:commodity, :with_description, goods_nomenclature_item_id: '1234567890', indents: 4)}
   it "allows a description to be edited" do
-    skip #not yet ready
     visit(new_manage_nomenclature_path(item_id: commodity.goods_nomenclature_item_id, suffix: commodity.producline_suffix))
-    click_on("Cancel")
+    fill_in("What is the name of this workbasket?", with: "Test basket name")
+    fill_in("What is the reason for these changes?", with: "Test edit nom reason")
+    click_on("Continue")
 
+    fill_in("Enter new description", with: "Shiny new description")
+    click_on("Submit for cross-check")
+
+    expect(page).to have_content('Amended commodity code Shiny new description has been submitted for cross-check.')
 
   end
 end


### PR DESCRIPTION
Prior to this change, the workbasket was saving the data entered but not creating the items in the appropriate tables, e.g. goods_nomenclature_description and goods_nomenclature_description_period
tables.

This change saves the items in these tables.

https://uktrade.atlassian.net/browse/TARIFFS-203