### PR TITLE
Fix: Oauth security issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem "font-awesome-rails"
 # Single sign on
 gem 'omniauth-oauth2'
 
+# needed to mitigate against CVE-2015-9284
+gem 'omniauth-rails_csrf_protection', '~> 0.1'
+
 # File uploads and AWS
 gem "shrine"
 gem "aws-sdk-rails"

--- a/app/controllers/log_in_controller.rb
+++ b/app/controllers/log_in_controller.rb
@@ -1,0 +1,3 @@
+class LogInController < ApplicationController
+  skip_before_action :authenticate_user!
+end

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -26,14 +26,14 @@ module AuthHelper
     @current_user = current_user
     if user_signed_in?
       if token_expired?
-        redirect_to login_path
+        redirect_to log_in_path
       end
       if current_user.disabled?
         redirect_to disabled_user_path
       end
       audit_session(current_user, request.original_url)
     else
-      redirect_to login_path
+      redirect_to log_in_path
     end
   end
 
@@ -46,14 +46,12 @@ module AuthHelper
 
 
   # The login page depends on the authentication provider [ditsso internal or the omniauth developer]
-  def login_path
-
+  def oauth_login_path
     if ENV['DITSSO_INTERNAL_PROVIDER'].present?
       '/auth/ditsso_internal/'
     else
       '/auth/developer/'
     end
-
   end
 
   def logout_path

--- a/app/views/log_in/index.html.erb
+++ b/app/views/log_in/index.html.erb
@@ -1,0 +1,1 @@
+<%= button_to("Log In", oauth_login_path) %>


### PR DESCRIPTION
This change is needed to mitigate against CVE-2015-9284. Installing the gem and
changing the get requests to our sso to post requests.

Our application running `authenticate_user!` before every controller action
so we cannot simply change the get requests made to our oauth provider to post requests
because we are redirecting all requests there if user is not logged in. Instead I have
added a simple view with a log in button to allow us to make post requests to our
oauth provider.