### PR TITLE
Fix: Missing approval links

### DIFF
--- a/app/helpers/approval_helper.rb
+++ b/app/helpers/approval_helper.rb
@@ -14,13 +14,13 @@ module ApprovalHelper
   end
 
   def approval_table_partial(workbasket)
-    if workbasket.type == 'create_measures'
+    if workbasket.type == 'create_measures' || workbasket.type == 'bulk_edit_of_measures'
       "workbaskets/shared/steps/review_and_submit/approval/measures"
-    elsif workbasket.type == 'create_quota'
+    elsif workbasket.type == 'create_quota'|| workbasket.type == 'edit_quota'
       "workbaskets/shared/steps/review_and_submit/approval/quotas"
-    elsif workbasket.type == 'create_geographical_area'
+    elsif workbasket.type == 'create_geographical_area' ||  workbasket.type == "edit_geographical_area"
       "workbaskets/shared/steps/review_and_submit/approval/geographical_areas"
-    elsif workbasket.type == 'create_additional_code'
+    elsif workbasket.type == 'create_additional_code' || workbasket.type == 'bulk_edit_of_additional_codes'
       "workbaskets/shared/steps/review_and_submit/approval/additional_code"
     elsif workbasket.type == 'edit_nomenclature'
       "workbaskets/shared/steps/review_and_submit/approval/edit_nomenclatures"


### PR DESCRIPTION
Prior to this fix, `edit` workbaskets did not have a working link via our `approve` button.

This commit fixes this issue.