### PR TITLE
Fix: Edit footnote after withdrawing bug

### DIFF
--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -333,7 +333,7 @@ module Workbaskets
             move_status_to!(current_admin, "editing")
 
             clean_up_draft_measures! if type == "bulk_edit_of_measures"
-            clean_up_draft_regulation! if type == "edit_regulation"
+            clean_up_drafts! if (type == "edit_regulation" || type == 'edit_footnote')
 
             settings.collection.map do |item|
               item.move_status_to!(:editing)
@@ -380,7 +380,7 @@ module Workbaskets
             end
           end
 
-          def clean_up_draft_regulation!
+          def clean_up_drafts!
             settings.collection.each(&:delete)
           end
 


### PR DESCRIPTION
Prior to this change, if a user edited a gootnote, using a description validity start date that already existed,
then withdrew the workbasket and tried to submit again, the user would see a server error.

This was due to the withdraw process deleting the footnote description that was being edited so the second time
the user went to edit, it was not available to update.

This commit fixes this issue by stopping the footnote descriptions being deleted upon withdrawal.