### PR TITLE
Fix: Nomenclature search

### DIFF
--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -15,7 +15,11 @@ class GoodsNomenclaturesController < ApplicationController
   end
 
   def search
-    redirect_to goods_nomenclature_path(params[:search_commodity])
+    if [1,2].include?(params[:search_commodity]&.length)
+      redirect_to chapter_path(search_commodity_code)
+    else
+      redirect_to goods_nomenclature_path(search_commodity_code)
+    end
   end
 
   def show
@@ -31,6 +35,13 @@ class GoodsNomenclaturesController < ApplicationController
     else
       @errors = "Could not find a matching commodity '#{@search_value}'."
     end
+  end
+
+  private
+
+  def search_commodity_code
+    user_value = params[:search_commodity].present? ? params[:search_commodity] : "0"
+    user_value.ljust(10, "0")
   end
 
 end

--- a/app/views/nomenclature/_sections_header.html.erb
+++ b/app/views/nomenclature/_sections_header.html.erb
@@ -26,7 +26,10 @@
           Enter commodity code you want to work with
         </label>
         <div class="gem-c-search__item-wrapper">
-          <input type="search" value="" id="search-commodity" title="Search" name="search_commodity" class="gem-c-search__item gem-c-search--on-white gem-c-search__input">
+          <input type="search" value="" id="search-commodity" title="Search" name="search_commodity"
+                 class="gem-c-search__item gem-c-search--on-white gem-c-search__input" type="number" maxlength="10"
+                 oninput="this.value = this.value.replace(/[^0-9]/g, '').replace(/(\..*)\./g, '$1');"
+          >
           <div class="gem-c-search__item gem-c-search__submit-wrapper">
             <button type="submit" class="gem-c-search__submit">Search</button>
           </div>


### PR DESCRIPTION
Prior to this change, searching for no value would crash.

This change defaults an empty search to '0000000000'
Also this change pads all entries to 10 characters, prevents user
entering non-digits and prevents more than 10 characters being entered.

https://uktrade.atlassian.net/browse/TARIFFS-377
https://uktrade.atlassian.net/browse/TARIFFS-378