### PR TITLE
Fix: Viewing workbasket details for create regulation

### DIFF
--- a/app/views/workbaskets/create_regulation/steps/_review_and_submit.html.slim
+++ b/app/views/workbaskets/create_regulation/steps/_review_and_submit.html.slim
@@ -8,6 +8,7 @@ script
                         } do |f|
 
   = render "workbaskets/create_regulation/steps/review_and_submit/message", read_only: read_only
+  = render "workbaskets/create_regulation/workflow_screens_parts/workbasket_details"
   = render "workbaskets/create_regulation/steps/review_and_submit/pdf_document", read_only: read_only
   = render "workbaskets/create_regulation/steps/review_and_submit/details", read_only: read_only
 


### PR DESCRIPTION
Prior to this change, workbasket details are not shown when viewing or
reviewing a Create Regulation Workbasket.

This change shows the deets.

https://uktrade.atlassian.net/browse/TARIFFS-462