### PR TITLE
Fix: Add missing cross check heading

### DIFF
--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -282,7 +282,6 @@ label abbr {
   .multiple-choice {
     label {
       font-size: 1em !important;
-      max-width: 35em !important;
 
       span.form-hint {
         font-size: 1em !important;

--- a/app/helpers/cross_check_helper.rb
+++ b/app/helpers/cross_check_helper.rb
@@ -8,6 +8,8 @@ module CrossCheckHelper
       'Cross-check and create geographical area'
     elsif workbasket.type == 'create_additional_code'
       "Cross-check and create additional codes"
+    elsif workbasket.type == 'edit_nomenclature'
+      "Cross-check and edit goods classification"
     end
   end
 

--- a/app/views/workbaskets/create_measures/steps/review_and_submit/_details.html.slim
+++ b/app/views/workbaskets/create_measures/steps/review_and_submit/_details.html.slim
@@ -34,13 +34,13 @@ table.create-measures-details-table
 
     tr
       td.heading_column
-        | Goods
+        | Goods commodity
       td
         = attributes_parser.commodity_codes
 
     tr
       td.heading_column
-        | Goods exceptions
+        | Goods commodity exceptions
       td
         = attributes_parser.entered_exception_codes
 

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -25,16 +25,16 @@ table.create-measures-details-table
         | Type
       td
         = "#{workbasket.settings.main_step_settings['measure_type_id']} - #{attributes_parser.measure_type}"
-        
+
     tr
       td.heading_column
-        | Goods
+        | Goods commodity
       td
         = attributes_parser.commodity_codes
 
     tr
       td.heading_column
-        | Goods exceptions
+        | Goods commodity exceptions
       td
         = attributes_parser.entered_exception_codes
 

--- a/app/views/workbaskets/create_quota/steps/main/_order_number.html.slim
+++ b/app/views/workbaskets/create_quota/steps/main/_order_number.html.slim
@@ -5,7 +5,7 @@ fieldset
   .form-group
     label.form-label
       span.form-hint
-        | This is the code an importer would need to enter into their custom declaration to benefit from this tariff quota. It will be shared by all goods codes associated with this quota. Order number should start with '09' and can contain digits only. Could be 6 length only.
+        | This is the code an importer would need to enter into their custom declaration to benefit from this tariff quota. It will be shared by all goods commodity codes associated with this quota. Order number should start with '09' and can contain digits only. Could be 6 length only.
 
     .row
       .col-xs-2.col-md-2.col-lg-2

--- a/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
+++ b/app/views/workbaskets/create_quota/steps/review_and_submit/_details.html.slim
@@ -9,7 +9,7 @@ table.create-measures-details-table
         | Workbasket name
       td
         = workbasket.title
-        
+
     tr
       td.heading_column
         | Order number
@@ -42,13 +42,13 @@ table.create-measures-details-table
 
     tr
       td.heading_column
-        | Goods
+        | Goods commodity
       td
         = attributes_parser.commodity_codes
 
     tr
       td.heading_column
-        | Goods exceptions
+        | Goods commodity exceptions
       td
         = attributes_parser.entered_exception_codes
 

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -42,13 +42,13 @@ table.create-measures-details-table
 
     tr
       td.heading_column
-        | Goods
+        | Goods commodity
       td
         = attributes_parser.commodity_codes
 
     tr
       td.heading_column
-        | Goods exceptions
+        | Goods commodity exceptions
       td
         = attributes_parser.entered_exception_codes
 

--- a/app/views/workbaskets/workflows/approves/_form.html.slim
+++ b/app/views/workbaskets/workflows/approves/_form.html.slim
@@ -26,12 +26,12 @@ script
               .multiple-choice
                 input type='radio' id="approve-decision-approve" class="radio-inline-group" name="approve[mode]" value="approve" required="true"
                   label.with_bigger_font-size for="approve-decision-approve"
-                    | Approve.
+                    | I confirm that I have checked the above details and am satisfied that they are correct.
             .approve-decision
               .multiple-choice
                 input type='radio' id="approve-decision-reject" class="radio-inline-group" name="approve[mode]" value="reject" required="true"
                   label.with_bigger_font-size for="approve-decision-reject"
-                    | I am not happy.
+                    | I am not satisfied with the above details.
 
               .panel.panel-border-narrow.hidden.js-approve-reject-details-block id="approval-rejection-reason"
                 label.form-label for="approve_reject_reasons"

--- a/app/views/workbaskets/workflows/cross_checks/_form.html.slim
+++ b/app/views/workbaskets/workflows/cross_checks/_form.html.slim
@@ -25,14 +25,14 @@ script
             .multiple-choice
               input type='radio' id="radioID" class="radio-inline-group js-cross-check-decision" name="cross_check[mode]" value="approve" required="true"
                 label.with_bigger_font-size for='radioID'
-                  | I confirm that I have checked the above details and am satisfied this has been configured correctly and reflect the requirements.
+                  | I confirm that I have checked the above details and am satisfied that they are correct.
                   span.form-hint.with_bigger_font-size
-                    | Selecting this option will have the system generate the measure(s). There will be a further approval step before they are sent to CDS.
+                    | There will be a further approval step before they are sent to CDS.
           .cross-check-decision
             .multiple-choice
               input type='radio' id="radioID2" class="radio-inline-group js-cross-check-decision" name="cross_check[mode]" value="reject" required="true"
                 label.with_bigger_font-size for='radioID2'
-                  | I am not happy.
+                  | I am not satisfied with the above details.
 
             .panel.panel-border-narrow.hidden.js-cross-check-reject-details-block id="cross-check-rejection-reason"
               label.form-label for="rejection_reason"

--- a/app/views/workbaskets/workflows/cross_checks/new.html.slim
+++ b/app/views/workbaskets/workflows/cross_checks/new.html.slim
@@ -5,7 +5,7 @@
 
     li
       = underlying_object_link
-      
+
     li aria-current="page"
       = cross_check_title(workbasket)
 

--- a/spec/features/workbasket/cross_check_and_approval/cross_check_and_approval_spec.rb
+++ b/spec/features/workbasket/cross_check_and_approval/cross_check_and_approval_spec.rb
@@ -121,21 +121,21 @@ RSpec.describe 'cross check', :js do
   end
 
   def select_approve
-    find("label", text:'I confirm that I have checked the above details and am satisfied this has been configured correctly and reflect the requirements.').click
+    find("label", text:'I confirm that I have checked the above details and am satisfied that they are correct.').click
   end
 
   def select_reject_and_give_reason
-    find("label", text:'I am not happy').click
+    find("label", text:'I am not satisfied with the above details.').click
     fill_in("Provide your reasons and/or state the changes required:", with: "Computer says no")
   end
 
   def confirm_approval
-    find("label", text:'Approve.').click
+    find("label", text:'I confirm that I have checked the above details and am satisfied that they are correct.').click
     click_button 'Finish approval'
   end
 
   def reject_approval
-    find("label", text:'I am not happy').click
+    find("label", text:'I am not satisfied with the above details.').click
     fill_in("Provide your reasons and/or state the changes required:", with: "Computer says no")
     click_button 'Finish approval'
   end

--- a/spec/features/workbasket/measure/measure_creation_approval_spec.rb
+++ b/spec/features/workbasket/measure/measure_creation_approval_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "approval process for a Create Measure workbasket", :js do
     workbasket = workbasket_creating_measure(status: :awaiting_cross_check)
 
     visit new_cross_check_path(workbasket.id)
-    select_radio(/I confirm that I have checked the above details?/i)
+    select_radio(/I confirm that I have checked the above details and am satisfied that they are correct.?/i)
     click_on("Finish cross-check")
 
     expect(page).to have_content "Measures cross-checked"
@@ -22,7 +22,7 @@ RSpec.describe "approval process for a Create Measure workbasket", :js do
     workbasket = workbasket_creating_measure(status: :awaiting_cross_check)
 
     visit new_cross_check_path(workbasket.id)
-    select_radio('I am not happy.')
+    select_radio('I am not satisfied with the above details.')
     click_on("Finish cross-check")
 
     message = page.find("#rejection_reason").native.attribute("validationMessage")
@@ -39,7 +39,7 @@ RSpec.describe "approval process for a Create Measure workbasket", :js do
     workbasket = workbasket_creating_measure(status: :awaiting_approval)
 
     visit new_approve_path(workbasket.id)
-    find("label", text:'Approve.').click
+    find("label", text:'I confirm that I have checked the above details and am satisfied that they are correct.').click
     click_on("Finish approval")
 
     expect(page).to have_content "Measures approved"
@@ -50,7 +50,7 @@ RSpec.describe "approval process for a Create Measure workbasket", :js do
 
     visit new_approve_path(workbasket.id)
 
-    find("label", text:'I am not happy.').click
+    find("label", text:'I am not satisfied with the above details.').click
     click_on("Finish approval")
 
     message = page.find("#approve_reject_reasons").native.attribute("validationMessage")


### PR DESCRIPTION
Prior to this change, there was no heading on cross-check
nomenclature page.

This change adds the missing case. Further more with this commit
there were some more copy changes/fixes taken place on confirmation
/reject labels

Resolves [TARIFFS-331](https://uktrade.atlassian.net/browse/TARIFFS-331), [TARIFFS-112](https://uktrade.atlassian.net/browse/TARIFFS-112)

**AFTER**

> <img width="827" alt="Screenshot 2019-07-30 at 14 22 20" src="https://user-images.githubusercontent.com/6704411/62137346-b4106280-b2dd-11e9-94a5-b93c87a72b09.png">

> <img width="847" alt="Screenshot 2019-07-30 at 14 22 10" src="https://user-images.githubusercontent.com/6704411/62137347-b4106280-b2dd-11e9-9fef-9084c679e194.png">

> <img width="822" alt="Screenshot 2019-07-30 at 14 21 53" src="https://user-images.githubusercontent.com/6704411/62138048-e1a9db80-b2de-11e9-9084-9051690a9e7a.png">

> <img width="755" alt="Screenshot 2019-07-30 at 14 20 53" src="https://user-images.githubusercontent.com/6704411/62137349-b4a8f900-b2dd-11e9-94d8-aac543af463f.png">
