### PR TITLE
Fix: XML export name

### DIFF
--- a/app/models/xml_export/file.rb
+++ b/app/models/xml_export/file.rb
@@ -43,7 +43,7 @@ module XmlExport
     end
 
     def envelope_id_offset_for_current_year
-      ENV.fetch("XML_ENVELOPE_ID_OFFSET_YEAR_#{Date.current.year}", 0).to_i
+      ENV["XML_ENVELOPE_ID_OFFSET_YEAR_#{Date.current.year}"]&.to_i || 0
     end
 
     class << self

--- a/app/services/xml_generation/upload.rb
+++ b/app/services/xml_generation/upload.rb
@@ -52,7 +52,7 @@ module XmlGeneration
     # DIT, followed by the year (two digits), followed by
     # the envelope ID (pre-padded with zeroes up to 4 digits)
     def remote_file_name_base
-      "DIT#{Date.today.strftime("%y")}#{record.envelope_id.to_s.rjust(4, "0")}"
+      "DIT#{record.envelope_id.to_s.rjust(4, "0")}"
     end
 
     def local_main_file_path


### PR DESCRIPTION
Prior to this change, the year was added to the envelope ID. But
envelope ID also included the year.

This change no longer adds the year to the envelope ID and instead
ensures the envelope ID is reset at the start of each year.