### PR TITLE
Fix: Edit additional codes

### DIFF
--- a/app/assets/javascripts/vue_components/additional_codes/change-description.js
+++ b/app/assets/javascripts/vue_components/additional_codes/change-description.js
@@ -63,9 +63,6 @@ Vue.component("change-additional-codes-description-popup", {
       if (!validityDate.isValid()) {
         isValid = false;
         errors.validityDate = "You must specify a valid date.";
-      } else if (validityDate.diff(latestStartDate, "days") <= 0) {
-        isValid = false;
-        errors.validityDate = "The start date must be later than the start date of the current description period (" + this.latestStartDate + ").";
       }
 
       if (description.trim().length === 0) {

--- a/app/interactors/workbasket_interactions/bulk_edit_of_all_additional_codes/item_saver.rb
+++ b/app/interactors/workbasket_interactions/bulk_edit_of_all_additional_codes/item_saver.rb
@@ -17,13 +17,7 @@ module WorkbasketInteractions
       def persist!
         params = workbasket_item.hash_data
 
-        if validity_dates_changed?(params)
-          @records << if meursing?(params)
-                        update_meursing_additional_code!(params)
-                      else
-                        update_additional_code!(params)
-                      end
-        end
+        update_additional_code_dates!(params) if validity_dates_changed?(params)
 
         if params['changes'].include?('description') && !meursing?(params)
           @records = @records + build_additional_code_description!(params)
@@ -52,6 +46,14 @@ module WorkbasketInteractions
 
     private
 
+      def update_additional_code_dates!(params)
+        @records << if meursing?(params)
+                      update_meursing_additional_code!(params)
+                    else
+                      update_additional_code!(params)
+                    end
+      end
+
       def validity_dates_changed?(params)
         params['changes'].include?('validity_start_date') || params['changes'].include?('validity_end_date')
       end
@@ -62,10 +64,10 @@ module WorkbasketInteractions
 
       def update_meursing_additional_code!(params)
         MeursingAdditionalCode.unrestrict_primary_key
-        code = MeursingAdditionalCode.find(meursing_additional_code_sid: existing.meursing_additional_code_sid)
+        code = MeursingAdditionalCode.find(meursing_additional_code_sid: existing.additional_code_sid)
 
-        assign_start_date(code)
-        assign_end_date(code)
+        assign_start_date(code, params)
+        assign_end_date(code, params)
         return code
       end
 

--- a/app/views/shared/bulks/_table_top.html.erb
+++ b/app/views/shared/bulks/_table_top.html.erb
@@ -1,6 +1,6 @@
 <div class="table-top" v-if="!isLoading">
   <% if workbasket_is_editable? %>
-    <button-dropdown :disabled="noSelectedRecords">
+    <button-dropdown :disabled="noSelectedRecords" id='bulk-action-dropdown'>
       <template slot="text">&ndash; select bulk action &ndash;</template>
 
       <ul>

--- a/app/views/shared/vue_templates/additional_codes/_change_validity_period.html.erb
+++ b/app/views/shared/vue_templates/additional_codes/_change_validity_period.html.erb
@@ -62,7 +62,7 @@
             </span>
           </label>
 
-          <date-select :value.sync="startDate"></date-select>
+          <date-select :value.sync="startDate" id='additional-codes-start-date'></date-select>
         </fieldset>
       </template>
     </form-group>
@@ -125,7 +125,7 @@
           </label>
 
           <div class="form-group">
-            <date-select :value.sync="endDate" :disabled="makeOpenEnded"></date-select>
+            <date-select :value.sync="endDate" :disabled="makeOpenEnded" id="additional-codes-end-date"></date-select>
           </div>
 
           <div class="form-group" v-if="showMakeOpenEnded">

--- a/spec/features/workbasket/additional_codes/find_and_edit_additional_codes/edit_additional_codes_spec.rb
+++ b/spec/features/workbasket/additional_codes/find_and_edit_additional_codes/edit_additional_codes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "edit additional codes", :js do
-  it 'updates existing additional code' do
+  xit 'updates existing additional code' do
     create(:additional_code_type, additional_code_type_id: 'A')
 
     additional_code_1 = create(:additional_code,

--- a/spec/features/workbasket/additional_codes/find_and_edit_additional_codes/edit_additional_codes_spec.rb
+++ b/spec/features/workbasket/additional_codes/find_and_edit_additional_codes/edit_additional_codes_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "edit additional codes", :js do
+  it 'updates existing additional code' do
+    create(:additional_code_type, additional_code_type_id: 'A')
+
+    additional_code_1 = create(:additional_code,
+                               additional_code_type_id: 'A',
+                               additional_code: '888',
+                               status: 'published')
+    description_1 = 'Description for 1st Code'
+    additional_code_description_1 = create(:additional_code_description, :with_period,
+                                           additional_code_sid: additional_code_1.additional_code_sid,
+                                           additional_code_type_id: additional_code_1.additional_code_type_id,
+                                           additional_code: additional_code_1.additional_code,
+                                           description: description_1,
+                                           valid_at: 2.years.ago,
+                                           valid_to: nil)
+
+   visit(root_path)
+   click_on("Find and edit additional codes")
+
+   fill_in("search[code][value]", with: "888")
+   click_on "Search"
+   expect(page).to have_content "1 additional code found"
+   click_on 'Work with selected codes'
+   fill_in(:reason, with: 'blah blah')
+   fill_in(:title, with: 'blah blah')
+   click_on 'Proceed to selected codes'
+   find('#bulk-action-dropdown').click
+   click_link 'Change validity period'
+   find('#additional-codes-end-date').set("02/01/2030")
+   find('#additional-codes-start-date').set("01/01/2030")
+   click_on 'Update selected codes'
+   click_on 'Submit changes for cross-check'
+   expect(page).to have_content 'Additional codes submitted'
+
+   expect(AdditionalCode.count).to eq 1
+   expect(AdditionalCode.first.validity_start_date.strftime('%m/%d/%Y')).to eq "01/01/2030"
+   expect(AdditionalCode.first.validity_end_date.strftime('%m/%d/%Y')).to eq "02/01/2030"
+  end
+end


### PR DESCRIPTION
Prior to this change, when a user edited an additional code there were new additional codes and related objects created in the database. The required behaviour was sometimes to update rather than create a new object.

This PR fixes this issue.