### PR TITLE
Fix: Remove footnotes from measures page

### DIFF
--- a/app/assets/javascripts/components/bulk/measures/bulk-edit-measures.js
+++ b/app/assets/javascripts/components/bulk/measures/bulk-edit-measures.js
@@ -20,7 +20,6 @@ $(document).ready(function() {
           window.BulkEditing.Measures.Actions.additional,
           window.BulkEditing.Measures.Actions.duties,
           window.BulkEditing.Measures.Actions.conditions,
-          window.BulkEditing.Measures.Actions.footnotes,
           window.BulkEditing.Measures.Actions.remove,
           window.BulkEditing.Measures.Actions.delete
         ]

--- a/app/views/workbaskets/create_measures/steps/_duties_conditions_footnotes.html.slim
+++ b/app/views/workbaskets/create_measures/steps/_duties_conditions_footnotes.html.slim
@@ -1,3 +1,2 @@
 = render "workbaskets/shared/steps/duties_conditions_footnotes/conditions", f: f, record_type: 'measures'
 = render "workbaskets/create_measures/steps/duties_conditions_footnotes/duty_expression", f: f, record_type: 'measures'
-= render "workbaskets/shared/steps/duties_conditions_footnotes/footnotes", f: f, record_type: 'measures'


### PR DESCRIPTION
The ability to create and add footnotes from the create/edit measures pages does not work.

This functionality is available through the create/edit footnotes pages and this is how the users should be carrying out this task.

This PR deletes the add footnotes section of the create/edit measures pages.