### PR TITLE
Fix: warning copy on cross check pages

### DIFF
--- a/app/helpers/approval_helper.rb
+++ b/app/helpers/approval_helper.rb
@@ -24,6 +24,12 @@ module ApprovalHelper
       "workbaskets/shared/steps/review_and_submit/approval/additional_code"
     elsif workbasket.type == 'edit_nomenclature'
       "workbaskets/shared/steps/review_and_submit/approval/edit_nomenclatures"
+    elsif workbasket.type == 'bulk_edit_of_measures'
+      "workbaskets/shared/steps/review_and_submit/approval/bulk_edit_measures"
+    elsif workbasket.type == 'bulk_edit_of_additional_codes'
+      "workbaskets/shared/steps/review_and_submit/approval/bulk_edit_additional_codes"
+    elsif workbasket.type == 'edit_geographical_area'
+      "workbaskets/shared/steps/review_and_submit/approval/geographical_areas"
     end
   end
 end

--- a/app/views/measures/bulks/work_with_selected_measures.html.erb
+++ b/app/views/measures/bulks/work_with_selected_measures.html.erb
@@ -1,6 +1,22 @@
+<div class="breadcrumbs">
+  <nav>
+    <ol>
+      <li>
+       <%= link_to "Tariff Management", root_url %>
+      </li>
+      <li>
+        <%= link_to "Measures", measures_url %>
+      </li>
+      <li>
+          Bulk edit measures
+      </li>
+    </ol>
+  </nav>
+</div>
+
 <div class="work-with-selected-measures">
   <%= form_tag({}, { method: :post }) do %>
-    <h1 class="heading-xlarge">
+    <h1 class="heading-large">
       Work with selected measures
     </h1>
 
@@ -86,8 +102,6 @@
       </div>
     </div>
 
-    <br>
-
     <div class="form-group">
       <button type="submit" class="button" :disabled="disableSubmit">
         Proceed to selected measures
@@ -95,10 +109,10 @@
       <a href="/" class="secondary-button">
         Cancel
       </a>
-      <br>
-      <label for="" class="form-label"><span class="form-hint">
+
+      <span class="form-hint m-t-20">
         When you proceed, the regulation (if any) and start date specified above will be applied to all of the selected measures. You will be able to edit those fields for any or all of the measures if you need to.
-      </span></label>
+      </span>
     </div>
   <% end %>
 </div>

--- a/app/views/workbaskets/bulk_edit_of_additional_codes/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_additional_codes/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,4 +1,2 @@
 p
-  | You are about to update
-  =< pluralize(workbasket.items.count, "additional code", "additional codes")
-  |.
+  | Please check that the amendments below are as intended and correctly reflect the requirement, then either confirm or reject.

--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -2,17 +2,6 @@
 - additional_codes_count = workbasket_settings.additional_codes_covered.compact.count
 
 p
-  | You are about to update
-  =< pluralize(workbasket.items.count, "measure", "measures")
-  | , covering
-
-  - msg = []
-  - if commodity_codes_count > 0
-    - msg << pluralize(commodity_codes_count, "commodity code", "commodity codes")
-  - if additional_codes_count > 0
-    - msg << pluralize(additional_codes_count, "additional code", "additional codes")
-  =< msg.join(" and ")
-
-  | .
+  | Please check that the amendments below are as intended and correctly reflect the requirement, then either confirm or reject.
 
 

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,4 +1,2 @@
 p
-  | You are about to create
-  =< pluralize(workbasket_settings.additional_codes.count, "additional code", "additional codes")
-  |.
+  |Please check that the amendments below are as intended and correctly reflect the requirement, then either confirm or reject.

--- a/app/views/workbaskets/create_geographical_area/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/create_geographical_area/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,2 +1,2 @@
 p
-  | You are about to create a geographical area.
+  | Please check that the amendments below are as intended and correctly reflect the requirement, then either confirm or reject.

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -2,17 +2,6 @@
 - additional_codes_count = workbasket_settings.additional_codes_covered.compact.count
 
 p
