### PR TITLE
Need to skip the GIS tables that the postgres postGIS extension creates.

### DIFF
--- a/db/migrate/20130207150008_add_oplog_columns.rb
+++ b/db/migrate/20130207150008_add_oplog_columns.rb
@@ -2,6 +2,7 @@ Sequel.migration do
   up do
     Sequel::Model.db.tables
                     .reject{|t_name| t_name.in?([:tariff_updates, :sections, :schema_migrations])}
+                    .reject{|t_gis_table| t_gis_table.in?([:spatial_ref_sys,:raster_columns, :raster_overviews, :geography_columns, :geometry_columns ])}
                     .reject{|t| t.to_s =~ /chief|chapter_notes|section_notes|chapters_sections|hidden|search/}.each do |table_name|
       alter_table table_name do
         add_primary_key :oid
@@ -14,6 +15,7 @@ Sequel.migration do
   down do
     Sequel::Model.db.tables
                     .reject{|t_name| t_name.in?([:tariff_updates, :sections, :schema_migrations])}
+                    .reject{|t_gis_table| t_gis_table.in?([:spatial_ref_sys,:raster_columns, :raster_overviews, :geography_columns, :geometry_columns ])}
                     .reject{|t| t.to_s =~ /chief|chapter_notes|section_notes|chapters_sections|hidden|search/}.each do |table_name|
       alter_table table_name do
         drop_column :oid

--- a/db/migrate/20130208142043_rename_to_oplog_tables.rb
+++ b/db/migrate/20130208142043_rename_to_oplog_tables.rb
@@ -2,6 +2,7 @@ Sequel.migration do
   up do
     Sequel::Model.db.tables
                     .reject{|t_name| t_name.in?([:tariff_updates, :sections, :schema_migrations])}
+                    .reject{|t_gis_table| t_gis_table.in?([:spatial_ref_sys,:raster_columns, :raster_overviews, :geography_columns, :geometry_columns ])}
                     .reject{|t| t.to_s =~ /chief|chapter_notes|section_notes|chapters_sections|hidden|search/}.each do |table_name|
       rename_table table_name, :"#{table_name}_oplog"
     end
@@ -10,6 +11,7 @@ Sequel.migration do
   down do
     Sequel::Model.db.tables
                     .reject{|t_name| t_name.in?([:tariff_updates, :sections, :schema_migrations])}
+                    .reject{|t_gis_table| t_gis_table.in?([:spatial_ref_sys,:raster_columns, :raster_overviews, :geography_columns, :geometry_columns ])}
                     .reject{|t| t.to_s =~ /chief|chapter_notes|section_notes|chapters_sections|hidden|search/}.each do |table_name|
       rename_table table_name, table_name.to_s.split("_oplog").first
     end

--- a/db/migrate/20130208170444_add_index_on_operation_date.rb
+++ b/db/migrate/20130208170444_add_index_on_operation_date.rb
@@ -2,6 +2,7 @@ Sequel.migration do
   up do
     Sequel::Model.db.tables
                     .reject{|t_name| t_name.in?([:tariff_updates, :sections, :schema_migrations])}
+                    .reject{|t_gis_table| t_gis_table.in?([:spatial_ref_sys,:raster_columns, :raster_overviews, :geography_columns, :geometry_columns ])}
                     .reject{|t| t.to_s =~ /chief|chapter_notes|section_notes|chapters_sections|hidden|search/}.each do |table_name|
       alter_table table_name do
         index_name = [
@@ -17,6 +18,7 @@ Sequel.migration do
   down do
     Sequel::Model.db.tables
                     .reject{|t_name| t_name.in?([:tariff_updates, :sections, :schema_migrations])}
+                    .reject{|t_gis_table| t_gis_table.in?([:spatial_ref_sys,:raster_columns, :raster_overviews, :geography_columns, :geometry_columns ])}
                     .reject{|t| t.to_s =~ /chief|chapter_notes|section_notes|chapters_sections|hidden|search/}.each do |table_name|
       alter_table table_name do
         drop_index :operation_date, name: :"#{table_name.to_s.split("_").map(&:first).join}_operation_date"

--- a/db/migrate/20151214224024_add_model_views_reloaded.rb
+++ b/db/migrate/20151214224024_add_model_views_reloaded.rb
@@ -26,6 +26,7 @@ Sequel.migration do
 
     Sequel::Model.db.tables
                     .reject{|t_name| t_name.in?([:tariff_updates, :sections, :schema_migrations])}
+                    .reject{|t_gis_table| t_gis_table.in?([:spatial_ref_sys,:raster_columns, :raster_overviews, :geography_columns, :geometry_columns ])}
                     .reject{|t| t.to_s =~ Regexp.new(rejected_tables.join("|"))}.each do |table_name|
       # name of the view we are going to build
       view_name = table_name.to_s.split("_oplog").first
@@ -60,6 +61,7 @@ Sequel.migration do
   down do
     Sequel::Model.db.tables
                     .reject{|t_name| t_name.in?([:tariff_updates, :sections, :schema_migrations])}
+                    .reject{|t_gis_table| t_gis_table.in?([:spatial_ref_sys,:raster_columns, :raster_overviews, :geography_columns, :geometry_columns ])}
                     .reject{|t| t.to_s =~ Regexp.new(rejected_tables.join("|"))}.each do |table_name|
       view_name = table_name.to_s.split("_oplog").first
       drop_view view_name


### PR DESCRIPTION
There are 4 migration scripts that add columns to tables it finds in the database.  On PaaS there are extra GIS tables that need to be skipped, otherwise the process will fail (and abort).  This would be only be a problem when creating a clean environment in PaaS. Luckily local initialisation is not affected.