### PR TITLE
Fix: Nomenclature date setting and search conflict

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,16 +15,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_nomenclature_view_date
-    if params[:date].present?
-      selected_date = params[:date]
+    if params[:nomenclature_date].present?
+      selected_date = params[:nomenclature_date]
       @view_date = Date.new selected_date["year"].to_i, selected_date["month"].to_i, selected_date["day"].to_i
-      if @view_date == Date.today
-        cookies.delete :nomenclature_view_date
-      else
-        cookies[:nomenclature_view_date] = @view_date
-      end
-    elsif cookies[:nomenclature_view_date].present?
-      @view_date = Date.parse(cookies[:nomenclature_view_date])
     else
       @view_date = Date.today
     end
@@ -33,7 +26,13 @@ class ApplicationController < ActionController::Base
   private
 
   def actual_date
-    Date.parse(params[:start_date].to_s)
+    if params[:nomenclature_date].present?
+      selected_date = params[:nomenclature_date]
+      Date.new selected_date["year"].to_i, selected_date["month"].to_i, selected_date["day"].to_i
+    else
+      Date.parse(params[:start_date].to_s)
+    end
+
   rescue ArgumentError
     Date.current
   end

--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -16,9 +16,9 @@ class GoodsNomenclaturesController < ApplicationController
 
   def search
     if [1,2].include?(params[:search_commodity]&.length)
-      redirect_to chapter_path(search_commodity_code)
+      redirect_to chapter_path(search_commodity_code, request.query_parameters.symbolize_keys)
     else
-      redirect_to goods_nomenclature_path(search_commodity_code)
+      redirect_to goods_nomenclature_path(search_commodity_code, request.query_parameters.symbolize_keys)
     end
   end
 

--- a/app/views/goods_nomenclatures/_tree_node_content.html.erb
+++ b/app/views/goods_nomenclatures/_tree_node_content.html.erb
@@ -2,6 +2,6 @@
   <div class="col-md-6"><%= node.content[:description] %></div>
   <div class="col-md-1"><%= node.content[:producline_suffix] == '80' ? '-' : node.content[:producline_suffix] %></div>
   <div class="col-md-2"><%= format_nomenclature_code(node.content[:goods_nomenclature_item_id]) %></div>
-  <div class="col-md-1"><%= link_to "Manage", new_manage_nomenclature_path(item_id: node.content[:goods_nomenclature_item_id], suffix: node.content[:producline_suffix]) %></div>
+  <div class="col-md-1"><%= link_to "Manage", new_manage_nomenclature_path(({item_id: node.content[:goods_nomenclature_item_id], suffix: node.content[:producline_suffix]}.merge(request.query_parameters)).symbolize_keys) %></div>
   <div class="col-md-2"><%= link_to "View measures", quick_search_measures_url(search_in_measures_by_commodity_rule(node.content)) %></div>
 </div>

--- a/app/views/goods_nomenclatures/show.html.erb
+++ b/app/views/goods_nomenclatures/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :content do %>
   <% if @errors.present? %>
-    <%= render partial: "nomenclature/sections_header", locals: {change_date_base_path: goods_nomenclatures_path } %>
+    <%= render partial: "nomenclature/sections_header", locals: {change_date_base_path: goods_nomenclature_path(params[:id], request.query_parameters.symbolize_keys) } %>
     <%= @errors %>
   <% else %>
     <%= render partial: "nomenclature/sections_header", locals: {change_date_base_path: goods_nomenclature_path(@nomenclature.goods_nomenclature_item_id) } %>
@@ -8,11 +8,11 @@
       <div class="column-three-quarters">
         <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt font-xsmall">
           <nav>
-            <%= link_to "All sections", sections_path, :class => "all-sections-link" %>
+            <%= link_to "All sections", sections_path(request.query_parameters.symbolize_keys), :class => "all-sections-link" %>
             <div class="desktop-only">
               <ul>
                 <li>
-                  <h1><%= link_to "Section #{@heading.chapter.section.numeral}: #{@heading.chapter.section.title}", @heading.chapter.section %></h1>
+                  <h1><%= link_to "Section #{@heading.chapter.section.numeral}: #{@heading.chapter.section.title}", section_path(@heading.chapter.section, request.query_parameters.symbolize_keys) %></h1>
                   <ul>
                     <li class="chapter-li">
                       <div class="chapter-code">

--- a/app/views/nomenclature/_sections_header.html.erb
+++ b/app/views/nomenclature/_sections_header.html.erb
@@ -11,7 +11,7 @@
 
   <%#= form_tag goods_nomenclature_path(@nomenclature.goods_nomenclature_item_id), method: :get do %>
   <%= form_tag change_date_base_path, method: :get do %>
-    <%= select_date @view_date %>
+    <%= select_date @view_date, prefix: :nomenclature_date %>
     <%= submit_tag("Set date") %>
   <% end  %>
   </details>
@@ -20,7 +20,7 @@
 
 <div class="grid-row">
   <div class="column-one-half">
-    <%= form_tag(search_goods_nomenclatures_path) do %>
+    <%= form_tag(search_goods_nomenclatures_path(request.query_parameters.symbolize_keys)) do %>
       <div class="form-group gem-c-search gem-c-search--on-white" data-module="gem-toggle-input-class-on-focus">
         <label for="search-commodity" class="form-label">
           Enter commodity code you want to work with

--- a/app/views/nomenclature/chapters/show.html.erb
+++ b/app/views/nomenclature/chapters/show.html.erb
@@ -5,11 +5,11 @@
   <div class="column-three-quarters">
     <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt font-xsmall">
       <nav>
