### PR TITLE
Fix: Training crash due to reference bug

### DIFF
--- a/app/views/workbaskets/main_menu_parts/_main_menu.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_main_menu.html.slim
@@ -12,7 +12,7 @@
         = link_to "Manage the goods classification", sections_url
     .col-xs-12.col-sm-12.col-md-4.col-lg-3
       p
-        = link_to "Create reference documents", ENV.fetch("TARIFF_TRADE_APPLICATION_URL"), :target => "_blank"
+        = link_to "Create reference documents", ENV.fetch("TARIFF_TRADE_APPLICATION_URL"), :target => "_blank" if ENV['TARIFF_TRADE_APPLICATION_URL']
   .bootstrap-row
     .col-xs-12.col-sm-12.col-md-4.col-lg-3
       p


### PR DESCRIPTION
Prior to this commit, our training environment was crashing due to use not having a trade tariff reference app in
our training environment that we can link to. The link was looking for an env variable which did not exist which
caused the app to crash, this commit fixes this issue by only showing the link if the ENV variable exists.

This is a short term fix, in the long term we need to set up a reference app in the training environment.