### PR TITLE
Fix: nomenclature search exception

### DIFF
--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -15,7 +15,7 @@ class GoodsNomenclaturesController < ApplicationController
   end
 
   def search
-    redirect_to goods_nomenclature_path(params[:search_commodity])
+    redirect_to goods_nomenclature_path(search_commodity_code)
   end
 
   def show
@@ -31,6 +31,12 @@ class GoodsNomenclaturesController < ApplicationController
     else
       @errors = "Could not find a matching commodity '#{@search_value}'."
     end
+  end
+
+  private
+
+  def search_commodity_code
+    params[:search_commodity].present? ? params[:search_commodity] : 0
   end
 
 end


### PR DESCRIPTION
Prior to this change, searching for nomenclature without any value would crash.

This change defaults to searching for '0' if no value is entered.