### PR TITLE
Fix: After approval on nomenclature a user could CC a basket 

### DIFF
--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -3,7 +3,7 @@ h3.heading-medium
   | Next steps
 
 ul class="list"
-  - if next_cross_check.present? && workbasket.id != next_cross_check.id
+  - if !current_user.approver_user && next_cross_check.present? && workbasket.id != next_cross_check.id
     li
       = link_to "Cross-check next workbasket", new_cross_check_url(next_cross_check.id)
 


### PR DESCRIPTION
despite being an approver, not a cross checker.

This change displays 'cross check next workbasket' link only for those
who are not an approver.

https://uktrade.atlassian.net/browse/TARIFFS-346