### PR TITLE
Fix: Display 'Cross-check next workbasket' if available

### DIFF
--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -3,11 +3,11 @@ h3.heading-medium
   | Next steps
 
 ul class="list"
-  - if mode == "cross_check" && next_cross_check.present? && workbasket.id != next_cross_check.id
+  - if next_cross_check.present? && workbasket.id != next_cross_check.id
     li
       = link_to "Cross-check next workbasket", new_cross_check_url(next_cross_check.id)
 
-  - if mode == "approve" && next_approve.present? && workbasket.id != next_approve.id
+  - if next_approve.present? && workbasket.id != next_approve.id
     li
       = link_to "Approve next workbasket", new_approve_url(next_approve.id)
 


### PR DESCRIPTION
Prior to this change, there was a bug that the code would check for mode
== 'cross-check' but mode is always 'approve' (i.e. it's the action
approve/reject, not whether you are cross checking.)

This change no longer checks what mode it is. The link will show whether
you approved or rejected the basket.

https://uktrade.atlassian.net/browse/TARIFFS-346