### PR TITLE
Fix: Add compressed tag to meta data

### DIFF
--- a/app/views/xml_generation/templates/metadata.builder
+++ b/app/views/xml_generation/templates/metadata.builder
@@ -31,6 +31,10 @@ xml.tag!("BatchFileInterfaceMetadata", xmlns: "http://www.hmrc.gsi.gov.uk/mdg/ba
     xml_data_item(record, self.xml_file_size)
   end
 
+  env.tag!("compressed") do |record|
+    xml_data_item(record, self.class::COMPRESSED)
+  end
+
   env.tag!("sourceLocation") do |record|
     xml_data_item(record, self.class::SOURCE_LOCATION)
   end


### PR DESCRIPTION
Prior to this change the metadata xml file did not use the required
compressed tag. This change adds this to metadata xml.