### PR TITLE
Fix: prevent user from using license quota in assoc.

### DIFF
--- a/app/forms/workbasket_forms/create_quota_association_form.rb
+++ b/app/forms/workbasket_forms/create_quota_association_form.rb
@@ -22,18 +22,28 @@ module WorkbasketForms
         @settings_errors[:workbasket_title] = "Workbasket title must be entered"
       end
 
-      parent_order = QuotaOrderNumber.find(quota_order_number_id: @parent_order_id)
-      if parent_order.nil?
-        @settings_errors[:parent_order_id] = "Parent quota order ID must exist"
-      elsif parent_order.validity_end_date.present?
-        @settings_errors[:parent_order_id] = "Parent quota order must not have an end date"
+      if is_license_quota?(@parent_order_id)
+        @settings_errors[:parent_order_id] = "Quota order ID must not begin with 094"
       end
 
-      child_order = QuotaOrderNumber.find(quota_order_number_id: @child_order_id)
-      if child_order.nil?
-        @settings_errors[:child_order_id] = "Child quota order ID must exist"
-      elsif child_order.validity_end_date.present?
-        @settings_errors[:child_order_id] = "Child quota order must not have an end date"
+      if is_license_quota?(@child_order_id)
+        @settings_errors[:child_order_id] = "Quota order ID must not begin with 094"
+      end
+
+      if @settings_errors.empty?
+        parent_order = QuotaOrderNumber.find(quota_order_number_id: @parent_order_id)
+        if parent_order.nil?
+          @settings_errors[:parent_order_id] = "Parent quota order ID must exist"
+        elsif parent_order.validity_end_date.present?
+          @settings_errors[:parent_order_id] = "Parent quota order must not have an end date"
+        end
+
+        child_order = QuotaOrderNumber.find(quota_order_number_id: @child_order_id)
+        if child_order.nil?
+          @settings_errors[:child_order_id] = "Child quota order ID must exist"
+        elsif child_order.validity_end_date.present?
+          @settings_errors[:child_order_id] = "Child quota order must not have an end date"
+        end
       end
 
       if @settings_errors.empty?
@@ -51,6 +61,10 @@ module WorkbasketForms
       end
 
       @settings_errors.empty?
+    end
+
+    private def is_license_quota?(quota_order_id)
+      quota_order_id.start_with? '094'
     end
   end
 end


### PR DESCRIPTION
Prior to this change, users could createa an association between license quotas (i.e. quota order IDs beginning with 094)

This change blocks order IDs starting with 094

https://uktrade.atlassian.net/browse/TARIFFS-548