### PR TITLE
Add header on edit bulk records

### DIFF
--- a/app/assets/javascripts/vue_components/bulk-edit-records.js
+++ b/app/assets/javascripts/vue_components/bulk-edit-records.js
@@ -94,6 +94,10 @@ Vue.component("bulk-edit-records", {
 
       return thing.toLowerCase().split(" ").join("-");
     },
+    entityName: function() {
+      var str = this.thing.replace("_", " ");
+      return str.charAt(0).toUpperCase() + str.slice(1);
+    },
     noSelectedRecords: function() {
       return this.selectedRecords.length === 0;
     },

--- a/app/views/quotas/bulks/_action_buttons.html.slim
+++ b/app/views/quotas/bulks/_action_buttons.html.slim
@@ -1,7 +1,7 @@
 .bulk-edit-of-measures-actions-block
   - if workbasket_is_editable?
     .submit_group_for_cross_check_block
-      = link_to "Submit changes for cross-check", "#", class: "secondary-button js-bulk-edit-of-measures-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
+      = link_to "Submit for cross-check", "#", class: "secondary-button js-bulk-edit-of-measures-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
 
       .js-bulk-edit-of-measures-submit-for-cross-check-spinner.spinner_block.hidden
         = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/shared/bulks/_action_buttons.html.slim
+++ b/app/views/shared/bulks/_action_buttons.html.slim
@@ -1,7 +1,7 @@
 .bulk-edit-of-records-actions-block
   - if workbasket_is_editable?
     .submit_group_for_cross_check_block
-      = link_to "Submit changes for cross-check", "#", class: "button js-bulk-edit-of-records-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
+      = link_to "Submit for cross-check", "#", class: "button js-bulk-edit-of-records-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
 
       .js-bulk-edit-of-records-submit-for-cross-check-spinner.spinner_block.hidden
         = render "shared/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/shared/vue_templates/_bulk_edit_records.html.erb
+++ b/app/views/shared/vue_templates/_bulk_edit_records.html.erb
@@ -12,6 +12,7 @@
       </strong>
     </div>
 
+    <h3 class="heading-medium">{{entityName}} to be updated after cross-check</h3>
     <div v-if="pagination.total_count > 0">
       <records-grid :table-class="tableClass" :primary-key="primaryKey" :on-item-selected="onItemSelected" :on-item-deselected="onItemDeselected" :data="visibleRecordsPage" :columns="columns" :selected-rows="selectedRecords" v-if="!isLoading" selection-type="none" :client-selection="true" :on-select-all-changed="selectAllHasChanged" :disable-scroller="true" :sort-by-changed="onSortByChange" :sort-dir-changed="onSortDirChanged"></records-grid>
 


### PR DESCRIPTION
This commit extends the functionality on bulk edit vue component
to display a heading above the records list. Also `changes` copy is
removed from submit buttons

**Relates:** [TARIFFS-373](https://uktrade.atlassian.net/browse/TARIFFS-373)

**After**
<img width="925" alt="Screenshot 2019-08-21 at 16 47 02" src="https://user-images.githubusercontent.com/6704411/63437800-ee2fd880-c433-11e9-92b5-289542bbfce5.png">
<img width="756" alt="Screenshot 2019-08-21 at 16 44 38" src="https://user-images.githubusercontent.com/6704411/63437804-eec86f00-c433-11e9-8785-cb832fce734e.png">