### PR TITLE
Fix: Unnecessary commodity code warning for create footnotes

### DIFF
--- a/app/interactors/workbasket_interactions/create_footnote/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/create_footnote/initial_validator.rb
@@ -101,6 +101,8 @@ module WorkbasketInteractions
       end
 
       def check_commodity_codes!
+        return unless can_add_commodity_code?
+        
         if commodity_codes.present?
           list = attrs_parser.parse_list_of_values(commodity_codes)
 
@@ -130,6 +132,10 @@ module WorkbasketInteractions
             end
           end
         end
+      end
+
+      def can_add_commodity_code?
+        ['NC', 'PN', 'TN'].include?(footnote_type_id)
       end
 
       def parse_date(option_name)


### PR DESCRIPTION
Prior to this change, when a user was creating a footnote and selected a footnote
type that could be associated with a goods commodity code, entered an incorrect
commodity code, but then changed to a footnote type that did not need a commodity code
the incorrect commodity code error still showed.

This change fixes the issue by only checking for commodity code errors if the footnote
type is one that takes a commodity code.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-395