### PR TITLE
Fix: Allow Measures to use types with future start date.

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -26,7 +26,7 @@ class Measure < Sequel::Model
   one_to_one :measure_type, primary_key: :measure_type_id,
                     key: :measure_type_id,
                     class_name: MeasureType do |ds|
-                      ds.with_actual(MeasureType)
+                      ds.with_actual(MeasureType, nil, true)
                     end
 
   one_to_many :measure_conditions, key: :measure_sid,

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -39,7 +39,7 @@ class MeasureType < Sequel::Model
     end
 
     def q_search(filter_ops)
-      scope = actual
+      scope = actual(include_future: true)
 
       if filter_ops[:quota].present? && filter_ops[:quota] == "true"
         scope = scope.where(order_number_capture_code: 1)

--- a/app/views/workbaskets/create_regulation/steps/main/_regulation_identifier.html.slim
+++ b/app/views/workbaskets/create_regulation/steps/main/_regulation_identifier.html.slim
@@ -5,6 +5,8 @@
     span.form-hint
       | This must be exactly 8 characters long. Please use the following structure for regulations. Start with one of the following characters:
     p.form-hint
+      | C Draft regulation
+      br
       | P Preferential Trade Agreement
       br
       | U Unilateral preferences (GSP)


### PR DESCRIPTION
Prior to this change, if a measure type has a validity start date in the
future then it is not possible to create a measure that utilises this
type.

This change adds a new parameter for 'actual' method (include_future)
that will result in the method also returning objects that have a future
start date.

https://uktrade.atlassian.net/browse/TARIFFS-461