### PR TITLE
Fix: create quota association validation

### DIFF
--- a/app/forms/workbasket_forms/create_quota_association_form.rb
+++ b/app/forms/workbasket_forms/create_quota_association_form.rb
@@ -31,14 +31,14 @@ module WorkbasketForms
       end
 
       if @settings_errors.empty?
-        parent_order = QuotaOrderNumber.where(quota_order_number_id: @parent_order_id).order(Sequel.desc(:oid)).first
+        parent_order = QuotaOrderNumber.where(quota_order_number_id: @parent_order_id).order(Sequel.desc(:quota_order_number_sid)).first
         if parent_order.nil?
           @settings_errors[:parent_order_id] = "Parent quota order ID must exist"
         elsif parent_order.validity_end_date.present?
           @settings_errors[:parent_order_id] = "Parent quota order must not have an end date"
         end
 
-        child_order = QuotaOrderNumber.where(quota_order_number_id: @child_order_id).order(Sequel.desc(:oid)).first
+        child_order = QuotaOrderNumber.where(quota_order_number_id: @child_order_id).order(Sequel.desc(:quota_order_number_sid)).first
         if child_order.nil?
           @settings_errors[:child_order_id] = "Child quota order ID must exist"
         elsif child_order.validity_end_date.present?


### PR DESCRIPTION
Prior to this change the validation was checking the wrong entry.

This fixes the validation by sorting on the quota_order_number_sid rather than the oid.

https://uktrade.atlassian.net/browse/TARIFFS-455