### PR TITLE
Fix: Allow 0 in certificate code

### DIFF
--- a/app/interactors/workbasket_interactions/create_certificate/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/create_certificate/initial_validator.rb
@@ -66,7 +66,7 @@ module WorkbasketInteractions
             @errors[:certificate_code] = errors_translator(:certificate_code_in_use)
           elsif certificate_code.size > 3
             @errors[:certificate_code] = errors_translator(:certificate_code_max_limit)
-          elsif certificate_code.match(/^[a-zA-Z1-9]+$/).nil?
+          elsif certificate_code.match(/^[a-zA-Z0-9]+$/).nil?
             @errors[certificate_code] = errors_translator(:certificate_code_alphanumeric)
           end
 


### PR DESCRIPTION
Prior to this change, only digits 1-9 were allowed in certificate codes, on create
certificate forms.

This fix corrects this issue to allow 0.