### PR TITLE
Fix: Server errors generated from edit/create footnotes

### DIFF
--- a/app/interactors/workbasket_interactions/create_footnote/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_footnote/settings_saver.rb
@@ -192,6 +192,8 @@ module WorkbasketInteractions
       end
 
       def add_new_commodity_codes_associations!
+        return unless can_add_commodity_code?
+
         commodity_codes.map do |code|
           gn = GoodsNomenclature.actual
                                 .by_code(code)
@@ -219,6 +221,8 @@ module WorkbasketInteractions
       end
 
       def add_new_measures_associations!
+        return unless can_add_measures?
+
         measure_sids.map do |measure_sid|
           measure = Measure.by_measure_sid(measure_sid)
                            .first
@@ -266,6 +270,14 @@ module WorkbasketInteractions
 
       def validator_class(record)
         "#{record.class.name}Validator".constantize
+      end
+
+      def can_add_commodity_code?
+        ['NC', 'PN', 'TN'].include?(footnote_type_id)
+      end
+
+      def can_add_measures?
+        ['CD','CG','DU','EU','IS','MG','MX','OZ','PB','TM','TR'].include?(footnote_type_id)
       end
     end
   end

--- a/app/interactors/workbasket_interactions/edit_footnote/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/edit_footnote/settings_saver.rb
@@ -130,8 +130,8 @@ module WorkbasketInteractions
               add_footnote_description!
             end
 
-            update_commodity_code_associations!
-            update_measures_associations!
+            update_commodity_code_associations! if can_add_commodity_code?
+            update_measures_associations! if can_add_measures?
           end
 
           parse_and_format_conformance_rules
@@ -168,7 +168,7 @@ module WorkbasketInteractions
               @conformance_errors.merge!(get_conformance_errors(footnote_description))
             end
 
-            if commodity_codes_candidates.present?
+            if commodity_codes_candidates.present? && can_add_commodity_code?
               commodity_codes_candidates.map do |item|
                 unless item.conformant?
                   @conformance_errors.merge!(get_conformance_errors(item))
@@ -176,7 +176,7 @@ module WorkbasketInteractions
               end
             end
 
-            if measures_candidates.present?
+            if measures_candidates.present? && can_add_measures?
               measures_candidates.map do |item|
                 unless item.conformant?
                   @conformance_errors.merge!(get_conformance_errors(item))
@@ -387,6 +387,14 @@ module WorkbasketInteractions
         ).assign!(false)
 
         description.save
+      end
+
+      def can_add_commodity_code?
+        ['NC', 'PN', 'TN'].include?(original_footnote.footnote.footnote_type_id)
+      end
+
+      def can_add_measures?
+        ['CD','CG','DU','EU','IS','MG','MX','OZ','PB','TM','TR'].include?(original_footnote.footnote.footnote_type_id)
       end
     end
   end


### PR DESCRIPTION
This PR fixes issues surrounding server errors being displayed on edit footnote and create footnote form screens when incomplete information was entered.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-392