### PR TITLE
Fix: Create Regualtion XML value for official journal number

### DIFF
--- a/app/value_objects/workbasket_value_objects/create_regulation/attributes_parser.rb
+++ b/app/value_objects/workbasket_value_objects/create_regulation/attributes_parser.rb
@@ -72,7 +72,7 @@ module WorkbasketValueObjects
       end
 
       def stub_some_attributes
-        @normalized_params[:officialjournal_number] = '00'
+        @normalized_params[:officialjournal_number] = "1"
         @normalized_params[:officialjournal_page] = 1
 
         @normalized_params[:community_code] = 1 if target_class == BaseRegulation


### PR DESCRIPTION
Prior to this change, the value of official journal number was always
'00'. Our expected behaviour Every time we create new regulations, we
need to put a value of "1" in the two fields officialjournal.number and
officialjournal.page

The reason for these two "journal" fields being "1' is so that Bit
Zesty can differentiate between UK and EU regulations on the Trade
Tariff Service - if both of these fields is "1", then this means it's a
UK regulation.

This change changes the hardcoded value from '00' to '1' for official
journal number.

https://uktrade.atlassian.net/browse/TARIFFS-404