### PR TITLE
Fix: Withdrawing an edit regulation workbasket bug.

### DIFF
--- a/app/interactors/workbasket_interactions/edit_regulation/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/edit_regulation/settings_saver.rb
@@ -53,7 +53,6 @@ module WorkbasketInteractions
 
       def save!
         workbasket.settings.reason_for_changes = @settings_params[:reason_for_changes]
-        workbasket.settings.base_regulation_id = @settings_params[:base_regulation_id]
         workbasket.settings.legal_id = @settings_params[:legal_id]
         workbasket.settings.reference_url = @settings_params[:reference_url]
         workbasket.settings.description = @settings_params[:description]
@@ -87,21 +86,10 @@ module WorkbasketInteractions
         check_required_params!
       end
 
-      def check_initial_validation_rules!
-        @initial_validator = ::WorkbasketInteractions::EditRegulation::InitialValidator.new(
-          workbasket.settings
-        )
-
-        @errors.merge(initial_validator.fetch_errors)
-        @errors_summary = initial_validator.errors_summary
-      end
-
-
       def update_regulation!
         @records = []
         original_regulation = BaseRegulation.find(base_regulation_id: @settings[:original_base_regulation_id], base_regulation_role: @settings[:original_base_regulation_role].to_i)
 
-        original_regulation.base_regulation_id = workbasket.settings.base_regulation_id
         original_regulation.information_text = workbasket.settings.legal_id + '|' +
           workbasket.settings.description + '|' +
           workbasket.settings.reference_url
@@ -126,16 +114,6 @@ module WorkbasketInteractions
               @errors[k] = "#{k.to_s.capitalize.split('_').join(' ')} can't be blank!"
             end
           end
-        end
-
-        if @settings_params[:base_regulation_id].present?
-          if !("CPUSXNMQA".include? @settings_params[:base_regulation_id]&.chr)
-            @errors[:base_regulation_id] = "Regulation identifier must begin with P,U,S,X,N,M,Q or A."
-          elsif @settings_params[:base_regulation_id].size != 8
-            @errors[:base_regulation_id] = "Regulation identifier's length can be 8 chars only (eg: 'C1812345')"
-          end
-        else
-          @errors[:base_regulation_id] = "Regulation identifier can't be blank!"
         end
       end
 

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -333,6 +333,7 @@ module Workbaskets
             move_status_to!(current_admin, "editing")
 
             clean_up_draft_measures! if type == "bulk_edit_of_measures"
+            clean_up_draft_regulation! if type == "edit_regulation"
 
             settings.collection.map do |item|
               item.move_status_to!(:editing)
@@ -377,6 +378,10 @@ module Workbaskets
             settings.collection.map do |item|
               item.move_status_to!(:sent_to_cds)
             end
+          end
+
+          def clean_up_draft_regulation!
+            settings.collection.each(&:delete)
           end
 
           def clean_up_draft_measures!

--- a/app/views/workbaskets/create_regulation/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/create_regulation/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -6,11 +6,17 @@ table.create-measures-details-table
       td.heading_column
         | Regulation identifier
       td
-        = regulation.legal_id
+        = regulation.base_regulation_id
 
     tr
       td.heading_column
         | Regulation name
+      td
+        = regulation.legal_id
+
+    tr
+      td.heading_column
+        | Regulation description
       td
         = regulation.description
 

--- a/app/views/workbaskets/edit_regulation/edit.html.slim
+++ b/app/views/workbaskets/edit_regulation/edit.html.slim
@@ -23,35 +23,6 @@ h1 class="heading-large m-b-20"
         .column-one-half
           = f.input :reason_for_changes, as: :text, label: false, input_html: { rows: 4 }
 
-  .form-group.m-b-10 v-bind:class="{ 'form-group-error': errors.base_regulation_id }"
-    fieldset
-      h3.heading-medium.m-t-5 id="base_regulation_id"
-        = f.label :base_regulation_id, 'What is the regulation identifier?'
-      span.form-hint
-        | This must be exactly 8 characters long. Please use the following structure for regulations. Start with one of the following characters:
-      p.form-hint
-        | P Preferential Trade Agreement
-        br
-        | U Unilateral preferences (GSP)
-        br
-        | S Suspensions and reliefs
-        br
-        | X Import and Export control
-        br
-        | N Trade remedies
-        br
-        | M MFN
-        br
-        | Q Quotas
-        br
-        | A Agri
-
-      span.error-message v-if="errors.base_regulation_id" v-html="errors.base_regulation_id"
-
-      .grid-row
-        .column-one-third
-          = f.input :base_regulation_id, label: false, as: :string, input_html: { maxlength: 8 }, required: true
-
   .form-group.m-b-10 v-bind:class="{ 'form-group-error': errors.legal_id }"
     fieldset
       h3.heading-medium.m-t-5 id="legal_id"

--- a/app/views/workbaskets/edit_regulation/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/edit_regulation/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -6,11 +6,17 @@ table.create-measures-details-table
       td.heading_column
         | Regulation identifier
       td
-        = regulation.legal_id
+        = regulation.base_regulation_id
 
     tr
       td.heading_column
         | Regulation name
+      td
+        = regulation.legal_id
+
+    tr
+      td.heading_column
+        | Regulation description
       td
         = regulation.description
 


### PR DESCRIPTION
Prior to this change, when withdrawing a workbasket it was creating an
entry in the oplog for deleting the whole regulation.

This change deletes all the entries in oplog connected to this workbasket
rather than adding a delete entry. Also, hides the 'edit the ID' feature
as ID cannot be edited for regulations.

https://uktrade.atlassian.net/browse/TARIFFS-470