### PR TITLE
Fix issue with vue instance, use date-gds

### DIFF
--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -116,6 +116,34 @@
     <div id="global-app-error" class="app-error hidden"></div>
 
     <%= yield :body_end %>
+    <script>
+        /**
+         * A Vue application should consists of a root Vue instance created with new Vue,
+         * optionally organized into a tree of nested, reusable components. Either that
+         * or work with single-file components.
+         *
+         * Unfortunatelly current application initialises many vue instances that resulting
+         * in undesirable side effects.
+         *
+         * An quick workaround to was to create the below clean instance that then can be
+         * used on demand when it is required in order to make proper components to work
+         *
+         * @see {@link https://vuejs.org/v2/guide/instance.html|Vue Instance}
+         * @see {@link https://vuejs.org/v2/guide/single-file-components.html|Vue Single File Components}
+         * @author Panos Paralakis
+         *
+         */
+        $(document).ready(function() {
+          if($(".vue-instance")[0]){
+            var app = new Vue({
+              el: '.vue-instance',
+              data: {
+                errors: null
+              }
+            })
+          }
+        })
+    </script>
     <%= javascript_include_tag "govuk-template.js", integrity: true, crossorigin: "anonymous" %>
     <%# if no GOVUK-namespaced module has loaded we can assume JS has failed and remove the class %>
     <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>

--- a/app/views/regulations/search/_form.html.slim
+++ b/app/views/regulations/search/_form.html.slim
@@ -8,14 +8,9 @@
 
       = f.input :regulation_group_id, as: :select, collection: regulation_search_form.regulation_groups, label_method: :description, value_method: :regulation_group_id, include_blank: true, prompt: "- select regulation group -", label: "Select the regulation group", input_html: { class: "selectize" }
 
-      .bootstrap-row
-        .col-sm-6.col-md-4.col-lg-4
-          = f.input :start_date, label: "Select start date", input_html: { class: "start-date", "data-parsley-moment" => true, "data-parsley-max-date-to" => "#search_end_date", "data-parsley-max-date-to-message" => "Start date should not be greater than End date", "data-parsley-trigger" => "change", "data-parsley-trigger-after-failure" => "change" }
-
-        .col-sm-6.col-md-4.col-lg-4
-          = f.input :end_date, label: "Select end date", input_html: { class: "end-date", "data-parsley-moment" => true, "data-parsley-min-date-to" => "#search_start_date", "data-parsley-min-date-to-message" => "End date should be greater than Start date", "data-parsley-trigger" => "change", "data-parsley-trigger-after-failure" => "change" }
-
-      / = f.input :geographical_area_id, as: :select, collection: regulation_search_form.geographical_areas, label_method: :description, value_method: :geographical_area_id, include_blank: true, prompt: "- start typing -", input_html: { class: "selectize", "data-min-length" => 1, "data-options" => regulation_search_form.geographical_areas.map(&:to_json).to_json, "data-value" => "geographical_area_id", "data-code" => "geographical_area_id", "data-label" => "description", "data-code-class" => "prefix--region" }, label: "Select a geographical area to which this regulation's measures apply"
+      .vue-instance
+        = content_tag "date-gds", "", "label" => "Start date from", "value" => regulation_search_form.start_date,  "id" => "search_start_date", "input_name" => "search[start_date]"
+        = content_tag "date-gds", "", "label" => "End date to", "value" => regulation_search_form.end_date,  "id" => "search_end_date", "input_name" => "search[end_date]"
 
       = f.input :keywords, as: :text, rows: 3, label: "Enter keyword(s)", hint: "If you know the ID of the regulation, then you can enter the ID in the box below. Alternatively, enter any other keyword(s) to help locate the regulation."
 

--- a/app/views/shared/vue_templates/_date_gds.html.erb
+++ b/app/views/shared/vue_templates/_date_gds.html.erb
@@ -11,11 +11,11 @@
       <div class="form-date">
         <div class="form-group form-group-day">
           <label class="form-label" for="day">Day</label>
-          <input class="form-control" id="day" name="day" type="string" pattern="[0-9]*" minlength="2" maxlength="2" title="Two digits day" v-bind:class='{ "form-control-error": errorMessage }' v-bind:required="required">
+          <input class="form-control" id="day" name="day" type="string" pattern="[0-9]*" minlength="1" maxlength="2" title="Two digits day" v-bind:class='{ "form-control-error": errorMessage }' v-bind:required="required">
         </div>
         <div class="form-group form-group-month">
           <label class="form-label" for="month">Month</label>
-          <input class="form-control" id="month" name="month" type="string" pattern="[0-9]*" minlength="2" maxlength="2" title="Two digits month" v-bind:class='{ "form-control-error": errorMessage }' v-bind:required="required">
+          <input class="form-control" id="month" name="month" type="string" pattern="[0-9]*" minlength="1" maxlength="2" title="Two digits month" v-bind:class='{ "form-control-error": errorMessage }' v-bind:required="required">
         </div>
         <div class="form-group form-group-year">
           <label class="form-label" for="year">Year</label>

--- a/spec/features/regulations_listing_spec.rb
+++ b/spec/features/regulations_listing_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe "Regulations listing" do
+RSpec.describe "Regulations listing", :js do
   let!(:regulation_group) do
     group = create(:regulation_group)
     create(:regulation_group_description, regulation_group_id: group.regulation_group_id, description: "Various")
@@ -19,7 +19,7 @@ describe "Regulations listing" do
   end
 
   it "Find a regulation page" do
-    visit root_url
+    visit(root_path)
     expect(page).to have_link("Find and edit regulations")
 
     click_link("Find and edit regulations")
@@ -27,18 +27,22 @@ describe "Regulations listing" do
 
     expect(page).to have_content("Enter criteria to help locate a regulation")
     expect(page).to have_content("Select the regulation group")
-    expect(page).to have_content("Select start date")
-    expect(page).to have_content("Select end date")
+    expect(page).to have_content("Start date from")
+    expect(page).to have_content("End date to")
     expect(page).to have_content("Enter keyword(s)")
     expect(page).to have_content("If you know the ID of the regulation, then you can enter the ID in the box below. Alternatively, enter any other keyword(s) to help locate the regulation.")
   end
 
   it "Search params for a regulation" do
-    visit regulations_path
+    visit(regulations_path)
 
-    select("Various", from: "Select the regulation group")
-    fill_in("Select start date", with: Date.today.strftime("%d/%m/%Y"))
-    fill_in("Select end date", with: (Date.today + 2.days).strftime("%d/%m/%Y"))
+    within("div.search_regulation_group_id") do
+      search_for_value(type_value: "Various", select_value: "Various")
+    end
+
+    input_date_gds("#search_start_date", Date.today)
+    input_date_gds("#search_end_date", Date.today + 2.days)
+
     fill_in("Enter keyword(s)", with: base_regulation.base_regulation_id)
 
     find(".form-actions .button").click


### PR DESCRIPTION
A Vue application should consists of a root Vue instance created with new Vue,
optionally organized into a tree of nested, reusable components. Either that
or work with single-file components.

Unfortunatelly current application initialises many vue instances that resulting
in undesirable side effects.
An quick workaround was to create a new clean instance that then can be
used on demand when it is required, in order to make proper components to work

**See:** [Vue Instance](https://vuejs.org/v2/guide/instance.html)
**See:** [Vue Single File Components](https://vuejs.org/v2/guide/single-file-components.html)