### PR TITLE
New: Edit footnotes cross check

### DIFF
--- a/app/controllers/workbaskets/edit_footnote_controller.rb
+++ b/app/controllers/workbaskets/edit_footnote_controller.rb
@@ -55,7 +55,7 @@ module Workbaskets
 
         if submit_for_cross_check_mode?
           saver.persist!
-          submit_for_cross_check.run!
+          workbasket.submit_for_cross_check!(current_admin: current_user)
 
           render json: { redirect_url: submitted_url },
                  status: :ok

--- a/app/helpers/approval_helper.rb
+++ b/app/helpers/approval_helper.rb
@@ -12,6 +12,8 @@ module ApprovalHelper
       "Approve new goods classification"
     elsif workbasket.type == 'create_footnote'
       "Approve new footnotes"
+    elsif workbasket.type == 'edit_footnote'
+      "Approve edited footnote"
     end
   end
 
@@ -34,6 +36,8 @@ module ApprovalHelper
       "workbaskets/shared/steps/review_and_submit/approval/geographical_areas"
     elsif workbasket.type == 'create_footnote'
       "workbaskets/shared/steps/review_and_submit/approval/create_footnote"
+    elsif workbasket.type == 'edit_footnote'
+      "workbaskets/shared/steps/review_and_submit/approval/edit_footnote"
     end
   end
 end

--- a/app/helpers/cross_check_helper.rb
+++ b/app/helpers/cross_check_helper.rb
@@ -18,6 +18,8 @@ module CrossCheckHelper
       "Cross-check and bulk edit additional codes"
     elsif workbasket.type == 'create_footnote'
       "Cross-check and create footnote"
+    elsif workbasket.type == 'edit_footnote'
+      "Cross-check and approve footnote"
     end
   end
 
@@ -40,6 +42,8 @@ module CrossCheckHelper
       "workbaskets/shared/steps/review_and_submit/edit_nomenclatures"
     elsif workbasket.type == 'create_footnote'
       "workbaskets/shared/steps/review_and_submit/create_footnote"
+    elsif workbasket.type == 'edit_footnote'
+      "workbaskets/shared/steps/review_and_submit/edit_footnote"
     end
   end
 

