### PR TITLE
Fix: Broken page when reviewing/cross-checking/approving quota

### DIFF
--- a/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -26,7 +26,8 @@ table.create-measures-details-table
       td.heading_column
         | Start date
       td
-        = format_date(attributes_parser.start_date)
+        - start_date = attributes_parser.start_date.to_date if attributes_parser.start_date
+        = format_date(start_date)
 
     tr
       td.heading_column


### PR DESCRIPTION
Prior to this change, the page would error and crash when we tried to review/approve
or view a submitted quota. This was due to a change to the way we displayed dates.
The summary_of_configuration page was passing a string to the format_date method
instead of passing a date to it.

This commit fixes this issue.