### PR TITLE
Fix: Add header for create regulation approval

### DIFF
--- a/app/helpers/approval_helper.rb
+++ b/app/helpers/approval_helper.rb
@@ -4,6 +4,8 @@ module ApprovalHelper
       'Approve new measures'
     elsif workbasket.type == 'create_quota'
       'Approve new quota'
+    elsif workbasket.type == 'create_regulation'
+      'Approve new regulation'
     elsif workbasket.type == 'create_geographical_area'
       'Approve new geographical area'
     elsif workbasket.type == 'create_additional_code'


### PR DESCRIPTION
Prior to this change, it was missing

This change added it

https://uktrade.atlassian.net/browse/TARIFFS-274