### PR TITLE
Fix: Errors shown when no codes are entered

### DIFF
--- a/app/interactors/workbasket_interactions/edit_footnote/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/edit_footnote/initial_validator.rb
@@ -155,6 +155,8 @@ module WorkbasketInteractions
       end
 
       def commodity_codes_are_invalid?
+        return unless commodity_codes.present?
+
         valid_codes = commodity_codes.split(', ').map do |code|
           code.length == 10 && code_contains_only_integers?(code)
         end
@@ -185,6 +187,8 @@ module WorkbasketInteractions
       end
 
       def measure_sids_are_invalid?
+        return unless measure_sids.present?
+
         valid_sids = measure_sids.split(', ').map do |sid|
           sid.length == 7 && code_contains_only_integers?(sid)
         end


### PR DESCRIPTION
Prior to this change, if no codes are entered into the measure codes or commodity
codes text fields and nothing is changed then a server error is raised.

This is due to no guard clause to ensure that these codes are actually present.

This commit fixes this issue.