### PR TITLE
Fix: Show description for footnotes

### DIFF
--- a/app/views/workbaskets/create_footnote/steps/review_and_submit/_footnote.html.slim
+++ b/app/views/workbaskets/create_footnote/steps/review_and_submit/_footnote.html.slim
@@ -21,7 +21,7 @@
         td.type-column
           = footnote.footnote_type_id
         td.description-column
-          = footnote.description
+          = FootnoteDescription.where(footnote_id: footnote.footnote_id).last.description
         td.measures-column
           = footnote.measures.map { |measure| measure.measure_sid }.join(', ')
         td.measures-column

--- a/app/views/workbaskets/create_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -30,7 +30,7 @@ table.create-measures-details-table
       td.heading_column
         | Description
       td
-        = footnote.description
+        = FootnoteDescription.where(footnote_id: footnote.footnote_id).last.description
     tr
 
       td.heading_column


### PR DESCRIPTION
Prior to this change, if a footnote was created with a description that starts in the future
then the description does not show up on the summary of configuration and review and
submit pages.

This commit fixes this issue.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-394