### PR TITLE
Fix: Measure search by Regulation ID

### DIFF
--- a/app/searches/measures/search_filters/regulation.rb
+++ b/app/searches/measures/search_filters/regulation.rb
@@ -35,7 +35,7 @@ module Measures
         return nil if regulation_id.blank?
 
         [
-          query_rule, value, value, value
+          query_rule, value, value
         ]
       end
 
@@ -69,32 +69,28 @@ module Measures
       def is_clause
         <<-eos
             measure_generating_regulation_id = ? OR
-            searchable_data #>> '{"regulation_code"}' = ? OR
-            justification_regulation_id = ?
+            searchable_data #>> '{"regulation_code"}' = ?
         eos
       end
 
       def is_not_clause
         <<-eos
             measure_generating_regulation_id != ? AND
-            searchable_data #>> '{"regulation_code"}' != ? AND
-            (justification_regulation_id != ? OR justification_regulation_id IS NULL)
+            searchable_data #>> '{"regulation_code"}' != ?
         eos
       end
 
       def contains_clause
         <<-eos
             measure_generating_regulation_id ilike ? OR
-            searchable_data #>> '{"regulation_code"}' ilike ? OR
-            justification_regulation_id ilike ?
+            searchable_data #>> '{"regulation_code"}' ilike ?
         eos
       end
 
       def does_not_contain_clause
         <<-eos
             measure_generating_regulation_id NOT ilike ? AND
-            searchable_data #>> '{"regulation_code"}' NOT ilike ? AND
-            justification_regulation_id NOT ilike ?
+            searchable_data #>> '{"regulation_code"}' NOT ilike ?
         eos
       end
     end

--- a/spec/unit/searches/measures/regulation_filter_spec.rb
+++ b/spec/unit/searches/measures/regulation_filter_spec.rb
@@ -45,8 +45,7 @@ describe "Measure search: regulation filter" do
         value: "R5555555"
       )
 
-      expect(res.count).to be_eql(1)
-      expect(res[0].measure_sid).to be_eql(c_measure.measure_sid)
+      expect(res.count).to be_eql(0)
 
       res = search_results(
         enabled: true,


### PR DESCRIPTION
Prior to this change, results were returned for measures that had the
regulation as it's "justification regulation".

This change changes the search so that we only return results for
"generating regulation" and NOT the "justification regulation"

https://uktrade.atlassian.net/browse/TARIFFS-138