### PR TITLE
Fix: Footnotes searching by measure sid bug

### DIFF
--- a/app/controllers/footnotes/footnotes_controller.rb
+++ b/app/controllers/footnotes/footnotes_controller.rb
@@ -31,7 +31,7 @@ module Footnotes
     end
 
     expose(:search_results) do
-      searcher.results
+      measure_sids_are_invalid? ? nil : searcher.results
     end
 
     def validate_search_settings
@@ -54,6 +54,14 @@ module Footnotes
 
     def collection
       Footnote.q_search(params)
+    end
+
+    def measure_sids_are_invalid?
+      valid_sids = search_ops['measure_sids'].split(', ').map do |sid|
+        sid.scan(/\D/).empty?
+      end
+
+      valid_sids.include? false
     end
   end
 end


### PR DESCRIPTION
Prior to this change, when a user searched for a footnote but entered an
invalid measure_sid then the page crashed.

This change stops the page crashing and renders 'no results found'
instead.