### PR TITLE
Fix: Change DIT XML file naming convention

### DIFF
--- a/app/services/xml_generation/upload.rb
+++ b/app/services/xml_generation/upload.rb
@@ -41,11 +41,18 @@ module XmlGeneration
     end
 
     def remote_metadata_file_name
-      "DIT#{record.envelope_id}_metadata.xml"
+      "#{remote_file_name_base}_metadata.xml"
     end
 
     def remote_main_file_name
-      "DIT#{record.envelope_id}.xml"
+      "#{remote_file_name_base}.xml"
+    end
+
+    # Format: Using the example of the file from 2019 with an envelope ID of 142, the filename will be DIT190142.xml, i.e.
+    # DIT, followed by the year (two digits), followed by
+    # the envelope ID (pre-padded with zeroes up to 4 digits)
+    def remote_file_name_base
+      "DIT#{Date.today.strftime("%y")}#{record.envelope_id.to_s.rjust(4, "0")}"
     end
 
     def local_main_file_path


### PR DESCRIPTION
The filenaming convention has been agreed by HMRC and European Dynamics,
and the decision has been taken to omit the timestamp, which had been
included in the HMRC interface documentation. Therefore the filenaming
conventions are as follows:

For the Taric 3 XML file:
Using the example of the file from 2019 with an envelope ID of 142, the
filename will be DIT190142.xml, i.e.
- DIT, followed by
- the year (two digits), followed by
- the envelope ID (pre-padded with zeroes up to 4 digits), followed by
- .xml

For the metadata file:
As above, but with _metadata inserted before the .xml extension