### PR TITLE
Fix: Change date inputs from selects to text fields

### DIFF
--- a/app/forms/workbasket_forms/edit_nomenclature_form.rb
+++ b/app/forms/workbasket_forms/edit_nomenclature_form.rb
@@ -5,12 +5,18 @@ module WorkbasketForms
 
     attr_accessor :original_nomenclature,
                   :description,
+                  :validity_start_date_day,
+                  :validity_start_date_month,
+                  :validity_start_date_year,
                   :validity_start_date
 
     def initialize(original_nomenclature, settings = {})
       @original_nomenclature = original_nomenclature
       @description = settings.present? ? settings[:description] : ""
       @validity_start_date = settings.present? ? settings[:validity_start_date] : nil
+      @validity_start_date_day = @validity_start_date.present? ? @validity_start_date.strftime("%d") : Date.tomorrow.strftime("%d")
+      @validity_start_date_month = @validity_start_date.present? ? @validity_start_date.strftime("%m") : Date.tomorrow.strftime("%m")
+      @validity_start_date_year = @validity_start_date.present? ? @validity_start_date.strftime("%Y") : Date.tomorrow.strftime("%Y")
     end
 
     def original_nomenclature_description

--- a/app/interactors/workbasket_interactions/edit_nomenclature/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/edit_nomenclature/settings_saver.rb
@@ -40,7 +40,7 @@ module WorkbasketInteractions
 
       def save!
         workbasket.settings.description = @settings_params[:description]
-        workbasket.settings.validity_start_date = Date.new(@settings_params["validity_start_date(1i)"].to_i, @settings_params["validity_start_date(2i)"].to_i, @settings_params["validity_start_date(3i)"].to_i)
+        workbasket.settings.validity_start_date = set_date
 
         workbasket.settings.save
         if valid?
@@ -56,6 +56,12 @@ module WorkbasketInteractions
       end
 
       private
+
+      def set_date
+        Date.new(@settings_params["validity_start_date_year"].to_i, @settings_params["validity_start_date_month"].to_i, @settings_params["validity_start_date_day"].to_i)
+      rescue ArgumentError
+        nil
+      end
 
       def validate!
         check_initial_validation_rules!

--- a/app/views/workbaskets/edit_nomenclature/edit.html.erb
+++ b/app/views/workbaskets/edit_nomenclature/edit.html.erb
@@ -79,7 +79,9 @@
                   <%= saver&.conformance_errors&.values[0] %>
                 </span>
               <% end %>
-              <%= f.input :validity_start_date, label: 'Description valid from date', :as => :date %>
+              <%= f.input :validity_start_date_day, label: 'Day', required: true  %>
+              <%= f.input :validity_start_date_month, label: 'Month', required: true %>
+              <%= f.input :validity_start_date_year, label: 'Year', required: true %>
             </div>
           </td>
         </tr>

--- a/app/views/workbaskets/manage_nomenclatures/new.html.erb
+++ b/app/views/workbaskets/manage_nomenclatures/new.html.erb
@@ -44,21 +44,21 @@
         </label>
       </div>
       <div class="multiple-choice">
-        <input type='radio' id="amend_description" class="radio-inline-group" name="workbasket_forms_manage_nomenclature_form[action]" value="amend_description">
+        <input type='radio' id="amend_description" class="radio-inline-group" name="workbasket_forms_manage_nomenclature_form[action]" value="amend_description" checked>
         <label for="amend_description">
           Amend description
         </label>
       </div>
       <div class="multiple-choice">
-        <input type='radio' id="new_nomenclature" class="radio-inline-group" name="workbasket_forms_manage_nomenclature_form[action]" value="new_nomenclature">
+        <input type='radio' id="new_nomenclature" class="radio-inline-group" name="workbasket_forms_manage_nomenclature_form[action]" value="new_nomenclature" disabled>
         <label for="new_nomenclature">
-          Add new code (structural)
+          Add new code (structural) (Not implemented)
         </label>
       </div>
       <div class="multiple-choice">
-        <input type='radio' id="remove_nomenclature" class="radio-inline-group" name="workbasket_forms_manage_nomenclature_form[action]" value="remove_nomenclature">
+        <input type='radio' id="remove_nomenclature" class="radio-inline-group" name="workbasket_forms_manage_nomenclature_form[action]" value="remove_nomenclature" disabled>
         <label for="remove_nomenclature">
-          Remove this code (structural)
+          Remove this code (structural) (Not implemented)
         </label>
       </div>
     </div>


### PR DESCRIPTION
Prior to this change, drop down selects were used.

This change uses text fields instead.