### PR TITLE
Fix: Withdraw additional code from workbasket causing error

### DIFF
--- a/app/controllers/bulks_base_controller.rb
+++ b/app/controllers/bulks_base_controller.rb
@@ -23,7 +23,7 @@ private
   helper_method :workbasket_is_editable?
 
   def require_to_be_workbasket_owner!
-    unless workbasket_author?
+    unless !workbasket || workbasket_author?
       render nothing: true, status: :ok
       false
     end

--- a/app/controllers/measures/bulks_controller.rb
+++ b/app/controllers/measures/bulks_controller.rb
@@ -159,9 +159,9 @@ module Measures
     end
 
     def destroy
-      workbasket.clean_up_workbasket!
+      workbasket.clean_up_workbasket! if workbasket
 
-      redirect_to root_url
+      redirect_to root_url, status: 303
     end
   end
 end


### PR DESCRIPTION
Prior to this change, if user tried to withdraw additional code(s) from a workbasket
in a way that would leave the workbasket empty, errors were being raised. This was
due to the workbasket no longer existing once it's contents had been deleted.

This caused issues in the measures/bulks_controller when some logic depended on
data from the now non existent workbasket.

This commit fixes these issues.