### PR TITLE
Fix: Geo area membership dates

### DIFF
--- a/app/assets/javascripts/vue_components/edit-geographical-area-membership-popup.js
+++ b/app/assets/javascripts/vue_components/edit-geographical-area-membership-popup.js
@@ -12,16 +12,6 @@ Vue.component("edit-geographical-area-membership-popup", {
     };
   },
   mounted: function() {
-    var start = moment(this.membership.validity_start_date, ["DD MMM YYYY", "DD/MM/YYYY"], true);
-    var end = moment(this.membership.validity_end_date, ["DD MMM YYYY", "DD/MM/YYYY"], true);
-
-    if (start.isValid()) {
-      this.join_date = start.format("DD/MM/YYYY");
-    }
-
-    if (end.isValid()) {
-      this.leave_date = end.format("DD/MM/YYYY");
-    }
   },
   computed: {
     disableJoinDate: function() {
@@ -64,13 +54,6 @@ Vue.component("edit-geographical-area-membership-popup", {
 
       this.validate(function() {
         var membership = self.membership;
-
-        var start = moment(self.join_date, "DD/MM/YYYY", true);
-        var end = moment(self.leave_date, "DD/MM/YYYY", true);
-
-        self.membership.delete = false;
-        self.membership.validity_start_date = start.isValid() ? start.format("DD MMMM YYYY") : null;
-          self.membership.validity_end_date = end.isValid() ? end.format("DD MMMM YYYY") : null;
 
         self.onClose();
       }, function() {

--- a/app/models/workbaskets/edit_geographical_area_settings.rb
+++ b/app/models/workbaskets/edit_geographical_area_settings.rb
@@ -38,7 +38,7 @@ module Workbaskets
 
     def current_memberships
       if original_geographical_area.group?
-        original_geographical_area.currently_contains
+        original_geographical_area.contained_geographical_areas
       else
         original_geographical_area.currently_member_of
       end
@@ -50,8 +50,15 @@ module Workbaskets
         hash[:geographical_area] = {
           'description' => area.description
         }
-        hash[:validity_start_date] = area.validity_start_date.to_date.to_formatted_s(:rfc822) if area.validity_start_date
-        hash[:validity_end_date] = area.validity_end_date.to_date.to_formatted_s(:rfc822) if area.validity_end_date
+
+        if original_geographical_area.group?
+          membership = GeographicalAreaMembership.find(geographical_area_sid: area.geographical_area_sid, geographical_area_group_sid: original_geographical_area.geographical_area_sid)
+        else
+          membership = GeographicalAreaMembership.find(geographical_area_sid: original_geographical_area.geographical_area_sid, geographical_area_group_sid: area.geographical_area_sid)
+        end
+
+        hash[:start_date] = membership.validity_start_date ? membership.validity_start_date.to_date.to_formatted_s(:rfc822) : ''
+        hash[:end_date] = membership.validity_end_date.to_date.to_formatted_s(:rfc822) if membership.validity_end_date
         hash
       end
     end

--- a/app/views/workbaskets/edit_geographical_area/steps/main/_memberships.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/steps/main/_memberships.html.slim
@@ -52,9 +52,9 @@ fieldset
               a href="#" role="button" v-on:click.prevent="editMembership(membership)"
                 | {{membership.geographical_area.description}}
             td
-              | {{membership.validity_start_date}}
+              | {{membership.start_date}}
             td
-              | {{membership.validity_end_date}}
+              | {{membership.end_date}}
             td
               a href="#" id="remove-group" role="button" v-on:click.prevent="removeMembershipTrigger(membership)"
                 | Remove


### PR DESCRIPTION
Prior to this change, the join date on the membership table showed the start date of the geo area
as opposed to the start date of the membership. This PR fixes this issue.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-524