### PR TITLE
Fix: Disable validity start date on addition.codes

### DIFF
--- a/app/assets/javascripts/vue_components/additional_codes/change-validity-period.js
+++ b/app/assets/javascripts/vue_components/additional_codes/change-validity-period.js
@@ -56,6 +56,11 @@ Vue.component("change-additional-codes-validity-period-popup", {
     } else {
       this.sameEndDate = true;
     }
+
+    // date picker requires this format
+    this.startDate = startDates[0].format("DD/MM/YYYY");
+    // we probably should display the latest end date
+    this.endDate = endDates[0].format("DD/MM/YYYY");
   },
   methods: {
     clearErrors: function() {

--- a/app/assets/javascripts/vue_components/date-select.js
+++ b/app/assets/javascripts/vue_components/date-select.js
@@ -43,6 +43,9 @@ Vue.component('date-select', {
     }
   },
   watch: {
+    value: function() {
+      this.vproxy = this.value;
+    },
     vproxy: function() {
       this.$emit("update:value", this.vproxy);
     },

--- a/app/views/shared/vue_templates/additional_codes/_change_validity_period.html.erb
+++ b/app/views/shared/vue_templates/additional_codes/_change_validity_period.html.erb
@@ -34,9 +34,8 @@
 
           <div v-if="sameStartDate">
             <info-message>
-              The selected codes currently start on {{earliestStartDate}}
-              <br />
-              This will be changed to the start date you select below.
+              The selected codes start on {{earliestStartDate}}
+              <%# <br /> This will be changed to the start date you select below. %>
             </info-message>
           </div>
 
@@ -62,7 +61,8 @@
             </span>
           </label>
 
-          <date-select :value.sync="startDate" id='additional-codes-start-date'></date-select>
+          <date-select v-bind:value="startDate" disabled="true" id='additional-codes-start-date'></date-select>
+
         </fieldset>
       </template>
     </form-group>
@@ -125,7 +125,7 @@
           </label>
 
           <div class="form-group">
-            <date-select :value.sync="endDate" :disabled="makeOpenEnded" id="additional-codes-end-date"></date-select>
+            <date-select v-bind:value="endDate" :disabled="makeOpenEnded" id="additional-codes-end-date"></date-select>
           </div>
 
           <div class="form-group" v-if="showMakeOpenEnded">


### PR DESCRIPTION
Prior to this change, date pickers did not display the defined dates

This change fixes this bug and also disables the start date per
requirements

Resolves: [TARIFFS-365](https://uktrade.atlassian.net/browse/TARIFFS-365)

**After**
<img width="936" alt="Screenshot 2019-08-20 at 10 36 00" src="https://user-images.githubusercontent.com/6704411/63327157-5ac4ad80-c336-11e9-8100-cfd53defc198.png">
