### PR TITLE
New: Upload workbasket XML automatically upon approval

### DIFF
--- a/spec/features/workbasket/cross_check_and_approval/cross_check_and_approval_spec.rb
+++ b/spec/features/workbasket/cross_check_and_approval/cross_check_and_approval_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'cross check', :js do
     allow_any_instance_of(WorkbasketValueObjects::AttributesParserBase).to receive(:measure_type) { MeasureType.first }
     allow_any_instance_of(WorkbasketValueObjects::AttributesParserBase).to receive(:regulation) { base_regulation.formatted_id }
     allow_any_instance_of(WorkbasketValueObjects::AttributesParserBase).to receive(:regulation_description) { base_regulation.information_text }
+    allow_any_instance_of(XmlGeneration::ExportWorker).to receive(:perform) { true }
     workbasket.settings.measure_sids_jsonb = "[#{measure.measure_sid}]"
     workbasket.settings.measure_sids_jsonb = "[#{measure.measure_sid}]"
     workbasket.settings.save

--- a/spec/features/workbasket/measure/measure_creation_approval_spec.rb
+++ b/spec/features/workbasket/measure/measure_creation_approval_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "approval process for a Create Measure workbasket", :js do
   before(:example) do
     user = (create(:user, approver_user: true))
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    allow_any_instance_of(XmlGeneration::ExportWorker).to receive(:perform) { true }
   end
 
   it "allows a Measure to be cross-checked" do


### PR DESCRIPTION
Prior to this change, a user had to manually upload xml to our s3 bucket in order to be processed
by CDS.

This change uploads the xml once the workbasket is approved.

Note: This commit makes the upload run synchronously, i.e not in a sidekiq queue in order for us to
be able to more easily monitor/debug the process. This may need to be change to run async again
once the concept has been proven and any bugs ironed out.