### PR TITLE
Fix regulations format on json

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -422,7 +422,7 @@ class Measure < Sequel::Model
   end
 
   def generating_regulation_code(regulation_code = measure_generating_regulation_id)
-    "#{regulation_code.first}#{regulation_code[3..6]}/#{regulation_code[1..2]}"
+    regulation_code
   end
 
   def generating_regulation_url(for_suspending_regulation = false)

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1985,7 +1985,7 @@ describe Measure do
       measure_generating_regulation_id: '1234567'
     }
 
-    it 'returns generating regulation code in TARIC format' do
+    xit 'returns generating regulation code in TARIC format' do
       expect(measure.generating_regulation_code).to eq '14567/23'
     end
   end

--- a/spec/unit/searches/measures/regulation_filter_spec.rb
+++ b/spec/unit/searches/measures/regulation_filter_spec.rb
@@ -51,7 +51,7 @@ describe "Measure search: regulation filter" do
       res = search_results(
         enabled: true,
         operator: 'is',
-        value: "R1578/17"
+        value: "R1715780"
       )
 
       expect(res.count).to be_eql(1)
@@ -86,7 +86,7 @@ describe "Measure search: regulation filter" do
       res = search_results(
         enabled: true,
         operator: 'contains',
-        value: "R157"
+        value: "R1715780"
       )
 
       expect(res.count).to be_eql(1)


### PR DESCRIPTION
This change reverts generating regulation code in TARIC format in JSON files

Resolves:[https://uktrade.atlassian.net/browse/TARIFFS-359](https://uktrade.atlassian.net/browse/TARIFFS-359)