### PR TITLE
Fix: only display description in nomenclature tree if description published

### DIFF
--- a/app/controllers/workbaskets/edit_nomenclature_controller.rb
+++ b/app/controllers/workbaskets/edit_nomenclature_controller.rb
@@ -36,10 +36,6 @@ module Workbaskets
         user: current_user
       )
 
-      workbasket_settings.update(
-        original_nomenclature_id: params[:nomenclature_id]
-      )
-
       redirect_to initial_step_url
     end
 

--- a/app/controllers/workbaskets/manage_nomenclatures_controller.rb
+++ b/app/controllers/workbaskets/manage_nomenclatures_controller.rb
@@ -33,11 +33,13 @@ module Workbaskets
       )
 
       if workbasket.save
+        original_nomenclature = find_original_nomenclature(workbasket_params[:original_nomenclature])
         workbasket.settings.update(
           workbasket_id: workbasket.id,
           workbasket_name: workbasket_params[:workbasket_name],
           reason_for_changes: workbasket_params[:reason_for_changes],
-          original_nomenclature: find_original_nomenclature(workbasket_params[:original_nomenclature]).goods_nomenclature_sid
+          original_nomenclature: original_nomenclature.goods_nomenclature_sid,
+          original_description: original_nomenclature.description
         )
       end
       workbasket

--- a/app/services/nomenclature_tree_service.rb
+++ b/app/services/nomenclature_tree_service.rb
@@ -13,6 +13,7 @@ class NomenclatureTreeService
              (select description
               from goods_nomenclature_descriptions
               where goods_nomenclature_sid = gn.goods_nomenclature_sid
+              and status = 'published'
               order by oid desc
               limit 1)
       from goods_nomenclatures gn

--- a/app/views/workbaskets/edit_nomenclature/show.html.erb
+++ b/app/views/workbaskets/edit_nomenclature/show.html.erb
@@ -58,7 +58,7 @@
                 Original description
               </summary>
               <div class="panel panel-border-narrow p-t-5 p-b-5">
-                <%= original_nomenclature.description %>
+                <%= workbasket_settings.original_description %>
               </div>
             </details>
           </td>

--- a/app/views/workbaskets/shared/steps/review_and_submit/_edit_nomenclatures.html.erb
+++ b/app/views/workbaskets/shared/steps/review_and_submit/_edit_nomenclatures.html.erb
@@ -47,7 +47,7 @@
               Original description
             </summary>
             <div class="panel panel-border-narrow p-t-5 p-b-5">
-              <%= original_nomenclature.description  %>
+              <%= workbasket_settings.original_description  %>
             </div>
           </details>
         </td>

--- a/db/migrate/20190725135752_add_original_description_to_edit_nomenclature_workbasket_settings.rb
+++ b/db/migrate/20190725135752_add_original_description_to_edit_nomenclature_workbasket_settings.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :edit_nomenclature_workbasket_settings do
+      add_column :original_description, String
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2100,7 +2100,8 @@ CREATE TABLE public.edit_nomenclature_workbasket_settings (
     original_nomenclature text,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    main_step_validation_passed boolean DEFAULT false
+    main_step_validation_passed boolean DEFAULT false,
+    original_description text
 );
 
 
@@ -12654,3 +12655,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20190603135337_replace_all
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190625152340_create_edit_nomenclature_workbasket_settings.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190712143348_add_workbasket_fields_goods_nomenclature_description.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20190716105325_add_main_step_validation_passed_to_edit_nomenclature_workbasket_settings.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20190725135752_add_original_description_to_edit_nomenclature_workbasket_settings.rb');

--- a/spec/factories/chapter_factory.rb
+++ b/spec/factories/chapter_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     goods_nomenclature_sid { generate(:goods_nomenclature_sid) }
     goods_nomenclature_item_id { "#{2.times.map { Random.rand(9) }.join}00000000" }
     validity_start_date { Date.today.ago(2.years) }
