### PR TITLE
New: Extend selectize to support default value

### DIFF
--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -22,7 +22,8 @@ Vue.component('custom-select', {
     "disabled",
     "compact",
     "showCompactAbbreviation",
-    "scopeDate"
+    "scopeDate",
+    "defaultValue"
   ],
   data: function() {
     return {
@@ -33,7 +34,14 @@ Vue.component('custom-select', {
   },
   template: "#selectize-template",
   mounted: function () {
+    var vm = this;
+
     this.initializeSelect();
+    this.$nextTick(function () {
+      if (vm.defaultValue) {
+        this.applyValueInSelect(vm.defaultValue);
+      }
+    })
   },
   watch: {
     disabled: function(value) {

--- a/app/views/workbaskets/create_quota/steps/main/_order_number.html.slim
+++ b/app/views/workbaskets/create_quota/steps/main/_order_number.html.slim
@@ -5,11 +5,7 @@ fieldset
   .form-group
     label.form-label
       span.form-hint
-        | This is the code an importer would need to enter into their custom declaration to benefit from this tariff quota.
-        br
-        | It will be shared by all goods codes associated with this quota.
-        br
-        | Order number should start with '09' and can contain digits only. Could be 6 length only.
+        | This is the code an importer would need to enter into their custom declaration to benefit from this tariff quota. It will be shared by all goods codes associated with this quota. Order number should start with '09' and can contain digits only. Could be 6 length only.
 
     .row
       .col-xs-2.col-md-2.col-lg-2

--- a/app/views/workbaskets/create_quota/steps/main/_quota_precision.html.slim
+++ b/app/views/workbaskets/create_quota/steps/main/_quota_precision.html.slim
@@ -5,8 +5,8 @@ fieldset
   .form-group
     label.form-label
       span.form-hint
-        | This is the maximum number of decimal places that a trader can enter on the SAD form in respect of the quantity being imported under this quota. Unless explicitly otherwise specified, please enter the value “3” in the box below.
+        | This is the maximum number of decimal places that a trader can enter on the SAD form in respect of the quantity being imported under this quota. Unless explicitly otherwise specified, the default value is set to "3" in the box below.
 
     .bootstrap-row
       .col-xs-2.col-md-2.col-lg-1
-        custom-select id="maximum_precision" v-model="measure.quota_precision" :options="precisions" placeholder="—"
+        custom-select id="maximum_precision" v-model="measure.quota_precision" :options="precisions" placeholder="—" default-value="3"

--- a/spec/support/capybara_form_helper.rb
+++ b/spec/support/capybara_form_helper.rb
@@ -9,6 +9,8 @@ module CapybaraFormHelper
   end
 
   def search_for_value(type_value:, select_value:)
+    find(".selectize-control .selectize-input").click
+    find(".selectize-control input").set ''
     find(".selectize-control input").click.send_keys(type_value)
     find(".selectize-dropdown-content .option", text: select_value).click
   end


### PR DESCRIPTION
Prior to this change, we would not set a default value using
the custom-select vue component

This change introduces a new property that serves that scope

Resolves: [https://uktrade.atlassian.net/browse/TARIFFS-187](https://uktrade.atlassian.net/browse/TARIFFS-187)

**After**
<img width="911" alt="Screenshot 2019-07-29 at 14 29 22" src="https://user-images.githubusercontent.com/6704411/62052430-57de0d80-b20d-11e9-9bc4-77b7141b65a8.png">
