### PR TITLE
Fix the issue with the  description validity date

### DIFF
--- a/app/assets/javascripts/components/workbaskets/edit-footnote.js
+++ b/app/assets/javascripts/components/workbaskets/edit-footnote.js
@@ -26,34 +26,6 @@ $(document).ready(function() {
     mounted: function() {
       var self = this;
 
-      var description_validity_period_date_input = $(".js-description-validity-period-date");
-
-      var description_validity_period_date_picker = new Pikaday({
-        field: description_validity_period_date_input[0],
-        format: "DD/MM/YYYY",
-        blurFieldOnSelect: true,
-        onSelect: function(value) {
-          description_validity_period_date_input.trigger("change");
-        }
-      });
-
-      window.js_start_date_pikaday_instance = description_validity_period_date_picker;
-
-      var changes_take_effect_date_input = $(".js-changes_take_effect_date_input");
-
-      var changes_take_effect_date_picker = new Pikaday({
-        field: changes_take_effect_date_input[0],
-        format: "DD/MM/YYYY",
-        blurFieldOnSelect: true,
-        onSelect: function(value) {
-          changes_take_effect_date_input.trigger("change");
-          new_val = moment(changes_take_effect_date_input.val(), 'DD/MM/YYYY').format('YYYY-MM-DD');
-          description_validity_period_date_picker.setDate(new_val);
-        }
-      });
-
-      window.js_end_date_pikaday_instance = changes_take_effect_date_picker;
-
       this.initialCheckOfDescriptionBlock();
 
       $(document).on('click', ".js-create-measures-v1-submit-button, .js-workbasket-base-submit-button", function(e) {
@@ -66,7 +38,6 @@ $(document).ready(function() {
         WorkbasketBaseSaveActions.toogleSaveSpinner($(this).attr('name'));
 
         changes_take_effect__date = $(".js-changes_take_effect_date_input").val();
-        description_validity_period__date = $(".js-description-validity-period-date").val();
 
         self.errors = {};
         self.conformanceErrors = {};
@@ -193,7 +164,7 @@ $(document).ready(function() {
       },
       footnotePayLoad: function() {
         if ($(".js-footnote-description-textarea").val() !== window.__original_footnote_description) {
-          description_validity_start_date = $(".js-description-validity-period-date").val();
+          description_validity_start_date = $("input[name='workbasket_forms_edit_footnote_form[description_validity_start_date]']").val();
         } else {
           description_validity_start_date = '';
         }

--- a/app/views/workbaskets/edit_footnote/steps/main/_description_validity_start_date.html.slim
+++ b/app/views/workbaskets/edit_footnote/steps/main/_description_validity_start_date.html.slim
@@ -1,21 +1,2 @@
-fieldset
-  .edit-footnote-description-validity-period-block.hidden
-    form-group :errors="errors" error-key="description_validity_start_date"
-      template slot-scope="slotProps"
-        h3.heading-medium.without_top_margin
-          | Description validity
-
-        label.form-label
-          span.error-message v-if="slotProps.hasError" v-cloak=""
-            | {{slotProps.error}}
-          span.form-hint
-            | You have edited the footnote description. Please specify the date when this change should apply, if different from the change-date already given above.
-
-        .bootstrap-row
-          .col-lg-6.col-md-7.col-sm-10.col-xs-12
-            = f.input :description_validity_start_date, label: false, input_html: { class: "js-description-validity-period-date", "v-model" => "footnote.description_validity_start_date" }
-
-        label.form-label
-          span.form-hint.hint_below_input
-            | This must fall between the footnote validity dates shown below.
-
+div.edit-footnote-description-validity-period-block.hidden.m-t-5
+  = content_tag "date-gds", "", "label" => "Description validity", "hint" =>"You have edited the footnote description. Please specify the date when this change should apply, if different from the change-date already given above. This must fall between the footnote validity dates shown below.", "v-model" => "footnote.description_validity_start_date",  "id" => "start_date",  ":required" => "true", "input_name" => "workbasket_forms_edit_footnote_form[description_validity_start_date]", ":error" => "errors.description_validity_start_date"


### PR DESCRIPTION
Prior to this change, there was a bug in edit-footnote.js
(probably there are more ...) which was preventing the put request to
go through as description validity could not been set.

This change fixes that bug and also is replacing the date picker with
the date-gds component

**Resolves:** [https://uktrade.atlassian.net/browse/TARIFFS-445](https://uktrade.atlassian.net/browse/TARIFFS-445)