### PR TITLE
Fix: Breadcrumbs for Create Regulation

### DIFF
--- a/app/views/workbaskets/create_regulation/_breadcrumbs.html.slim
+++ b/app/views/workbaskets/create_regulation/_breadcrumbs.html.slim
@@ -3,8 +3,5 @@
     li
       = link_to "Main menu", root_url
 
-    li
-      = link_to "Regulations", regulations_url
-
     li aria-current="page"
       | Create a new regulation


### PR DESCRIPTION
Prior to this change, there was an extra breadcrumb linking to find
regulation.

This change removes the extra breadcrumb

https://uktrade.atlassian.net/browse/TARIFFS-415