### PR TITLE
New: Find Measures when viewing Nomenclatures

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -59,7 +59,20 @@ module CommoditiesHelper
     end
   end
 
-private
+  def search_in_measures_by_commodity_rule(item)
+    {
+      search: {
+        commodity_code: {
+          enabled: "1",
+          operator: "is",
+          value: item[:goods_nomenclature_item_id]
+        }
+      }
+    }
+  end
+
+
+  private
 
   def chapter_and_heading_codes(code)
     "<div class='chapter-code'>

--- a/app/views/goods_nomenclatures/_tree_node_content.html.erb
+++ b/app/views/goods_nomenclatures/_tree_node_content.html.erb
@@ -4,5 +4,5 @@
   <div class="col-md-1"><%= node.content[:producline_suffix] == '80' ? '-' : node.content[:producline_suffix] %></div>
   <div class="col-md-2"><%= format_nomenclature_code(node.content[:goods_nomenclature_item_id]) %></div>
   <div class="col-md-1"><%= link_to "Manage", new_manage_nomenclature_path(item_id: node.content[:goods_nomenclature_item_id], suffix: node.content[:producline_suffix]) %></div>
-  <div class="col-md-2"><a href="#">View measures</a></div>
+  <div class="col-md-2"><%= link_to "View measures", quick_search_measures_url(search_in_measures_by_commodity_rule(node.content)) %></div>
 </div>


### PR DESCRIPTION
This change creates a 'View measures' link when viewing nomenclatures.
The link will open up the measures search page with the commodity code
prefilled and listing matching measures.

https://uktrade.atlassian.net/browse/TARIFFS-325