### PR TITLE
Fix: Description wasn't being correctly updated during edit.

### DIFF
--- a/app/interactors/workbasket_interactions/edit_nomenclature/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/edit_nomenclature/settings_saver.rb
@@ -66,10 +66,11 @@ module WorkbasketInteractions
         GoodsNomenclatureDescription.unrestrict_primary_key
         goods_nomenclature_description = GoodsNomenclatureDescription.new(
           language_id: 'EN',
+          goods_nomenclature_description_period_sid: goods_nomenclature_description_period.goods_nomenclature_description_period_sid,
           goods_nomenclature_sid: original_nomenclature.goods_nomenclature_sid,
           goods_nomenclature_item_id: original_nomenclature.goods_nomenclature_item_id,
           productline_suffix: original_nomenclature.producline_suffix,
-          description: workbasket.settings.validity_start_date
+          description: workbasket.settings.description
         )
         @records << goods_nomenclature_description
 


### PR DESCRIPTION
Prior to this change, the description was being assigned the validity date (copy and paste error while brain dead with cold)

This change correctly assigns the description.

https://uktrade.atlassian.net/browse/TARIFFS-333