### PR TITLE
Fix: Nomenclature tree bug for heading group

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -14,6 +14,7 @@ class Chapter < GoodsNomenclature
     Heading.actual
            .filter("goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE '__00______'", relevant_headings)
            .where(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
+           .order(Sequel.asc(:goods_nomenclatures__goods_nomenclature_item_id), Sequel.asc(:goods_nomenclatures__producline_suffix))
   }
 
   one_to_one :chapter_note, primary_key: :to_param

--- a/app/services/nomenclature_tree_service.rb
+++ b/app/services/nomenclature_tree_service.rb
@@ -27,8 +27,12 @@ class NomenclatureTreeService
     Sequel::Model.db.fetch(nomenclature_children_sql, "#{nomenclature_code[0..3]}______").each do |nomenclature|
       new_node = TreeNode.new(nomenclature[:goods_nomenclature_item_id], nomenclature)
       if root_node == nil
-        root_node = new_node
-        current_path = [root_node]
+        if nomenclature[:producline_suffix] != "10"
+          root_node = new_node
+          current_path = [root_node]
+        else
+          # item is a heading group - do nothing (e.g. see 7101000000 which has an item suffix 10 as a group heading)
+        end
       elsif (nomenclature[:number_indents] -1 == current_path[-1].content[:number_indents])
         # new_node is a child of the current path end
         current_path[-1].children << new_node

--- a/app/views/nomenclature/chapters/show.html.erb
+++ b/app/views/nomenclature/chapters/show.html.erb
@@ -44,7 +44,13 @@
             <tr>
               <th scope="row"><%= format_nomenclature_code(heading.goods_nomenclature_item_id) %></th>
               <th scope="row"><%= heading.producline_suffix == '80' ? '-' : heading.producline_suffix %></th>
-              <td><%= link_to heading.description, goods_nomenclature_path(heading.goods_nomenclature_item_id) %></a></td>
+              <td>
+                <% if heading.producline_suffix == '80' %>
+                  <%= link_to heading.description, goods_nomenclature_path(heading.goods_nomenclature_item_id) %></a>
+                <% else %>
+                  <%= heading.description %></a>
+                <% end %>
+              </td>
               <td>Manage</td>
             </tr>
             <%end %>


### PR DESCRIPTION
Prior to this change, if a Heading item (e.g. 710100000) had entries for bot producline_suffix 10 AND 80 an exception would be thrown.

This change treats headings with a suffix 10 as a 'heading group title'
See https://www.trade-tariff.service.gov.uk/chapters/71 for an example, where suffix 10 is displayed as a heading "I. NATURAL OR CULTURED PEARLS AND PRECIOUS OR SEMI-PRECIOUS STONES"

https://uktrade.atlassian.net/browse/TARIFFS-330