### PR TITLE
Hide locked column on record grid on demand

### DIFF
--- a/app/assets/javascripts/vue_components/records-grid.js
+++ b/app/assets/javascripts/vue_components/records-grid.js
@@ -18,6 +18,7 @@ Vue.component("records-grid", {
     "clientSelection",
     "disableSelection",
     "disableSelectAll",
+    "hideLockedColumn",
     "singleSelection",
     "selectedItem",
     "back-end-sort"

--- a/app/views/shared/vue_templates/_records_grid.html.erb
+++ b/app/views/shared/vue_templates/_records_grid.html.erb
@@ -4,7 +4,7 @@
       <table class="table" id="records-table">
           <thead class="actions">
             <tr>
-              <th class="locked-column">
+              <th class="locked-column" v-if="hideLockedColumn !== true">
                   <span>Locked</span>
               </th>
               <th class="select-all-column" v-if="disableSelection !== true">
@@ -28,7 +28,7 @@
           </thead>
           <tbody>
               <tr :class="{ deleted: item.deleted }" :data-measure-sid="item.row_id" :data-record-sid="item.row_id" v-for="(item, index) in sorted">
-                <td class="locked-column">
+                <td class="locked-column" v-if="hideLockedColumn !== true">
                   <span>
                     <i v-if="locked(item)">&#x1F510;</i>
                   </span>

--- a/app/views/workbaskets/create_additional_code/show.html.slim
+++ b/app/views/workbaskets/create_additional_code/show.html.slim
@@ -16,7 +16,7 @@
     = render "workbaskets/create_additional_code/workflow_screens_parts/actions_allowed"
     = render "workbaskets/create_additional_code/workflow_screens_parts/workbasket_details", screen_type: :view
 
-    records-grid primary-key="additional_code_sid" :data="additional_codes" :columns="columns" :client-sorting="true" :disable-selection="true"
+    records-grid primary-key="additional_code_sid" :data="additional_codes" :columns="columns" :client-sorting="true" :disable-selection="true" :hide-locked-column="true"
 
 = render "shared/vue_templates/records_grid"
 


### PR DESCRIPTION
I have added another property to record-grid component that can be used to hide locked column on demand

**Resolves** [https://uktrade.atlassian.net/browse/TARIFFS-516](https://uktrade.atlassian.net/browse/TARIFFS-516)