### PR TITLE
Fix: Temporarily disable find and edit regulations

### DIFF
--- a/app/views/workbaskets/main_menu_parts/_main_menu.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_main_menu.html.slim
@@ -2,7 +2,7 @@
   .bootstrap-row
     .col-xs-12.col-sm-12.col-md-4.col-lg-3
       p
-        = link_to "Find and edit regulations", regulations_path
+        = "Find and edit regulations (temporarily disabled)"
     .col-xs-12.col-sm-12.col-md-4.col-lg-3
       p
         = link_to "Create a new regulation", new_create_regulation_url

--- a/spec/features/regulations_listing_spec.rb
+++ b/spec/features/regulations_listing_spec.rb
@@ -18,7 +18,7 @@ describe "Regulations listing" do
     create(:base_regulation, validity_start_date: 1.year.ago)
   end
 
-  it "Find a regulation page" do
+  xit "Find a regulation page" do
     visit root_url
     expect(page).to have_link("Find and edit regulations")
 
@@ -33,7 +33,7 @@ describe "Regulations listing" do
     expect(page).to have_content("If you know the ID of the regulation, then you can enter the ID in the box below. Alternatively, enter any other keyword(s) to help locate the regulation.")
   end
 
-  it "Search params for a regulation" do
+  xit "Search params for a regulation" do
     visit regulations_path
 
     select("Various", from: "Select the regulation group")


### PR DESCRIPTION
The find and edit regulations page does not load due to missing data from HMRC in some explicit abrogation regulations (and perhaps others).

This change disables the find and edit regulations link until we receive correct data.