### PR TITLE
Add a warning message when selecting rows for editing

### DIFF
--- a/app/views/shared/vue_templates/_bulk_edit_records.html.erb
+++ b/app/views/shared/vue_templates/_bulk_edit_records.html.erb
@@ -3,6 +3,15 @@
   <div class="bulk-edit-records">
     <%= render "shared/bulks/table_top" %>
 
+    <div class="notice m-t-30  m-b-30" v-if="!noSelectedRecords">
+      <i class="icon icon-important">
+        <span class="visually-hidden">Warning</span>
+      </i>
+      <strong class="bold-small">
+        Changes will only apply to selected rows.
+      </strong>
+    </div>
+
     <div v-if="pagination.total_count > 0">
       <records-grid :table-class="tableClass" :primary-key="primaryKey" :on-item-selected="onItemSelected" :on-item-deselected="onItemDeselected" :data="visibleRecordsPage" :columns="columns" :selected-rows="selectedRecords" v-if="!isLoading" selection-type="none" :client-selection="true" :on-select-all-changed="selectAllHasChanged" :disable-scroller="true" :sort-by-changed="onSortByChange" :sort-dir-changed="onSortDirChanged"></records-grid>
 


### PR DESCRIPTION
Display a warning message when selecting rows to for applying changes
on bulk editing

**Resolves:**  [TARIFFS-301](https://uktrade.atlassian.net/browse/TARIFFS-301)

**Before:**
<img width="1050" alt="Screenshot 2019-07-31 at 09 58 15" src="https://user-images.githubusercontent.com/6704411/62199545-942f7c00-b37b-11e9-92bc-37f9f15d852c.png">

**After**
<img width="1051" alt="Screenshot 2019-07-31 at 09 57 52" src="https://user-images.githubusercontent.com/6704411/62199564-9f82a780-b37b-11e9-8770-a0810c83f272.png">
<img width="1026" alt="Screenshot 2019-07-31 at 09 57 47" src="https://user-images.githubusercontent.com/6704411/62199565-9f82a780-b37b-11e9-9cb8-672bfe7fea92.png">
