### PR TITLE
Fix: Show current quota suspensions periods

### DIFF
--- a/app/controllers/quota_suspensions/quota_suspensions_controller.rb
+++ b/app/controllers/quota_suspensions/quota_suspensions_controller.rb
@@ -1,5 +1,5 @@
 class QuotaSuspensions::QuotaSuspensionsController < ApplicationController
   def index
-    @quota_suspensions = QuotaSuspensionPeriod.where('suspension_end_date < ?', Date.today)
+    @quota_suspensions = QuotaSuspensionPeriod.where('suspension_end_date > ?', Date.today)
   end
 end


### PR DESCRIPTION
Prior to this commit, the view quota suspension periods page showed quota suspensions that had
already finished. This commit fixes this issue.