### PR TITLE
Remove formatting from regulations

### DIFF
--- a/app/models/base_regulation.rb
+++ b/app/models/base_regulation.rb
@@ -62,7 +62,8 @@ class BaseRegulation < Sequel::Model
     year = Date.strptime(base_regulation_id.slice(1, 2), "%y").strftime("%Y");
     number = base_regulation_id.slice(3, 4)
 
-    "#{year}/#{number}"
+    # "#{year}/#{number}"
+    base_regulation_id
   end
 
   def to_json(_options = {})

--- a/app/models/modification_regulation.rb
+++ b/app/models/modification_regulation.rb
@@ -40,7 +40,8 @@ class ModificationRegulation < Sequel::Model
     year = Date.strptime(modification_regulation_id.slice(1, 2), "%y").strftime("%Y");
     number = modification_regulation_id.slice(3, 4)
 
-    "#{year}/#{number}"
+    # "#{year}/#{number}"
+    modification_regulation_id
   end
 
   def last_fts_regulation


### PR DESCRIPTION
Show regulation format as  8 digits field to be consistent. 

Resolves:[https://uktrade.atlassian.net/browse/TARIFFS-359](https://uktrade.atlassian.net/browse/TARIFFS-359)