### PR TITLE
Fix: Show users correct information on associated codes

### DIFF
--- a/app/interactors/workbasket_interactions/create_footnote/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/create_footnote/initial_validator.rb
@@ -124,7 +124,7 @@ module WorkbasketInteractions
 
       def commodity_codes_are_invalid?
         valid_codes = commodity_codes.split(', ').map do |code|
-          code.length == 10 && code_contains_only_integers(code)
+          code.length == 10 && code_contains_only_integers?(code)
         end
 
         valid_codes.include? false
@@ -154,13 +154,13 @@ module WorkbasketInteractions
 
       def measure_sids_are_invalid?
         valid_sids = measure_sids.split(', ').map do |sid|
-          sid.length == 7 && code_contains_only_integers(sid)
+          sid.length == 7 && code_contains_only_integers?(sid)
         end
 
         valid_sids.include? false
       end
 
-      def code_contains_only_integers(sid)
+      def code_contains_only_integers?(sid)
         sid.scan(/\D/).empty?
       end
 

--- a/app/interactors/workbasket_interactions/edit_footnote/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/edit_footnote/initial_validator.rb
@@ -170,7 +170,7 @@ module WorkbasketInteractions
 
       def commodity_codes_are_invalid?
         valid_codes = commodity_codes.split(', ').map do |code|
-          code.length == 10 && code_contains_only_integers(code)
+          code.length == 10 && code_contains_only_integers?(code)
         end
 
         valid_codes.include? false
@@ -200,7 +200,7 @@ module WorkbasketInteractions
 
       def measure_sids_are_invalid?
         valid_sids = measure_sids.split(', ').map do |sid|
-          sid.length == 7 && code_contains_only_integers(sid)
+          sid.length == 7 && code_contains_only_integers?(sid)
         end
 
         valid_sids.include? false
@@ -218,6 +218,10 @@ module WorkbasketInteractions
 
           nil
         end
+      end
+
+      def code_contains_only_integers?(code)
+        code.scan(/\D/).empty?
       end
 
       def can_add_commodity_code?

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -224,7 +224,7 @@ class Footnote < Sequel::Model
   def associated_records_count
     goods_nomenclatures.count +
       export_refund_nomenclatures.count +
-      measures.count +
+      current_associated_measures.count +
       additional_codes.count +
       meursing_headings.count
   end

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -185,6 +185,10 @@ class Footnote < Sequel::Model
     # # FO17
     # associated :footnote_type, ensure: :footnote_type_validity_period_spans_validity_periods
 
+  def current_associated_measures
+    footnote_association_measures.select { |association| association.operation == 'C'}.map(&:measure_sid)
+  end
+
   def code
     "#{footnote_type_id}#{footnote_id}"
   end

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -189,6 +189,10 @@ class Footnote < Sequel::Model
     footnote_association_measures.select { |association| association.operation == 'C'}.map(&:measure_sid)
   end
 
+  def current_associated_commodity_codes
+    FootnoteAssociationGoodsNomenclature.current.where(footnote_id: footnote_id, footnote_type: footnote_type_id)
+  end
+
   def code
     "#{footnote_type_id}#{footnote_id}"
   end
@@ -222,7 +226,7 @@ class Footnote < Sequel::Model
   end
 
   def associated_records_count
-    goods_nomenclatures.count +
+    current_associated_commodity_codes.count +
       export_refund_nomenclatures.count +
       current_associated_measures.count +
       additional_codes.count +

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -186,7 +186,7 @@ class Footnote < Sequel::Model
     # associated :footnote_type, ensure: :footnote_type_validity_period_spans_validity_periods
 
   def current_associated_measures
-    footnote_association_measures.select { |association| association.operation == 'C'}.map(&:measure_sid)
+    footnote_association_measures.select { |association| association.operation == :create }.map(&:measure_sid)
   end
 
   def current_associated_commodity_codes

--- a/app/models/footnote_association_goods_nomenclature.rb
+++ b/app/models/footnote_association_goods_nomenclature.rb
@@ -17,4 +17,10 @@ class FootnoteAssociationGoodsNomenclature < Sequel::Model
   def subrecord_code
     "20".freeze
   end
