### PR TITLE
Fix: display problem caused by my copy/paste :(

### DIFF
--- a/app/views/workbaskets/edit_nomenclature/submitted_for_cross_check.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/submitted_for_cross_check.html.slim
@@ -1,7 +1,7 @@
 .panel.panel--confirmation
   h3.heading-medium
     | Amended commodity description
-    =<> "\"#{workbasket.settings.description}\""
+    =<> "'#{workbasket.settings.description}'"
     | has been submitted for cross-check.
 
 br

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_approval_rejected.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_approval_rejected.html.slim
@@ -4,7 +4,7 @@
 
   h3.heading-medium
     | You indicated that the new Nomenclature
-    = workbasket.settings.description
+    =<> "'#{workbasket.settings.description}'"
     | had problems and has not been approved. The submitter has been notified.
 
 = render "workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
@@ -4,7 +4,7 @@
 
   h3.heading-medium
     | Nomenclature
-    = workbasket.settings.add_additional_code_description
+    =<> "'#{workbasket.settings.description}'"
     | has has been submitted for approval.
 
 = render "workbaskets/create_geographical_area/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_awaiting_cds_upload_create_new.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_awaiting_cds_upload_create_new.html.slim
@@ -4,7 +4,7 @@
 
   h3.heading-medium
     | Nomenclature description
-    = workbasket.settings.add_additional_code_description
+    =<> "'#{workbasket.settings.description}'"
     | has been approved. It is ready to be sent to CDS.
 
 = render "workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_awaiting_cds_upload_edit.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_awaiting_cds_upload_edit.html.slim
@@ -4,7 +4,7 @@
 
   h3.heading-medium
     | Nomenclature description
-    = workbasket.settings.add_additional_code_description
+    =<> "'#{workbasket.settings.description}'"
     | has been approved. It is ready to be sent to CDS.
 
 = render "workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_cross_check_rejected.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_cross_check_rejected.html.slim
@@ -4,7 +4,7 @@
 
   h3.heading-medium
     | You indicated that nomenclature
-    = workbasket.settings.description
+    =<> "'#{workbasket.settings.description}'"
     | has problems. It has not passed cross-check. The submitter has been notified.
 
 = render "workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_ready_for_approval.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_ready_for_approval.html.slim
@@ -4,7 +4,7 @@
 
   h3.heading-medium
     | Nomenclature
-    = workbasket.settings.description
+    =<> "'#{workbasket.settings.description}'"
     | has passed cross-check.
     br
     | It has not yet been submitted for approval.

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_ready_for_export.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_ready_for_export.html.slim
@@ -4,7 +4,7 @@
 
   h3.heading-medium
     | Nomenclature
-    = workbasket.settings.add_additional_code_description
+    =<> "'#{workbasket.settings.description}'"
     | is approved It has not yet been sent through to CDS and has not been scheduled for export.
 
 = render "workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"

--- a/spec/features/workbasket/goods_nomenclature/goods_nomenclature_spec.rb
+++ b/spec/features/workbasket/goods_nomenclature/goods_nomenclature_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "edit description" do
     fill_in("Enter new description", with: "Shiny new description")
     click_on("Submit for cross-check")
 
-    expect(page).to have_content('Amended commodity description "Shiny new description" has been submitted for cross-check.')
+    expect(page).to have_content("Amended commodity description 'Shiny new description' has been submitted for cross-check.")
 
   end
 end


### PR DESCRIPTION
Prior to this change, some edit nomenclature screens had a problem when
displaying the status information in the workflow.