### PR TITLE
Fix period type quota start dates

### DIFF
--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -14,29 +14,7 @@
 
     <div class="panel panel-border-narrow" v-if="section.type">
       <fieldset v-if="section.type != 'custom'">
-        <date-gds v-if="section.type == 'annual'" label="What is the start date of this section?" :value.sync="section.start_date" id="annual_start_date"></date-gds>
-        <div v-else class="form-group">
-          <fieldset>
-            <legend>
-              <h3 class="heading-medium m-t-5">What is the start date of this section?</h3>
-            </legend>
-
-            <div class="form-date">
-              <div class="form-group form-group-day">
-                <label class="form-label" for="day">Day</label>
-                <input class="form-control" id="day" name="day" type="string" pattern="[0-9]*" minlength="2" maxlength="2" title="Two digits day" value="01" disabled>
-              </div>
-              <div class="form-group form-group-month">
-                <label class="form-label" for="month">Month</label>
-                <input class="form-control" id="month" name="month" type="string" pattern="[0-9]*" minlength="2" maxlength="2" title="Two digits month" value="01" disabled>
-              </div>
-              <div class="form-group form-group-year">
-                <label class="form-label" for="year">Year</label>
-                <input class="form-control" id="quota-period-year" name="year" type="string" pattern="[0-9]*" minlength="4" maxlength="4" title="Four digits year" :value="section.start_date && section.start_date.split('/')[2]" @input="section.start_date = '01/01/'+$event.target.value;">
-              </div>
-            </div>
-          </fieldset>
-        </div>
+        <date-gds label="What is the start date of this section?" :value.sync="section.start_date" id="quota_start_date"></date-gds>
 
         <div class="form-group">
           <label for="" class="form-label">

--- a/spec/features/workbasket/quota/quota_creation_validations_spec.rb
+++ b/spec/features/workbasket/quota/quota_creation_validations_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "adding quotas", :js do
     within(find("fieldset", text: "What period type will this section have?")) do
       search_for_value(type_value: "Annual", select_value: "Annual")
     end
-    input_date_gds("#annual_start_date", "01/01/2019".to_date)
+    input_date_gds("#quota_start_date", "01/01/2019".to_date)
     within(find("form", text: "How will the quota balance(s) in this section be measured?")) do
       find("#measurement-unit-code").click
       find(".selectize-dropdown-content .selection", text: measurement_unit.measurement_unit_code).click

--- a/spec/features/workbasket/quota/quota_spec.rb
+++ b/spec/features/workbasket/quota/quota_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "quotas", :js do
     within(find("fieldset", text: "What period type will this section have?")) do
       search_for_value(type_value: "Annual", select_value: "Annual")
     end
-    input_date_gds("#annual_start_date", "01/01/2019".to_date)
+    input_date_gds("#quota_start_date", "01/01/2019".to_date)
     within(find("form", text: "How will the quota balance(s) in this section be measured?")) do
       find("#measurement-unit-code").click
       find(".selectize-dropdown-content .selection", text: measurement_unit.measurement_unit_code).click


### PR DESCRIPTION
Prior to this change, month and day were disabled for Bi-Annual,
Quarterly and Monthly periods

This change removes the previously applied logic for dates based on
period type

**Resolves:** [https://uktrade.atlassian.net/browse/TARIFFS-423](https://uktrade.atlassian.net/browse/TARIFFS-423)