### PR TITLE
Fix: Allow C to be used as regulation identifier

### DIFF
--- a/app/interactors/workbasket_interactions/create_regulation/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_regulation/settings_saver.rb
@@ -283,10 +283,10 @@ module WorkbasketInteractions
         end
 
         if original_params[:base_regulation_id].present?
-          if !("PUSXNMQA".include? original_params[:base_regulation_id]&.chr)
-            @errors[:base_regulation_id] = "Regulation identifier must begin with P,U,S,X,N,M,Q or A."
+          if !("CPUSXNMQA".include? original_params[:base_regulation_id]&.chr)
+            @errors[:base_regulation_id] = "Regulation identifier must begin with C,P,U,S,X,N,M,Q or A."
           elsif original_params[:base_regulation_id].size != 8
-            @errors[:base_regulation_id] = "Regulation identifier's length can be 8 chars only (eg: 'R1812345')"
+            @errors[:base_regulation_id] = "Regulation identifier's length can be 8 chars only (eg: 'C1812345')"
           end
         else
           @errors[:base_regulation_id] = "Regulation identifier can't be blank!"

--- a/app/interactors/workbasket_interactions/edit_regulation/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/edit_regulation/settings_saver.rb
@@ -129,10 +129,10 @@ module WorkbasketInteractions
         end
 
         if @settings_params[:base_regulation_id].present?
-          if !("PUSXNMQA".include? @settings_params[:base_regulation_id]&.chr)
+          if !("CPUSXNMQA".include? @settings_params[:base_regulation_id]&.chr)
             @errors[:base_regulation_id] = "Regulation identifier must begin with P,U,S,X,N,M,Q or A."
           elsif @settings_params[:base_regulation_id].size != 8
-            @errors[:base_regulation_id] = "Regulation identifier's length can be 8 chars only (eg: 'R1812345')"
+            @errors[:base_regulation_id] = "Regulation identifier's length can be 8 chars only (eg: 'C1812345')"
           end
         else
           @errors[:base_regulation_id] = "Regulation identifier can't be blank!"

--- a/spec/support/shared_contexts/system/create_regulation_base_context.rb
+++ b/spec/support/shared_contexts/system/create_regulation_base_context.rb
@@ -20,7 +20,7 @@ shared_context 'create_regulation_base_context' do
     create(:base_regulation,
            base_regulation_id:
                # %w(C D A I J R).sample + # Old EU regulation values
-               %w(P U S X N M Q A).sample +  # New UK regulation values
+               %w(C P U S X N M Q A).sample +  # New UK regulation values
                Forgery(:basic).number(at_least: 10, at_most: 19).to_s +
                Forgery(:basic).number(at_least: 1000, at_most: 9999).to_s +
                Forgery(:basic).number(at_least: 0, at_most: 9).to_s,


### PR DESCRIPTION
Prior to this change, we removed the EU identifiers and replaced them
with UK ones. This change adds back the ability to use 'C' as an
identifier.

https://uktrade.atlassian.net/browse/TARIFFS-459