### PR TITLE
Fix: Remove "(not implemented)" from withdrawal link

### DIFF
--- a/app/views/workbaskets/edit_nomenclature/submitted_for_cross_check.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/submitted_for_cross_check.html.slim
@@ -11,7 +11,7 @@ h3.heading-medium
 ul class="list"
   li
     a href="#"
-      | Withdraw submission / edit goods classification (not implemented)
+      | Withdraw submission / edit goods classification
   li
     = link_to "Edit another goods classification", sections_url
   li


### PR DESCRIPTION
Prior to this change, when submitting workbasket for edit nomenclature the link for 'withdraw' said it was not implemented but this has now been completed.

This change removes the 'not implemented' text.

https://uktrade.atlassian.net/browse/TARIFFS-371