### PR TITLE
Update typo/layout on Geographical Area

### DIFF
--- a/app/views/workbaskets/create_additional_code/steps/main/_start_end_dates.html.slim
+++ b/app/views/workbaskets/create_additional_code/steps/main/_start_end_dates.html.slim
@@ -1,3 +1,3 @@
 = content_tag "date-gds", "", "label" => "When are these new codes' start date?", ":value.sync" => "validity_start_date",  "id" => "start_date",  ":required" => "true", ":error" => "errors.validity_start_date"
 
-= content_tag "date-gds", "", "label" => "When are these new codes' end date?", "hint" => "Optional – leave blank if the codes will remain valid indefinitely.", ":value.sync" => "validity_end_date",  "id" => "end_date", ":error" => "errors.validity_end_date"
+= content_tag "date-gds", "", "label" => "When is the area’s end date?", "hint" => "Optional – leave blank if the codes will remain valid indefinitely.", ":value.sync" => "validity_end_date",  "id" => "end_date", ":error" => "errors.validity_end_date"

--- a/app/views/workbaskets/create_geographical_area/steps/main/_type.html.slim
+++ b/app/views/workbaskets/create_geographical_area/steps/main/_type.html.slim
@@ -17,7 +17,7 @@ fieldset
               label for="geographical_area_type_country"
                 | A country
                 span.form-hint
-                  | This will have two-letter ISO code. You can add countires to geographical area groups, but a country cannot itself be a group.
+                  | This will have two-letter ISO code. You can add countries to geographical area groups, but a country cannot itself be a group.
           .geographical-area-type
             .multiple-choice
               input type='radio' id="geographical_area_type_region" class="radio-inline-group" name="geographical_area[geographical_code]" :checked="geographical_area.geographical_code == 'region'" v-model="geographical_area.geographical_code" value="region"

--- a/app/views/workbaskets/create_geographical_area/steps/main/_validity_period.html.slim
+++ b/app/views/workbaskets/create_geographical_area/steps/main/_validity_period.html.slim
@@ -1,4 +1,3 @@
 = content_tag "date-gds", "", "label" => "When is the area's start date?", ":value.sync" => "geographical_area.validity_start_date",  "id" => "validity_start_date", ":required" => "true", ":error" => "errors.validity_start_date"
-.grid-row
-  .column-two-thirds
-    = content_tag "date-gds", "", "label" => "When are these new codes' end date?", "hint" => "This is optional and should usually be left unset (open-ended) unless you know the area is only needed for a limited time.", ":value.sync" => "geographical_area.validity_end_date",  "id" => "validity_end_date", ":error" => "errors.validity_end_date"
+
+= content_tag "date-gds", "", "label" => "When is the area’s end date?", "hint" => "This is optional and should usually be left unset (open-ended) unless you know the area is only needed for a limited time.", ":value.sync" => "geographical_area.validity_end_date",  "id" => "validity_end_date", ":error" => "errors.validity_end_date"

--- a/app/views/workbaskets/edit_geographical_area/steps/main/_type.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/steps/main/_type.html.slim
@@ -11,7 +11,7 @@ fieldset
 
             label.with_bigger_font-size for="geographical-area-type-country"
               | A country
-              span.form-hint.with_bigger_font-size This will have two-letter ISO code. You can add countires to geographical area groups, but a country cannot itself be a group.
+              span.form-hint.with_bigger_font-size This will have two-letter ISO code. You can add countries to geographical area groups, but a country cannot itself be a group.
 
         .geographical-area-type
           .multiple-choice data-type-value="2"


### PR DESCRIPTION
There was a  typo error that is now fixed. A small layout change 
also took place in order to render description in a single line 