### PR TITLE
Fix: display the footnotes correctly for nomenclature edit

### DIFF
--- a/app/views/workbaskets/edit_nomenclature/edit.html.erb
+++ b/app/views/workbaskets/edit_nomenclature/edit.html.erb
@@ -100,6 +100,7 @@
         <tr>
           <td class="bold-small">Footnotes</td>
           <td>
+            <%= original_nomenclature.footnotes.map(&:code).join(", ") %>
           </td>
         </tr>
         <tr>

--- a/app/views/workbaskets/edit_nomenclature/show.html.erb
+++ b/app/views/workbaskets/edit_nomenclature/show.html.erb
@@ -84,6 +84,7 @@
         <tr>
           <td class="heading_column">Footnotes</td>
           <td>
+            <%= original_nomenclature.footnotes.map(&:code).join(", ") %>
           </td>
         </tr>
         <tr>

--- a/app/views/workbaskets/shared/steps/review_and_submit/_edit_nomenclatures.html.erb
+++ b/app/views/workbaskets/shared/steps/review_and_submit/_edit_nomenclatures.html.erb
@@ -73,6 +73,7 @@
       <tr>
         <td class="heading_column">Footnotes</td>
         <td>
+          <%= original_nomenclature.footnotes.map(&:code).join(", ") %>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Prior to this change, the footnotes were not being displayed

This change displays all the footnotes for the nomenclature.

https://uktrade.atlassian.net/browse/TARIFFS-327