### PR TITLE
Fix: Additional code approval failing

### DIFF
--- a/app/controllers/workbaskets/workflows/base_controller.rb
+++ b/app/controllers/workbaskets/workflows/base_controller.rb
@@ -66,7 +66,7 @@ module Workbaskets
 
         record.save_with_envelope_id
 
-        XmlGeneration::ExportWorker.new.perform(record.id)
+        XmlGeneration::ExportWorker.perform_async(record.id)
       end
     end
   end


### PR DESCRIPTION
Prior to this change, approving an additional code sometimes took user to a crash page.

This seems to be because the export worker is running synchronously and if the next page loads
before the job has finished the page crashes.

This change makes the worker run async which should ensure the user never gets to a crash page
for this reason.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-503