### PR TITLE
New: add conformance rule, nomenclature desc start date

### DIFF
--- a/app/validators/goods_nomenclature_description_period_validator.rb
+++ b/app/validators/goods_nomenclature_description_period_validator.rb
@@ -9,4 +9,8 @@ class GoodsNomenclatureDescriptionPeriodValidator < TradeTariffBackend::Validato
       (record.goods_nomenclature.validity_end_date >= record.validity_start_date)
     end
 
+  validation :NIG12, 'The start date must be later than or equal to the start date of the nomenclature.' do |record|
+    (record.goods_nomenclature.validity_start_date <= record.validity_start_date)
+  end
+
 end


### PR DESCRIPTION
Prior to this change, it was possible to create a description with a
start date earlier than the nomenclature code start date,

This change prevents that.

https://uktrade.atlassian.net/browse/TARIFFS-214