### PR TITLE
Temporarily stop download xml worker

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -34,7 +34,3 @@
   SearchableDataReindexWorker:
     cron: "5 0 * * *"
     description: "SearchableDataReindexWorker will run at 00:05 every day"
-
-  DownloadXmlWorker:
-    cron: '0 * * * * *'
-    description: "Polls S3 for responses"


### PR DESCRIPTION
This commit temporarily stops the download xml worker from running in order to investigate issues relating
to the upload of data to our s3 bucket.