+
+  dataset_module do
+    def current
+      where("validity_end_date > :date or validity_end_date is NULL", date: Date.today)
+    end
+  end
 end

--- a/app/views/workbaskets/edit_footnote/show.html.slim
+++ b/app/views/workbaskets/edit_footnote/show.html.slim
@@ -1,28 +1,26 @@
-.panel.panel--confirmation
-  h1.heading-xlarge
-    | Footnote submitted
+.breadcrumbs
+  ol
+    li
+      = link_to "Main menu", root_url
 
-  h3.heading-medium
-    | The edited footnote of type
-    =<> "'#{footnote.decorate.footnote_type_description}'"
-    | and ID
-    =<> "'#{footnote.footnote_id}'"
-    | has been submitted for cross-check.
+    li
+      = link_to "Footnote", footnotes_url
 
-br
-h3.heading-medium.m-t-100
-  | Next steps
+    li aria-current="page"
+      | View Footnote
 
-ul class="list"
-  li
-    = link_to "Withdraw submission / edit footnote", "#",
-    data: { target_url: withdraw_workbasket_from_workflow_edit_footnote_url(workbasket.id), target_modal: workbasket.id },
-    class: "js-main-menu-show-withdraw-confirmation-link"
-  li
-    = link_to "View this footnote", read_only_section_url
-  li
-    = link_to "Edit another footnote", search_footnotes_url
-  li
-    = link_to "Return to main menu", root_url
+header
+  h1.heading-large
+    | View footnote
 
-= render "workbaskets/main_menu_parts/withdraw_confirmation_popup", modal_id: "withdraw_confirmation_popup_#{workbasket.id}", workbasket: workbasket
+  .view-workbasket-container
+    = render "workbaskets/edit_footnote/workflow_screens_parts/notifications/block", screen_type: :view
+    = render "workbaskets/edit_footnote/workflow_screens_parts/actions_allowed"
+    = render "workbaskets/edit_footnote/workflow_screens_parts/workbasket_details"
+
+    - if iam_workbasket_author? && workbasket_rejected?
+      = link_to "Edit footnote", '#',
+              data: {target_url: move_to_editing_mode_edit_footnote_url(workbasket.id)},
+              class: "secondary-button view-workbasket-edit-measures-link js-main-menu-show-withdraw-confirmation-link"
+
+    = render "workbaskets/edit_footnote/workflow_screens_parts/summary_of_configuration"

--- a/app/views/workbaskets/edit_footnote/steps/review_and_submit/_footnote.html.slim
+++ b/app/views/workbaskets/edit_footnote/steps/review_and_submit/_footnote.html.slim
@@ -23,6 +23,6 @@
         td.description-column
           = footnote.description
         td.measures-column
-          = footnote.measures.map { |measure| measure.measure_sid }.join(', ')
+          = footnote.current_associated_measures.join(', ')
         td.measures-column
           = footnote.goods_nomenclatures.map { |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }.join(', ')

--- a/app/views/workbaskets/edit_footnote/steps/review_and_submit/_footnote.html.slim
+++ b/app/views/workbaskets/edit_footnote/steps/review_and_submit/_footnote.html.slim
@@ -25,4 +25,4 @@
         td.measures-column
           = footnote.current_associated_measures.join(', ')
         td.measures-column
-          = footnote.goods_nomenclatures.map { |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }.join(', ')
+          = footnote.current_associated_commodity_codes.map{ |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }.join(', ')

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -36,4 +36,4 @@ table.create-measures-details-table
       td.heading_column
         | Associated goods codes
       td
-        = footnote.goods_nomenclatures.map{ |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }.join(', ')
+        = footnote.current_associated_commodity_codes.map{ |nomenclature| nomenclature.goods_nomenclature_item_id.to_i }.join(', ')

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -24,7 +24,7 @@ table.create-measures-details-table
       td.heading_column
         | Associated measures
       td
-        = footnote.measures.map { |measure| measure.measure_sid }.join(', ')
+        = footnote.current_associated_measures.join(', ')
 
     tr
       td.heading_column


### PR DESCRIPTION
Prior to this change, all associated codes were displayed to a user when cross-checking or approving a footnote, regardless of any deletions.

This PR fixes this issue and only shows currently active associations to cross-checkers and approvers.