### PR TITLE
Fix: Create user from SSO bug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,7 @@ class User < Sequel::Model
     else
       Rails.logger.debug "user does not exist in system"
       Rails.logger.debug user_params_from_auth(auth)
+      User.unrestrict_primary_key
       user = create(user_params_from_auth(auth))
     end
 
@@ -53,6 +54,7 @@ class User < Sequel::Model
 
     # return a set of parameters to create the user record
     {
+        'id' => User.last.id + 1,
         'uid' => auth.uid,
         'email' => auth.info.email,
         # perhaps add these separate fields in the future?


### PR DESCRIPTION
Prior to this change, when a user was created in our db by signing into the dit sso for
the first time the user did not get assigned an id and it caused the application to crash.

This commit assigns an id when creating a new user and fixes the issue.