### PR TITLE
Fix: No withdraw button for edit footnotes

### DIFF
--- a/app/helpers/workbasket_helper.rb
+++ b/app/helpers/workbasket_helper.rb
@@ -358,6 +358,8 @@ module WorkbasketHelper
       withdraw_workbasket_from_workflow_edit_nomenclature_url(workbasket.id)
     elsif workbasket.object.type == "create_footnote"
       withdraw_workbasket_from_workflow_create_footnote_url(workbasket.id)
+    elsif workbasket.object.type == "edit_footnote"
+      withdraw_workbasket_from_workflow_edit_footnote_url(workbasket.id)
     end
   end
 


### PR DESCRIPTION
Prior to this change, a user did not have the option to withdraw an edit
footnote workbasket from workflow.

This commit fixes this issue.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-438