### PR TITLE
Fix: Raise error for invalid measure_sids or commodity codes for create/edit footnote

### DIFF
--- a/app/interactors/workbasket_interactions/create_footnote/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/create_footnote/initial_validator.rb
@@ -103,7 +103,7 @@ module WorkbasketInteractions
       def check_commodity_codes!
         return unless can_add_commodity_code?
 
-        if commodity_codes.present?
+        if commodity_codes.present? && !commodity_codes_are_invalid?
           list = attrs_parser.parse_list_of_values(commodity_codes)
 
           if list.present?
@@ -116,12 +116,24 @@ module WorkbasketInteractions
             end
           end
         end
+
+        if commodity_codes_are_invalid?
+          @errors[:commodity_codes] = errors_translator(:commodity_codes_not_recognised)
+        end
+      end
+
+      def commodity_codes_are_invalid?
+        valid_codes = commodity_codes.split(', ').map do |code|
+          code.length == 10 && code_contains_only_integers(code)
+        end
+
+        valid_codes.include? false
       end
 
       def check_measures!
         return unless can_add_measures?
 
-        if measure_sids.present?
+        if measure_sids.present? && !measure_sids_are_invalid?
           list = attrs_parser.parse_list_of_values(measure_sids)
 
           if list.present?
@@ -134,6 +146,22 @@ module WorkbasketInteractions
             end
           end
         end
+
+        if measure_sids_are_invalid?
+          @errors[:measure_sids] = errors_translator(:measures_not_recognised)
+        end
+      end
+
+      def measure_sids_are_invalid?
+        valid_sids = measure_sids.split(', ').map do |sid|
+          sid.length == 7 && code_contains_only_integers(sid)
+        end
+
+        valid_sids.include? false
+      end
+
+      def code_contains_only_integers(sid)
+        sid.scan(/\D/).empty?
       end
 
       def can_add_commodity_code?


### PR DESCRIPTION
Prior to this commit, if a user entered an invalid measure_sid or commodity
code then it rendered a 'server error'.

This commit handles this issue and raises an error in the way we would expect.