### PR TITLE
Fix: Remove square brackets on view footnote page

### DIFF
--- a/app/views/workbaskets/create_footnote/steps/review_and_submit/_footnote.html.slim
+++ b/app/views/workbaskets/create_footnote/steps/review_and_submit/_footnote.html.slim
@@ -23,6 +23,6 @@
         td.description-column
           = footnote.description
         td.measures-column
-          = footnote.measures.map {|measure| measure.measure_sid}
+          = footnote.measures.map { |measure| measure.measure_sid }.join(', ')
         td.measures-column
-          = footnote.goods_nomenclatures.map { |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }
+          = footnote.goods_nomenclatures.map { |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }.join(', ')

--- a/app/views/workbaskets/create_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -24,7 +24,7 @@ table.create-measures-details-table
       td.heading_column
         | Associated measures
       td
-        = footnote.measures.map { |measure| measure.measure_sid }
+        = footnote.measures.map { |measure| measure.measure_sid }.join(', ')
 
     tr
       td.heading_column
@@ -36,4 +36,4 @@ table.create-measures-details-table
       td.heading_column
         | Associated goods codes
       td
-        = footnote.goods_nomenclatures.map{ |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }
+        = footnote.goods_nomenclatures.map{ |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }.join(', ')


### PR DESCRIPTION
Prior to this change, the associated measures and commodity code id's were shown
in arrays. This change removes the square brackets around the list of ids.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-393