### PR TITLE
Fix: Only display published nomenclature description

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -66,6 +66,7 @@ class GoodsNomenclature < Sequel::Model
                                                  right_key: %i[goods_nomenclature_description_period_sid goods_nomenclature_sid],
                                                  right_primary_key: %i[goods_nomenclature_description_period_sid goods_nomenclature_sid] do |ds|
     ds.with_actual(GoodsNomenclatureDescriptionPeriod, self)
+      .where(goods_nomenclature_descriptions__status: 'published')
       .order(Sequel.desc(:goods_nomenclature_description_periods__validity_start_date))
   end
 


### PR DESCRIPTION
Prior to this change, any nomenclature description would be displayed
even if it had not yet been approved and published.

This change will only display descriptions with the status 'published'

https://uktrade.atlassian.net/browse/TARIFFS-333