### PR TITLE
New: Update existing description if start date is the same

### DIFF
--- a/app/interactors/workbasket_interactions/edit_geographical_area/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/edit_geographical_area/settings_saver.rb
@@ -299,7 +299,7 @@ module WorkbasketInteractions
         check_geo_area_conformance
 
         if description_changed?
-          if  existing_description_period_on_same_day.empty?
+          if existing_description_period_on_same_day.empty?
             @conformance_errors.merge!(get_conformance_errors(geographical_area_description_period)) unless geographical_area_description_period.conformant?
             unless geographical_area_description_period.conformant?
               @conformance_errors.merge!(get_conformance_errors(geographical_area_description_period))

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_awaiting_approval.html.slim
@@ -1,10 +1,10 @@
-- footnote = footnote ? footnote : Footnote.find(workbasket_id: workbasket.id)
+- footnote = footnote ? footnote : Footnote.find(footnote_id: workbasket.settings.original_footnote_id, footnote_type_id: workbasket.settings.original_footnote_type_id)
 
 .panel.panel--confirmation
   h1.heading-xlarge
     | Footnote cross-checked
   h3.heading-medium
-    | The footnote with type  
+    | The footnote with type
     = footnote.footnote_type_id
     |  and ID
     = footnote.footnote_id

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_awaiting_cds_upload_edit.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/status_pages/_awaiting_cds_upload_edit.html.slim
@@ -1,4 +1,4 @@
-- footnote = footnote ? footnote : Footnote.find(workbasket_id: workbasket.id)
+- footnote = footnote ? footnote : Footnote.find(footnote_id: workbasket.settings.original_footnote_id, footnote_type_id: workbasket.settings.original_footnote_type_id)
 
 .panel.panel--confirmation
   h1.heading-xlarge

--- a/app/views/workbaskets/shared/steps/review_and_submit/_edit_footnote.html.slim
+++ b/app/views/workbaskets/shared/steps/review_and_submit/_edit_footnote.html.slim
@@ -1,2 +1,2 @@
 h3.heading-medium Footnote to be edited after cross-check
-= render "workbaskets/create_footnote/steps/review_and_submit/footnote"
+= render "workbaskets/edit_footnote/steps/review_and_submit/footnote"


### PR DESCRIPTION
Prior to this change, If a footnote description was changed but the start date was the same as the previous description then the application would create a new footnote rather than updating the existing one. This commit fixes this issue.

This commit also contains fixes for the edit footnote workflow.