### PR TITLE
Fix: Regulations should conform to the new UK initials 'P,U,S,X,N,M,Q,A'

### DIFF
--- a/app/interactors/workbasket_interactions/create_regulation/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_regulation/settings_saver.rb
@@ -283,7 +283,9 @@ module WorkbasketInteractions
         end
 
         if original_params[:base_regulation_id].present?
-          if original_params[:base_regulation_id].size != 8
+          if !("PUSXNMQA".include? original_params[:base_regulation_id]&.chr)
+            @errors[:base_regulation_id] = "Regulation identifier must begin with P,U,S,X,N,M,Q or A."
+          elsif original_params[:base_regulation_id].size != 8
             @errors[:base_regulation_id] = "Regulation identifier's length can be 8 chars only (eg: 'R1812345')"
           end
         else

--- a/app/interactors/workbasket_interactions/edit_regulation/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/edit_regulation/settings_saver.rb
@@ -129,7 +129,9 @@ module WorkbasketInteractions
         end
 
         if @settings_params[:base_regulation_id].present?
-          if @settings_params[:base_regulation_id].size != 8
+          if !("PUSXNMQA".include? original_params[:base_regulation_id]&.chr)
+            @errors[:base_regulation_id] = "Regulation identifier must begin with P,U,S,X,N,M,Q or A."
+          elsif original_params[:base_regulation_id].size != 8
             @errors[:base_regulation_id] = "Regulation identifier's length can be 8 chars only (eg: 'R1812345')"
           end
         else

--- a/spec/support/shared_contexts/form_savers/regulation_saver_base_context.rb
+++ b/spec/support/shared_contexts/form_savers/regulation_saver_base_context.rb
@@ -28,7 +28,7 @@ shared_context "regulation_saver_base_context" do
   let!(:base_regulation) do
     create(:base_regulation,
       base_regulation_role: "1",
-      base_regulation_id: "D9402622")
+      base_regulation_id: "N9402622")
   end
 
   let(:base_ops) do

--- a/spec/support/shared_contexts/system/create_regulation_base_context.rb
+++ b/spec/support/shared_contexts/system/create_regulation_base_context.rb
@@ -19,7 +19,8 @@ shared_context 'create_regulation_base_context' do
   let!(:base_regulation) do
     create(:base_regulation,
            base_regulation_id:
-               %w(C D A I J R).sample +
+               # %w(C D A I J R).sample + # Old EU regulation values
+               %w(P U S X N M Q A).sample +  # New UK regulation values
                Forgery(:basic).number(at_least: 10, at_most: 19).to_s +
                Forgery(:basic).number(at_least: 1000, at_most: 9999).to_s +
                Forgery(:basic).number(at_least: 0, at_most: 9).to_s,
@@ -59,7 +60,7 @@ shared_context 'create_regulation_base_context' do
         # { name: 'Publication year', value: Forgery(:basic).number(at_least: 10, at_most: 19).to_s, type: :text },
         # { name: 'Regulation number', value: Forgery(:basic).number(at_least: 1000, at_most: 9999).to_s, type: :text },
         # { name: 'Number suffix', value: Forgery(:basic).number(at_least: 0, at_most: 9).to_s, type: :text },
-        { name: 'Regulation identifier', id: 'workbasket_forms_create_regulation_form_base_regulation_id', value: 'C1234567', type: :text },
+        { name: 'Regulation identifier', id: 'workbasket_forms_create_regulation_form_base_regulation_id', value: 'N1234567', type: :text },
         { name: 'Legal ID', id: 'workbasket_forms_create_regulation_form_legal_id', value: Forgery('lorem_ipsum').characters, type: :text },
         { name: 'Description', id: 'workbasket_forms_create_regulation_form_description', value: Forgery('lorem_ipsum').sentence, type: :text },
         { name: 'Reference URL', id: 'workbasket_forms_create_regulation_form_reference_url', value: Forgery(:internet).domain_name, type: :text }


### PR DESCRIPTION
Prior to this change, there was no validation on the inital letter.

This change forces the initial letter to be one of 'P,U,S,X,N,M,Q,A'
which are the new UK values.

https://uktrade.atlassian.net/browse/TARIFFS-459