### PR TITLE
Fix: Show correct breadcrumbs for nomenclature workbaskets

### DIFF
--- a/app/helpers/workbasket_workflow_helper.rb
+++ b/app/helpers/workbasket_workflow_helper.rb
@@ -37,6 +37,8 @@ module WorkbasketWorkflowHelper
       link_to "Additional Codes", additional_codes_url
     elsif workbasket.type.include?("quot")
       link_to "Quotas", quotas_url
+    elsif workbasket.type.include?("nomenclature")
+      link_to "Goods classification", sections_url
     else
       link_to "Measures", measures_url
     end


### PR DESCRIPTION
Prior to this change, when a user was editing a nomenclature workbasket
the breadcrumbs linked to 'measures'.

This commit shows the correct 'Goods classification' link.