### PR TITLE
Show current nomenclature description

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -50,6 +50,12 @@ class GoodsNomenclature < Sequel::Model
       .order(Sequel.desc(:goods_nomenclature_indents__validity_start_date))
   end
 
+  one_to_many :goods_nomenclature_description_periods, key: :goods_nomenclature_sid,
+                                           primary_key: :goods_nomenclature_sid do |ds|
+    ds.with_actual(GoodsNomenclatureDescriptionPeriod, self)
+      .order(Sequel.desc(:goods_nomenclature_description_periods__validity_start_date))
+  end
+
   def goods_nomenclature_indent
     goods_nomenclature_indents(reload: true).first
   end
@@ -131,6 +137,18 @@ class GoodsNomenclature < Sequel::Model
 
   def to_s
     "#{number_indents}: #{goods_nomenclature_item_id}: #{description}"
+  end
+
+  def current_description_period
+    past_description_periods.sort_by {|period| period.validity_start_date}.last
+  end
+
+  def past_description_periods
+    goods_nomenclature_description_periods.select {|period| period.validity_start_date.to_date <= Date.today}
+  end
+
+  def current_description
+    goods_nomenclature_description.description
   end
 
   def heading_id

--- a/app/views/goods_nomenclatures/_tree_node_content.html.erb
+++ b/app/views/goods_nomenclatures/_tree_node_content.html.erb
@@ -1,5 +1,6 @@
+<% current_description = GoodsNomenclature.find(goods_nomenclature_sid: node.content[:goods_nomenclature_sid]).current_description %>
 <div class="row">
-  <div class="col-md-6"><%= node.content[:description] %></div>
+  <div class="col-md-6"><%= current_description %></div>
   <div class="col-md-1"><%= node.content[:producline_suffix] == '80' ? '-' : node.content[:producline_suffix] %></div>
   <div class="col-md-2"><%= format_nomenclature_code(node.content[:goods_nomenclature_item_id]) %></div>
   <div class="col-md-1"><%= link_to "Manage", new_manage_nomenclature_path(item_id: node.content[:goods_nomenclature_item_id], suffix: node.content[:producline_suffix]) %></div>

--- a/app/views/goods_nomenclatures/show.html.erb
+++ b/app/views/goods_nomenclatures/show.html.erb
@@ -15,13 +15,13 @@
                     <div class="chapter-code">
                       <div class="code-text"><%= @nomenclature.chapter.short_code %></div>
                     </div>
-                    <%= @nomenclature.chapter.description.capitalize %>
+                    <%= @nomenclature.chapter.current_description.capitalize %>
                     <ul>
                       <li class="chapter-li">
                         <div class="chapter-code">
                           <div class="code-text"><%= @nomenclature.short_code[2..3] %></div>
                         </div>
-                        <%= @nomenclature.description.capitalize %>
+                        <%= @nomenclature.current_description.capitalize %>
                       </li>
                     </ul>
                   </li>
@@ -43,5 +43,3 @@
   <%end %>
 
 <% end %>
-
-

--- a/app/views/nomenclature/chapters/show.html.erb
+++ b/app/views/nomenclature/chapters/show.html.erb
@@ -15,7 +15,7 @@
                   <div class="chapter-code">
                     <div class="code-text"><%= @chapter.short_code %></div>
                   </div>
-                  <%= @chapter.description.capitalize %>
+                  <%= @chapter.current_description.capitalize %>
                   </ul>
                 </li>
               </ul>
@@ -46,9 +46,9 @@
               <th scope="row"><%= heading.producline_suffix == '80' ? '-' : heading.producline_suffix %></th>
               <td>
                 <% if heading.producline_suffix == '80' %>
-                  <%= link_to heading.description, goods_nomenclature_path(heading.goods_nomenclature_item_id) %></a>
+                  <%= link_to heading.current_description, goods_nomenclature_path(heading.goods_nomenclature_item_id) %></a>
                 <% else %>
-                  <%= heading.description %></a>
+                  <%= heading.current_description %></a>
                 <% end %>
               </td>
               <td>Manage</td>

--- a/app/views/nomenclature/sections/show.html.erb
+++ b/app/views/nomenclature/sections/show.html.erb
@@ -33,7 +33,7 @@
             <% @section.chapters.each do |chapter| %>
             <tr>
               <th scope="row"><%= chapter.goods_nomenclature_item_id[0..1] %></th>
-              <td><%= link_to chapter.description.capitalize, chapter_path(chapter.goods_nomenclature_item_id) %></a></td>
+              <td><%= link_to chapter.current_description.capitalize, chapter_path(chapter.goods_nomenclature_item_id) %></a></td>
               <td>Manage</td>
             </tr>
             <%end %>


### PR DESCRIPTION
This change shows the user the currently accurate description for a goods commodity code. i.e if a change to the description is made, but it should not be applied until next year then it will not be shown until next year.

Previously, we were showing the latest description, regardless whether or not it was in it's validity period.