### PR TITLE
Fix: Unnecessary measure warning for create footnotes

### DIFF
--- a/app/interactors/workbasket_interactions/create_footnote/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/create_footnote/initial_validator.rb
@@ -102,7 +102,7 @@ module WorkbasketInteractions
 
       def check_commodity_codes!
         return unless can_add_commodity_code?
-        
+
         if commodity_codes.present?
           list = attrs_parser.parse_list_of_values(commodity_codes)
 
@@ -119,6 +119,8 @@ module WorkbasketInteractions
       end
 
       def check_measures!
+        return unless can_add_measures?
+
         if measure_sids.present?
           list = attrs_parser.parse_list_of_values(measure_sids)
 
@@ -136,6 +138,10 @@ module WorkbasketInteractions
 
       def can_add_commodity_code?
         ['NC', 'PN', 'TN'].include?(footnote_type_id)
+      end
+
+      def can_add_measures?
+        ['CD','CG','DU','EU','IS','MG','MX','OZ','PB','TM','TR'].include?(footnote_type_id)
       end
 
       def parse_date(option_name)


### PR DESCRIPTION
Prior to this change, when a user was creating a footnote and selected a footnote
type that could be associated with a measure, entered an incorrect
measure, but then changed to a footnote type that did not need a measure
the incorrect measure error still showed.

This change fixes the issue by only checking for measure errors if the footnote
type is one that takes a measure.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-395