### PR TITLE
Fix: Nomenclature search didn't handle invalid searches well.

### DIFF
--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -20,7 +20,7 @@ class GoodsNomenclaturesController < ApplicationController
 
   def show
     set_nomenclature_view_date
-    @search_value = params[:id]
+    @search_value = params[:id].delete('^0-9')
     @nomenclature = GoodsNomenclature.actual.where(goods_nomenclature_item_id: @search_value).first.try(:sti_instance)
     @nomenclature_tree = NomenclatureTreeService.nomenclature_tree(params[:id], @view_date)
 

--- a/app/views/goods_nomenclatures/show.html.erb
+++ b/app/views/goods_nomenclatures/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for :content do %>
-  <%= render partial: "nomenclature/sections_header", locals: {change_date_base_path: goods_nomenclature_path(@nomenclature.goods_nomenclature_item_id) } %>
-
   <% if @errors.present? %>
+    <%= render partial: "nomenclature/sections_header", locals: {change_date_base_path: goods_nomenclatures_path } %>
     <%= @errors %>
   <% else %>
+    <%= render partial: "nomenclature/sections_header", locals: {change_date_base_path: goods_nomenclature_path(@nomenclature.goods_nomenclature_item_id) } %>
     <div class="grid-row">
       <div class="column-three-quarters">
         <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt font-xsmall">


### PR DESCRIPTION
Prior to this change, entering a code with spaces, or an invalid code
would throw an exception.

This change removes any non-digit values and handles an invalid code
without throwing an exception.