### PR TITLE
New: Add success notification on bulk edit actions

### DIFF
--- a/app/assets/javascripts/vue_components/bulk-edit-records.js
+++ b/app/assets/javascripts/vue_components/bulk-edit-records.js
@@ -14,11 +14,12 @@ Vue.component("bulk-edit-records", {
     "columns",
     "actions",
     "recordTableProcessing",
-    "preprocessRecord"
+    "preprocessRecord",
   ],
   data: function() {
     var data = {
       selectedRecords: [],
+      showActionSuccessMessage: null,
       showTooltips: true,
       overloaded: false,
       currentPage: 1,
@@ -44,7 +45,6 @@ Vue.component("bulk-edit-records", {
   },
   mounted: function() {
     var self = this;
-
     if (this.pagination.total_count === 0) {
       return;
     }
@@ -165,6 +165,9 @@ Vue.component("bulk-edit-records", {
     },
 
     triggerAction: function(val) {
+      // Remove previous action messages if any to hide the dom element
+      this.showActionSuccessMessage = null;
+
       if (val == "toggle_unselected") {
         this.toggleUnselected();
       } else {
@@ -305,6 +308,7 @@ Vue.component("bulk-edit-records", {
       });
       this.recordsUpdated();
       this.updateSelectedAll();
+      this.showActionSuccessMessage = 'Selected item(s) have been removed from the workbasket';
     },
     updateSelectedAll: function() {
       var self = this;
@@ -316,6 +320,7 @@ Vue.component("bulk-edit-records", {
     },
     allRecordsRemoved: function() {
       DB.destroyBulk(this.search_code);
+      this.showActionSuccessMessage = 'All item(s) have been removed from the workbasket';
     },
     onSortByChange: function(val) {
       this.sortBy = val;

--- a/app/views/shared/vue_templates/_bulk_edit_records.html.erb
+++ b/app/views/shared/vue_templates/_bulk_edit_records.html.erb
@@ -12,6 +12,16 @@
       </strong>
     </div>
 
+    <div class="grid-row" v-if="showActionSuccessMessage">
+      <div class="column-full">
+        <div class="govuk-box-highlight">
+          <h1 class="heading-large">
+            {{showActionSuccessMessage}}
+          </h1>
+        </div>
+      </div>
+  </div>
+
     <h3 class="heading-medium">{{entityName}} to be updated after cross-check</h3>
     <div v-if="pagination.total_count > 0">
       <records-grid :table-class="tableClass" :primary-key="primaryKey" :on-item-selected="onItemSelected" :on-item-deselected="onItemDeselected" :data="visibleRecordsPage" :columns="columns" :selected-rows="selectedRecords" v-if="!isLoading" selection-type="none" :client-selection="true" :on-select-all-changed="selectAllHasChanged" :disable-scroller="true" :sort-by-changed="onSortByChange" :sort-dir-changed="onSortDirChanged"></records-grid>


### PR DESCRIPTION
Prior to this change, when a user was taking an action he could not
see any success notification

This change extends the bulk edit fuctionality to show success
messages. Currently as requested we are only showing message for
workbasket removals. If we need to we can now show messages for other
actions as well.

Resolves:[TARIFFS-266](https://uktrade.atlassian.net/browse/TARIFFS-266)

**After**
<img width="1339" alt="Screenshot 2019-08-23 at 13 26 41" src="https://user-images.githubusercontent.com/6704411/63586296-b21e8400-c5a9-11e9-84e0-9332052c1722.png">
