### PR TITLE
Fix: Add description and associated goods code to view footnote screens

### DIFF
--- a/app/views/workbaskets/create_footnote/steps/review_and_submit/_footnote.html.slim
+++ b/app/views/workbaskets/create_footnote/steps/review_and_submit/_footnote.html.slim
@@ -12,6 +12,8 @@
           a Description
         th.measures-column
           a Associated measures
+        th.measures-column
+          a Associated goods codes
     tbody
       tr
         td.validity_start_date-column
@@ -22,3 +24,5 @@
           = footnote.description
         td.measures-column
           = footnote.measures.map {|measure| measure.measure_sid}
+        td.measures-column
+          = footnote.goods_nomenclatures.map { |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }

--- a/app/views/workbaskets/create_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -24,4 +24,16 @@ table.create-measures-details-table
       td.heading_column
         | Associated measures
       td
-        = footnote.measures.map {|measure| measure.measure_sid}
+        = footnote.measures.map { |measure| measure.measure_sid }
+
+    tr
+      td.heading_column
+        | Description
+      td
+        = footnote.description
+    tr
+
+      td.heading_column
+        | Associated goods codes
+      td
+        = footnote.goods_nomenclatures.map{ |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }


### PR DESCRIPTION
Prior to this change, the view footnote page and the review and submit footnote page were
missing some details.

This change adds description and associated goods codes to the view page and associated
goods code to the review and submit page.