### PR TITLE
Fix: Crash page when submitting quota suspension with no definition p…

### DIFF
--- a/app/forms/workbasket_forms/edit_quota_suspension_form.rb
+++ b/app/forms/workbasket_forms/edit_quota_suspension_form.rb
@@ -42,12 +42,14 @@ module WorkbasketForms
         @settings_errors[:end_date] = "You must select an end date"
       end
 
-      unless start_date_valid?
-        @settings_errors[:start_date_invalid] = 'You must select the date as on or after start date or before end date of the selected definition or suspension period'
-      end
+      if @workbasket_settings.quota_definition_sid
+        unless start_date_valid?
+          @settings_errors[:start_date_invalid] = 'You must select the date as on or after start date or before end date of the selected definition or suspension period'
+        end
 
-      if @workbasket_settings.description.length > 500
-        @settings_errors[:description_too_long] = 'Description cannot be more than 500 characters'
+        if @workbasket_settings.description.length > 500
+          @settings_errors[:description_too_long] = 'Description cannot be more than 500 characters'
+        end
       end
 
       if @settings_errors.empty?


### PR DESCRIPTION
…eriod

Prior to this change, the app crashed when we tried to submit a quota suspension period without a
definition.

This commit fixes this issue.