-  | You are about to create
-  =< pluralize(workbasket_settings.measure_sids.count, "measure", "measures")
-  | , covering
-
-  - msg = []
-  - if commodity_codes_count > 0
-    - msg << pluralize(commodity_codes_count, "commodity code", "commodity codes")
-  - if additional_codes_count > 0
-    - msg << pluralize(additional_codes_count, "additional code", "additional codes")
-  =< msg.join(" and ")
-
-  | .
+  | Please check that the amendments below are as intended and correctly reflect the requirement, then either confirm or reject.
 
 

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,21 +1,4 @@
 - prefix = attributes_parser.commodity_codes_formatted.present? ? "commodity" : "additional"
 
 p
-  | You are about to create
-  =<> pluralize(attributes_parser.candidates.count, "#{prefix} code", "#{prefix} codes")
-
-  - if attributes_parser.commodity_codes_exclusions.present?
-    | (with
-    =<> pluralize(attributes_parser.commodity_codes_exclusions.count, "exception", "exceptions")
-    | ), comprising
-
-  =<> workbasket_quota_periods_overview
-  | over
-
-  =< workbasket_quota_periods_years_length
-  | .
-
-p
-  | This quota will have
-  =< pluralize(workbasket_settings.measure_sids.count, "associated measure", "associated measures")
-  | .
+  | Please check that the amendments below are as intended and correctly reflect the requirement, then either confirm or reject.

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,2 +1,2 @@
 p
-  | You are about to edit goods classification.
+  | Please check that the amendments below are as intended and correctly reflect the requirement, then either confirm or reject.

--- a/app/views/workbaskets/shared/steps/review_and_submit/approval/_bulk_edit_additional_codes.html.slim
+++ b/app/views/workbaskets/shared/steps/review_and_submit/approval/_bulk_edit_additional_codes.html.slim
@@ -1,0 +1,12 @@
+h3.heading-medium Bulk additional codes to be created after approval
+
+.bulk-edit-additional-codes.submitted-for-cross-check-view
+  review-bulk-edit-records workbasket_id="#{workbasket.id}" primary-key="additional_code_sid" initial-sort-key="type_id" :bulk-actions="bulkActions" thing="additional_codes" :columns="columns" :actions="actions" :record-table-processing="recordTableProcessing" :preprocess-record="preprocessRecord"
+    template slot-scope="slotProps"
+
+= render "shared/vue_templates/review_bulk_edit_records.html.erb"
+script
+  == "window.__workbasket_id = #{workbasket.id};"
+  == "window.__pagination_metadata = {page: 1, total_count: 1, per_page: 1000};"
+  == "window.all_settings = #{workbasket_settings.settings.to_json};"
+  == "window.current_step_settings = {};"

--- a/app/views/workbaskets/shared/steps/review_and_submit/approval/_bulk_edit_measures.html.slim
+++ b/app/views/workbaskets/shared/steps/review_and_submit/approval/_bulk_edit_measures.html.slim
@@ -1,0 +1,11 @@
+h3.heading-medium Bulk measures to be created after approval
+
+.review-bulk-edit-measures.submitted-for-cross-check-view
+  review-bulk-edit-records workbasket_id="#{workbasket.id}" primary-key="measure_sid" initial-sort-key="measure_sid" :bulk-actions="bulkActions" thing="measures" :columns="columns" :actions="actions" :record-table-processing="recordTableProcessing" :preprocess-record="preprocessRecord"
+= render "shared/vue_templates/review_bulk_edit_records.html.erb"
+
+script
+  == "window.__workbasket_id = #{workbasket.id};"
+  == "window.__pagination_metadata = {page: 1, total_count: 1, per_page: 1000};"
+  == "window.all_settings = #{workbasket_settings.settings.to_json};"
+  == "window.current_step_settings = {};"


### PR DESCRIPTION
Prior to this change, warning copy was not met
the copy of the designs. 

This changes uses the correct copy. 
This change also fixes a bug on approval pages.

Relates: [https://uktrade.atlassian.net/browse/TARIFFS-331](https://uktrade.atlassian.net/browse/TARIFFS-331)