--- a/app/views/workbaskets/edit_footnote/steps/review_and_submit/_footnote.html.slim
+++ b/app/views/workbaskets/edit_footnote/steps/review_and_submit/_footnote.html.slim
@@ -1,0 +1,28 @@
+.records-table-wrapper
+  table class="table"  id="records-table"
+    thead
+      tr
+        th.validity_start_date-column
+          a
+          | Footnote valid from
+          - footnote = Footnote.find(footnote_id: workbasket.settings.original_footnote_id, footnote_type_id: workbasket.settings.original_footnote_type_id)
+        th.name-column
+          a Footnote type
+        th.code-column
+          a Description
+        th.measures-column
+          a Associated measures
+        th.measures-column
+          a Associated goods codes
+    tbody
+      tr
+        td.validity_start_date-column
+          = format_date(footnote.validity_start_date.to_date)
+        td.type-column
+          = footnote.footnote_type_id
+        td.description-column
+          = footnote.description
+        td.measures-column
+          = footnote.measures.map { |measure| measure.measure_sid }.join(', ')
+        td.measures-column
+          = footnote.goods_nomenclatures.map { |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }.join(', ')

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/_actions_allowed.html.slim
@@ -1,0 +1,11 @@
+- if workbasket_view_show_actions_allowed?
+  .view-workbasket-actions-allowed
+    - if iam_workbasket_author? && workbasket.can_withdraw?
+      = link_to "Withdraw workbasket from workflow", "#",
+      data: { target_url: withdraw_workbasket_from_workflow_create_footnote_url(workbasket.id), target_modal: workbasket.id },
+      class: "button js-main-menu-show-withdraw-confirmation-link"
+      br
+
+= render "workbaskets/main_menu_parts/schedule_export_to_cds_popup"
+= render "workbaskets/main_menu_parts/confirmation_popup", modal_id: "delete_confirmation_popup", title: "You are going to delete workbasket"
+= render "workbaskets/main_menu_parts/withdraw_confirmation_popup", modal_id: "withdraw_confirmation_popup_#{workbasket.id}", workbasket: workbasket

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -1,0 +1,39 @@
+h3.heading-medium Summary of footnote configuration
+- footnote = Footnote.find(footnote_id: workbasket.settings.original_footnote_id, footnote_type_id: workbasket.settings.original_footnote_type_id)
+table.create-measures-details-table
+  tbody
+    tr
+      td.heading_column
+        | Validity Start Date
+      td
+        = format_date(footnote.validity_start_date)
+
+    tr
+      td.heading_column
+        | Footnote type
+      td
+        = footnote.footnote_type_id
+
+    tr
+      td.heading_column
+        | Footnote ID
+      td
+        = footnote.footnote_id
+
+    tr
+      td.heading_column
+        | Associated measures
+      td
+        = footnote.measures.map { |measure| measure.measure_sid }.join(', ')
+
+    tr
+      td.heading_column
+        | Description
+      td
+        = footnote.description
+    tr
+
+      td.heading_column
+        | Associated goods codes
+      td
+        = footnote.goods_nomenclatures.map{ |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }.join(', ')

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/_workbasket_details.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/_workbasket_details.html.slim
@@ -1,0 +1,18 @@
+h3.heading-medium Workbasket details
+
+table.create-measures-details-table class="#{'view-workbasket-details-block' if workbasket_rejected?}"
+  tbody
+    tr
+      td.heading_column
+        | Created by
+      td
+        = workbasket.author_name
+
+    tr
+      td.heading_column
+        | Created on
+      td
+        = workbasket.created_at.strftime("%d %B %Y")
+
+    - workbasket.ordered_events.map do |event|
+      = render "workbaskets/events/#{event.event_type}", event: event

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/_block.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/_block.html.slim
@@ -1,0 +1,7 @@
+- extra_alert_css = workbasket_status_in_error_level? ? 'error' : 'info'
+
+.alert.create-measures-message-block class="alert--#{extra_alert_css}"
+  svg.icon class="icon--#{extra_alert_css}" version="1.1" viewbox=("0 0 24 28") xmlns="http://www.w3.org/2000/svg"
+    path d=("M16 21.5v-2.5c0-0.281-0.219-0.5-0.5-0.5h-1.5v-8c0-0.281-0.219-0.5-0.5-0.5h-5c-0.281 0-0.5 0.219-0.5 0.5v2.5c0 0.281 0.219 0.5 0.5 0.5h1.5v5h-1.5c-0.281 0-0.5 0.219-0.5 0.5v2.5c0 0.281 0.219 0.5 0.5 0.5h7c0.281 0 0.5-0.219 0.5-0.5zM14 7.5v-2.5c0-0.281-0.219-0.5-0.5-0.5h-3c-0.281 0-0.5 0.219-0.5 0.5v2.5c0 0.281 0.219 0.5 0.5 0.5h3c0.281 0 0.5-0.219 0.5-0.5zM24 14c0 6.625-5.375 12-12 12s-12-5.375-12-12 5.375-12 12-12 12 5.375 12 12z")
+
+  = render (defined?(partial_name) ? partial_name : "workbaskets/#{workbasket.type}/workflow_screens_parts/notifications/#{screen_type}/#{workbasket.status}")

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/approves/_general.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/approves/_general.html.slim
@@ -1,0 +1,2 @@
+p
+  | Please review the footnote shown below and either approve or reject. Once approved, they will be sent through to CDS in the next export batch on or after the date you specify.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/cross_check/_awaiting_cross_check.html.slim
@@ -1,0 +1,2 @@
+p
+  | Please check that the amendments below are as intended and correctly reflect the requirement, then either confirm or reject.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_approval_rejected.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_approval_rejected.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited footnote has been rejected. The approver gave the reasons detailed below.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_awaiting_approval.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_awaiting_approval.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited footnote shown below has been submitted for approval and is waiting for response. If you need to re-edit it, first withdraw the workbasket from workflow.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_awaiting_cds_upload_create_new.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_awaiting_cds_upload_create_new.html.slim
@@ -1,0 +1,3 @@
+p
+  | The edited footnote has been approved, but has not yet been sent through to CDS. It will be sent in the next batch.
+  | .

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_awaiting_cross_check.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited footnote shown below has been submitted for cross-check and is waiting for response. If you need to re-edit it, first withdraw the workbasket from workflow.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_cds_error.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_cds_error.html.slim
@@ -1,0 +1,4 @@
+p
+  | The edited footnote was not imported by CDS because of error.
+  =<> link_to "View error details"
+  | .

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_cross_check_rejected.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_cross_check_rejected.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited footnote has been rejected. The cross-checker gave the reasons detailed below.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_published.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_published.html.slim
@@ -1,0 +1,2 @@
+p
+  | The footnote detailed below has been published to HMRC.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_ready_for_approval.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_ready_for_approval.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited footnote has been cross-checked, but has not yet been submitted for approval.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_ready_for_export.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_ready_for_export.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited footnote has been approved, but has not yet been sent through to CDS and has not been scheduled for export.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_sent_to_cds.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_sent_to_cds.html.slim
@@ -1,0 +1,2 @@
+p
+  | The edited footnote has been sent to CDS.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_approval_rejected.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_approval_rejected.html.slim
@@ -1,0 +1,14 @@
+- footnote = footnote ? footnote : Footnote.find(workbasket_id: workbasket.id)
+
+.panel.panel--confirmation
+  h1.heading-xlarge
+    | Footnote approval rejected
+
+  h3.heading-medium
+    | The footnote with type
+    = footnote.footnote_type_id
+    |  and ID
+    = footnote.footnote_id
+    | has problems. It has not been approved. The submitter has been notified.
+
+= render "workbaskets/create_footnote/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
@@ -1,0 +1,13 @@
+- footnote = footnote ? footnote : Footnote.find(workbasket_id: workbasket.id)
+
+.panel.panel--confirmation
+  h1.heading-xlarge
+    | Footnote cross-checked
+  h3.heading-medium
+    | The footnote with type  
+    = footnote.footnote_type_id
+    |  and ID
+    = footnote.footnote_id
+    | has been submitted for approval.
+
+= render "workbaskets/create_footnote/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_awaiting_cds_upload_create_new.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_awaiting_cds_upload_create_new.html.slim
@@ -1,0 +1,14 @@
+- footnote = footnote ? footnote : Footnote.find(workbasket_id: workbasket.id)
+
+.panel.panel--confirmation
+  h1.heading-xlarge
+    | Footnote approved
+
+  h3.heading-medium
+    | The footnote with type 
+    = footnote.footnote_type_id
+    |  and ID
+    = footnote.footnote_id
+    |  has been approved. It has been scheduled for export CDS
+
+= render "workbaskets/create_footnote/workflow_screens_parts/status_pages/next_step_links", mode: "approve"

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_cross_check_rejected.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_cross_check_rejected.html.slim
@@ -1,0 +1,15 @@
+- footnote = footnote ? footnote : Footnote.find(workbasket_id: workbasket.id)
+
+.panel.panel--confirmation
+  h1.heading-xlarge
+    | Geographical area cross-check rejected
+
+  h3.heading-medium
+    | You indicated that the new footnote
+    | with type
+    = footnote.footnote_type_id
+    |  and ID
+    = footnote.footnote_id
+    |  has problems. It has not passed cross-check. The submitter has been notified.
+
+= render "workbaskets/create_footnote/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_next_step_links.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_next_step_links.html.slim
@@ -1,0 +1,21 @@
+br
+h3.heading-medium
+  | Next steps
+
+ul class="list"
+  - if mode == "cross_check" && next_cross_check.present? && workbasket.id != next_cross_check.id
+    li
+      = link_to "Cross-check next workbasket", new_cross_check_url(next_cross_check.id)
+
+  - if mode == "approve" && next_approve.present? && workbasket.id != next_approve.id
+    li
+      = link_to "Approve next workbasket", new_approve_url(next_approve.id)
+
+  li
+    = link_to "Return to main menu", root_url
+
+  - unless workbasket_rejected?
+    li
+      = link_to "View this footnote", create_footnote_url(workbasket.id)
+br
+br

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_ready_for_approval.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_ready_for_approval.html.slim
@@ -1,0 +1,14 @@
+- footnote = footnote ? footnote : Footnote.find(workbasket_id: workbasket.id)
+
+.panel.panel--confirmation
+  h1.heading-xlarge
+    | Footnote cross-checked
+
+  h3.heading-medium
+    | The footnote with type
+    = footnote.footnote_type_id
+    |  and ID
+    = footnote.footnote_id
+    |  has not yet been submitted for approval.
+
+= render "workbaskets/create_footnote/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_ready_for_export.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_ready_for_export.html.slim
@@ -1,0 +1,14 @@
+- footnote = footnote ? footnote : Footnote.find(workbasket_id: workbasket.id)
+
+.panel.panel--confirmation
+  h1.heading-xlarge
+    | Footnote approved
+
+  h3.heading-medium
+    | The footnote with type 
+    = footnote.footnote_type_id
+    |  and ID
+    = footnote.footnote_id
+    |  has not yet been sent through to CDS and has not been scheduled for export.
+
+= render "workbaskets/create_footnote/workflow_screens_parts/status_pages/next_step_links", mode: "cross_check"

--- a/app/views/workbaskets/shared/steps/review_and_submit/_edit_footnote.html.slim
+++ b/app/views/workbaskets/shared/steps/review_and_submit/_edit_footnote.html.slim
@@ -1,0 +1,2 @@
+h3.heading-medium Footnote to be edited after cross-check
+= render "workbaskets/create_footnote/steps/review_and_submit/footnote"

--- a/app/views/workbaskets/shared/steps/review_and_submit/approval/_edit_footnote.html.slim
+++ b/app/views/workbaskets/shared/steps/review_and_submit/approval/_edit_footnote.html.slim
@@ -1,0 +1,2 @@
+h3.heading-medium Footnote to be edited after approval
+= render "workbaskets/edit_footnote/steps/review_and_submit/footnote"


### PR DESCRIPTION
Prior to this change, there was no cross-check or approval process for edit footnotes.

This commit adds this workflow process.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-398
https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-399