### PR TITLE
Fix: Download Measures now uses Web Sockets to prevent timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem "aws-sdk-rails"
 gem "aws-sdk-s3"
 gem "rubyzip", "~> 1.2.2"
 
+gem 'filesaverjs-rails'
+
 # Helpers
 gem "hashie", "~> 3.4"
 gem 'oj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
+    filesaverjs-rails (1.1.20150716)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
     foreman (0.85.0)
@@ -548,6 +549,7 @@ DEPENDENCIES
   factory_bot_rails
   fakefs
   ffi (~> 1.9.24)
+  filesaverjs-rails
   font-awesome-rails
   foreman
   forgery

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,8 @@
 //= require ./polyfills/matches
 //= require jquery
 //= require jquery_ujs
+//= require cable
+//= require FileSaver
 //= require moment
 //= require pikaday
 //= require parsley
@@ -36,3 +38,23 @@ $(function () {
     }
   }
 });
+
+function generateUUID() {
+  var S4 = function() {
+    return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
+  };
+  return (
+    S4() +
+    S4() +
+    "-" +
+    S4() +
+    "-" +
+    S4() +
+    "-" +
+    S4() +
+    "-" +
+    S4() +
+    S4() +
+    S4()
+  );
+}

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,0 +1,13 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `rails generate channel` command.
+//
+//= require action_cable
+//= require_self
+//= require_tree ./channels
+
+(function() {
+  this.App || (this.App = {});
+
+  App.cable = ActionCable.createConsumer();
+
+}).call(this);

--- a/app/assets/javascripts/channels/download.js
+++ b/app/assets/javascripts/channels/download.js
@@ -1,0 +1,28 @@
+function subscribeDownloadChannel(uuid, callback) {
+  App.download = App.cable.subscriptions.create(
+    { channel: "DownloadChannel", uuid: uuid },
+    {
+      connected: function() {
+        callback();
+      },
+
+      disconnected: function() {},
+
+      received: function(data) {
+        var blob = new Blob([data.csv], {
+          type: "text/csv;charset=utf-8"
+        });
+
+        saveAs(blob, "measures_download_" + new Date().toISOString().slice(0, 10) +".csv");
+
+        $("#download_measures")
+          .prop('value', 'Download as CSV')
+          .removeAttr("disabled");
+
+        App.download.unsubscribe();
+        App.cable.disconnect();
+        delete App.download;
+      }
+    }
+  );
+}

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end

--- a/app/channels/download_channel.rb
+++ b/app/channels/download_channel.rb
@@ -1,0 +1,8 @@
+class DownloadChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "downloads_channel_#{params[:uuid]}"
+  end
+
+  def unsubscribed;
+  end
+end

--- a/app/services/measure_service/download_measures.rb
+++ b/app/services/measure_service/download_measures.rb
@@ -1,0 +1,16 @@
+module MeasureService
+  class DownloadMeasures
+    class << self
+      def call(search_code)
+        CSV.generate(headers: false) do |csv|
+          csv << Measure.table_array_headers
+          ::Measures::Search.new(
+            Rails.cache.read(search_code)
+          ).results(false).map do |measure|
+            csv << measure.to_table_array
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/measures/measures/_search_page.html.slim
+++ b/app/views/measures/measures/_search_page.html.slim
@@ -31,8 +31,8 @@ script
           span.number-of-records-badge
             = pluralize(search_results.total_count, 'measure', 'measures')
             =<> "found"
-        p.clearfix
-          = link_to "Download as CSV", measures_path(search_code: current_search_code, format: :csv), class: "search-results-download-link"
+      p.clearfix
+        = button_to "Download as CSV", download_measures_path(search_code: current_search_code), class: "button", id: "download_measures", form: { "id" => "download_form" }
 
       = render "measures_table" if measures_search.present?
 
@@ -45,3 +45,16 @@ script
         = content_tag "loading-spinner", nil
 
 = render "shared/vue_templates/records_grid"
+
+javascript:
+  $(document).on('click', '#download_measures', function (e) {
+    e.preventDefault();
+    var uuid = generateUUID();
+    $(this).prop('value', 'Downloading, please wait...')
+    $(this).attr('disabled', 'disabled');
+    var url = document.getElementById('download_form').action + '&uuid=' + uuid;
+    subscribeDownloadChannel(uuid, function () {
+      $.get(url);
+    });
+    return false;
+  });

--- a/app/workers/available_download_broadcast_worker.rb
+++ b/app/workers/available_download_broadcast_worker.rb
@@ -1,0 +1,9 @@
+class AvailableDownloadBroadcastWorker
+  include Sidekiq::Worker
+
+  def perform(uuid, search_code=nil)
+    ActionCable.server.broadcast(
+      "downloads_channel_#{uuid}", csv: MeasureService::DownloadMeasures.call(search_code)
+    )
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require "csv"
+require 'action_cable/engine'
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "sprockets/railtie"

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,0 +1,12 @@
+development:
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  channel_prefix: trade_tariff_manangement_development
+
+test:
+  adapter: async
+
+production:
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  channel_prefix: trade_tariff_manangement_production

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,7 @@ Rails.application.routes.draw do
       collection do
         post :search
 
+        get :download
         get :quick_search
         get :all_measures_data
       end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,3 @@
 download_xml_job:
-  cron: "*/1 * * * *" 
+  cron: "*/1 * * * *"
   class: "DownloadXmlWorker"

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -29,7 +29,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
-
 --
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
 --


### PR DESCRIPTION
Prior to this fix the download would timeout if it took longer than a
minute. Also, it blocked the process.

This fix uses a background job to create the csv and then uses web
sockets (action cable) to deliver the results.

https://uktrade.atlassian.net/browse/TARIFFS-335