### PR TITLE
Fix: Cancel edit quota bug

### DIFF
--- a/app/views/quotas/bulks/work_with_selected.erb
+++ b/app/views/quotas/bulks/work_with_selected.erb
@@ -206,7 +206,7 @@
       <button type="submit" class="button" v-on:click="validate" :disabled="disableSubmit">
         {{buttonText}}
       </button>
-      <a href="/app/assets/stylesheets" class="secondary-button">
+      <a href="/" class="secondary-button">
         Cancel
       </a>
     </div>


### PR DESCRIPTION
Prior to this fix, when a user selected a quota to edit, but decided to cancel before creating the workbasket
the app crashed. This was due to an incorrect link on the cancel button.

This fix corrects this issue by redirecting the user to the home page after cancelling the edit quota
workbasket.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-424