-        <%= link_to "All sections", sections_path, :class => "all-sections-link"  %>
+        <%= link_to "All sections", sections_path(request.query_parameters.symbolize_keys), :class => "all-sections-link"  %>
         <div class="desktop-only">
           <ul>
             <li>
-              <h1><%= link_to "Section #{@chapter.section.numeral}: #{@chapter.section.title}", @chapter.section %></h1>
+              <h1><%= link_to "Section #{@chapter.section.numeral}: #{@chapter.section.title}", section_path(@chapter.section, request.query_parameters.symbolize_keys) %></h1>
               <ul>
                 <li class="chapter-li">
                   <div class="chapter-code">
@@ -46,13 +46,13 @@
               <th scope="row"><%= heading.producline_suffix == '80' ? '-' : heading.producline_suffix %></th>
               <td>
                 <% if heading.producline_suffix == '80' %>
-                  <%= link_to heading.current_description, goods_nomenclature_path(heading.goods_nomenclature_item_id) %></a>
+                  <%= link_to heading.current_description, goods_nomenclature_path(heading.goods_nomenclature_item_id, request.query_parameters.symbolize_keys) %></a>
                 <% else %>
                   <%= heading.current_description %></a>
                 <% end %>
               </td>
               <td>
-                <div class="col-md-1"><%= link_to "Manage", new_manage_nomenclature_path(item_id: heading.goods_nomenclature_item_id, suffix: heading.producline_suffix) %></div>
+                <div class="col-md-1"><%= link_to "Manage", new_manage_nomenclature_path(({item_id: heading.goods_nomenclature_item_id, suffix: heading.producline_suffix}.merge(request.query_parameters)).symbolize_keys) %></div>
               </td>
             </tr>
             <%end %>

--- a/app/views/nomenclature/sections/index.html.erb
+++ b/app/views/nomenclature/sections/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :content do %>
-  <%= render partial: "nomenclature/sections_header", locals: {change_date_base_path: sections_path}%>
+  <%= render partial: "nomenclature/sections_header", locals: {change_date_base_path: sections_path(request.query_parameters.symbolize_keys)}%>
 
   <% if @sections %>
     <div class="grid-row">
@@ -22,7 +22,7 @@
                 <% else %>
                   <td><%= section.chapter_from.delete_prefix("0") %> to <%= section.chapter_to.delete_prefix("0") %></td>
                 <%end %>
-                <td><%= link_to section.title, section %></td>
+                <td><%= link_to section.title, section_path(section, request.query_parameters.symbolize_keys) %></td>
               </tr>
             <%end %>
           </tbody>

--- a/app/views/nomenclature/sections/show.html.erb
+++ b/app/views/nomenclature/sections/show.html.erb
@@ -5,7 +5,7 @@
   <div class="column-three-quarters">
     <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt font-xsmall">
       <nav>
-        <%= link_to "All sections", sections_path, :class => "all-sections-link"  %>
+        <%= link_to "All sections", sections_path(request.query_parameters.symbolize_keys), :class => "all-sections-link"  %>
         <div class="desktop-only">
           <ul>
             <li>
@@ -33,9 +33,9 @@
             <% @section.chapters.each do |chapter| %>
             <tr>
               <th scope="row"><%= chapter.goods_nomenclature_item_id[0..1] %></th>
-              <td><%= link_to chapter.current_description.capitalize, chapter_path(chapter.goods_nomenclature_item_id) %></a></td>
+              <td><%= link_to chapter.current_description.capitalize, chapter_path(chapter.goods_nomenclature_item_id, request.query_parameters.symbolize_keys) %></a></td>
               <td>
-                <div class="col-md-1"><%= link_to "Manage", new_manage_nomenclature_path(item_id: chapter.goods_nomenclature_item_id, suffix: chapter.producline_suffix) %></div>
+                <div class="col-md-1"><%= link_to "Manage", new_manage_nomenclature_path(({item_id: chapter.goods_nomenclature_item_id, suffix: chapter.producline_suffix}.merge(request.query_parameters)).symbolize_keys) %></div>
               </td>
             </tr>
             <%end %>

--- a/spec/features/workbasket/goods_nomenclature/goods_nomenclature_spec.rb
+++ b/spec/features/workbasket/goods_nomenclature/goods_nomenclature_spec.rb
@@ -41,16 +41,21 @@ RSpec.describe "edit description" do
     expect(page).to have_content("Nom nom description")
 
     find('#change_nomenclature_date').click
-    select (1.year.from_now.year.to_s), :from => "date[year]"
+    select (1.year.from_now.year.to_s), :from => "nomenclature_date[year]"
     click_on('Set date')
     expect(page).to have_content("I am from the future")
 
-    # Check date is not lost when browsing from the home page again.
-    visit (root_path)
-    click_on('Manage the goods classification')
+    # Check date is not lost when browsing through links.
     click_on chapter.section.title
     click_on chapter.description.capitalize
     click_on heading.description
     expect(page).to have_content("I am from the future")
+
+    find('#change_nomenclature_date').click
+    select (Date.today.year.to_s), :from => "nomenclature_date[year]"
+    click_on('Set date')
+    expect(page).to_not have_content("I am from the future")
+    expect(page).to have_content("Nom nom description")
+
   end
 end


### PR DESCRIPTION
Prior to this change, the nomenclature date change was using a cookie to
remember the date chosen. This conflicts with the way the original
system used dates (within time_machine) to restrict searches etc.

This change uses a similar mechanism to continue to pass the date
parameters within the url.

https://uktrade.atlassian.net/browse/TARIFFS-378
https://uktrade.atlassian.net/browse/TARIFFS-333