+    status { 'published' }
 
     trait :with_section do
       after(:create) { |chapter, _evaluator|
@@ -24,7 +25,8 @@ FactoryBot.define do
                           goods_nomenclature_item_id: chapter.goods_nomenclature_item_id,
                           validity_start_date: chapter.validity_start_date,
                           validity_end_date: chapter.validity_end_date,
-                          description: evaluator.description)
+                          description: evaluator.description,
+                          status: 'published')
       }
     end
 

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -16,12 +16,14 @@ FactoryBot.define do
     producline_suffix   { "80" }
     validity_start_date { Date.today.ago(2.years) }
     validity_end_date   { nil }
+    status              { 'published' }
 
     after(:build) { |gono, evaluator|
       FactoryBot.create(:goods_nomenclature_indent, goods_nomenclature_sid: gono.goods_nomenclature_sid,
                                                      validity_start_date: gono.validity_start_date,
                                                      validity_end_date: gono.validity_end_date,
-                                                     number_indents: evaluator.indents)
+                                                     number_indents: evaluator.indents,
+                                                     status: 'pubilshed')
     }
 
     trait :actual do
@@ -52,7 +54,8 @@ FactoryBot.define do
                                                             goods_nomenclature_item_id: gono.goods_nomenclature_item_id,
                                                             validity_start_date: gono.validity_start_date,
                                                             validity_end_date: gono.validity_end_date,
-                                                            description: evaluator.description)
+                                                            description: evaluator.description,
+                                                            status: 'published')
       }
     end
 
@@ -79,7 +82,8 @@ FactoryBot.define do
                            validity_start_date: commodity.validity_start_date,
                            validity_end_date: commodity.validity_end_date,
                            productline_suffix: commodity.producline_suffix,
-                           number_indents: evaluator.indents)
+                           number_indents: evaluator.indents,
+                           status: 'published')
       }
     end
 
@@ -101,7 +105,8 @@ FactoryBot.define do
                           goods_nomenclature_item_id: gono.goods_nomenclature_item_id,
                           validity_start_date: gono.validity_start_date,
                           validity_end_date: gono.validity_end_date,
-                          description: evaluator.description)
+                          description: evaluator.description,
+                          status: 'published')
       }
     end
 
@@ -142,7 +147,8 @@ FactoryBot.define do
                           goods_nomenclature_item_id: gono.goods_nomenclature_item_id,
                           validity_start_date: gono.validity_start_date,
                           validity_end_date: gono.validity_end_date,
-                          description: evaluator.description)
+                          description: evaluator.description,
+                          status: 'published')
       }
     end
 
@@ -154,6 +160,7 @@ FactoryBot.define do
     number_indents { Forgery(:basic).number }
     validity_start_date { Date.today.ago(3.years) }
     validity_end_date   { nil }
+    status { 'published' }
 
     trait :xml do
       goods_nomenclature_item_id     { Forgery(:basic).text(exactly: 2) }
@@ -184,13 +191,15 @@ FactoryBot.define do
     goods_nomenclature_sid { generate(:sid) }
     description { Forgery(:basic).text }
     goods_nomenclature_description_period_sid { generate(:sid) }
+    status { 'published'}
 
     before(:create) { |gono_description, evaluator|
       FactoryBot.create(:goods_nomenclature_description_period, goods_nomenclature_description_period_sid: gono_description.goods_nomenclature_description_period_sid,
                                                               goods_nomenclature_sid: gono_description.goods_nomenclature_sid,
                                                               goods_nomenclature_item_id: gono_description.goods_nomenclature_item_id,
                                                               validity_start_date: evaluator.validity_start_date,
-                                                              validity_end_date: evaluator.validity_end_date)
+                                                              validity_end_date: evaluator.validity_end_date,
+                                                              status: 'published')
     }
 
     trait :xml do


### PR DESCRIPTION
Prior to this change, the tree displayed descriptions even if they were
waiting for approval.

This change checks the status for published.

https://uktrade.atlassian.net/browse/TARIFFS-333