### PR TITLE
Fix: Change words used to describe edit nomenclature

### DIFF
--- a/app/decorators/workbaskets/workbasket_decorator.rb
+++ b/app/decorators/workbaskets/workbasket_decorator.rb
@@ -31,7 +31,7 @@ module Workbaskets
       when "edit_geographical_area"
         "Edit Geographical Area"
       when "edit_nomenclature"
-        "Edit Nomenclature"
+        "Edit Goods Classification"
       end
     end
 

--- a/app/views/workbaskets/edit_nomenclature/submitted_for_cross_check.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/submitted_for_cross_check.html.slim
@@ -11,9 +11,9 @@ h3.heading-medium
 ul class="list"
   li
     a href="#"
-      | Withdraw submission / edit nomenclature (not implemented)
+      | Withdraw submission / edit goods classification (not implemented)
   li
-    = link_to "Edit another nomenclature", sections_url
+    = link_to "Edit another goods classification", sections_url
   li
     = link_to "Return to main menu", root_url
 br

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,2 +1,2 @@
 p
-  | You are about to edit nomenclature.
+  | You are about to edit goods classification.


### PR DESCRIPTION
Prior to this change, we said 'nomenclature'

This change changes to use 'goods classification'

https://uktrade.atlassian.net/browse/TARIFFS-326