### PR TITLE
Fix: Bug around original description

### DIFF
--- a/app/views/workbaskets/edit_footnote/steps/review_and_submit/_footnote.html.slim
+++ b/app/views/workbaskets/edit_footnote/steps/review_and_submit/_footnote.html.slim
@@ -21,12 +21,7 @@
         td.type-column
           = footnote.footnote_type_id
         td.description-column
-          = footnote.footnote_descriptions.first.description
-          details
-            summary
-              | Original description
-            panel.panel-border-narrow.p-t-5.p-b-5
-              = footnote.footnote_descriptions.second.description
+          = footnote.description
         td.measures-column
           = footnote.current_associated_measures.join(', ')
         td.measures-column

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/_summary_of_configuration.html.slim
@@ -31,12 +31,8 @@ table.create-measures-details-table
       td.heading_column
         | Description
       td
-        = footnote.footnote_descriptions.first.description
-        details
-          summary
-            | Original description
-          panel.panel-border-narrow.p-t-5.p-b-5
-            = footnote.footnote_descriptions.second.description
+        = footnote.description
+
     tr
 
       td.heading_column


### PR DESCRIPTION
Showing original descriptions was causing issues when a footnote only had one description.

Disabling this functionality for now until we can work on the wider issue.