### PR TITLE
Fix: Withdraw edit footnotes bug

### DIFF
--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/_actions_allowed.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/_actions_allowed.html.slim
@@ -2,7 +2,7 @@
   .view-workbasket-actions-allowed
     - if iam_workbasket_author? && workbasket.can_withdraw?
       = link_to "Withdraw workbasket from workflow", "#",
-      data: { target_url: withdraw_workbasket_from_workflow_create_footnote_url(workbasket.id), target_modal: workbasket.id },
+      data: { target_url: withdraw_workbasket_from_workflow_edit_footnote_url(workbasket.id), target_modal: workbasket.id },
       class: "button js-main-menu-show-withdraw-confirmation-link"
       br
 


### PR DESCRIPTION
Prior to this change, when a user viewed a submitted edit footnote workbasket and
clicked 'withdraw basket from workflow' it showed a 'create footnote' screen with errors.

This was due to the button having an incorrect link.

This commit fixes this issue.