### PR TITLE
Fix: Remove delete option on edit aditional codes

### DIFF
--- a/app/assets/javascripts/components/bulk-edit-additional-codes.js
+++ b/app/assets/javascripts/components/bulk-edit-additional-codes.js
@@ -22,7 +22,8 @@ $(document).ready(function() {
           { value: 'toggle_unselected', label: 'Hide/Show unselected items' },
           { value: 'change_description', label: 'Change description' },
           { value: 'change_validity_period', label: 'Change validity period...' },
-          { value: 'delete', label: 'Delete...' },
+          // PP: Temporarirly disabled TARIFFS-347
+          // { value: 'delete', label: 'Delete...' },
           { value: 'remove_from_group', label: 'Remove from workbasket...' },
         ]
       };


### PR DESCRIPTION
Prior to this change, user was able to delete additional codes
on bulc edit

This change temporarily disables this functionality

Resolves: [https://uktrade.atlassian.net/browse/TARIFFS-347](https://uktrade.atlassian.net/browse/TARIFFS-347)

**After**
<img width="598" alt="Screenshot 2019-08-21 at 11 03 19" src="https://user-images.githubusercontent.com/6704411/63414068-bc068280-c403-11e9-8bf4-e432683add87.png">
