### PR TITLE
Fix: Quota Association Deletion issues

### DIFF
--- a/app/controllers/quota_associations/quota_associations_controller.rb
+++ b/app/controllers/quota_associations/quota_associations_controller.rb
@@ -1,7 +1,5 @@
 class QuotaAssociations::QuotaAssociationsController < ApplicationController
   def index
-    @quota_associations = QuotaAssociation.where(quota_associations__status: 'published')
-                            .join(QuotaDefinition.where{quota_definitions__validity_start_date >= 2.years.ago }, quota_definition_sid: :main_quota_definition_sid)
-                            .order(:quota_order_number_id, Sequel.desc(:validity_start_date))
+    @quota_associations = QuotaAssociation.recent
   end
 end

--- a/app/models/concerns/workbasket_helpers/association.rb
+++ b/app/models/concerns/workbasket_helpers/association.rb
@@ -18,12 +18,23 @@ module WorkbasketHelpers
       self.manual_add = true
       self.status = new_status
 
+      mark_deleted if pending_deletion?(new_status)
+
       save
     end
 
     def already_end_dated?
       validity_end_date.present? &&
         validity_end_date <= Date.today.midnight
+    end
+
+    private def pending_deletion?(new_status)
+      # Updates for Quota Associations are actually deletions.
+      self.class == QuotaAssociation && self.operation == :update && new_status == 'published'
+    end
+
+    private def mark_deleted
+      self.operation = 'D'
     end
   end
 end

--- a/app/models/quota_association.rb
+++ b/app/models/quota_association.rb
@@ -16,6 +16,20 @@ class QuotaAssociation < Sequel::Model
               key: :sub_quota_definition_sid,
               class: QuotaDefinition
 
+  def self.recent
+    recent_sql = <<END_SQL
+      SELECT qa.*, qd.quota_order_number_id 
+      FROM quota_associations qa,
+           quota_definitions qd 
+      WHERE qa.status = 'published'
+      AND qa.main_quota_definition_sid = qd.quota_definition_sid
+      AND qd.validity_start_date >= now() - interval '2 year'
+      ORDER BY qd.quota_order_number_id ASC, qd.validity_start_date DESC
+END_SQL
+
+    with_sql(recent_sql).all
+  end
+
   def record_code
     "370".freeze
   end


### PR DESCRIPTION
Prior to this fix. The Quota Association wasn't actually deleted
(we were waiting for implementation of the CDS cycle)

This commit changes that so whenever the basket is published the item
is marked deleted.

https://uktrade.atlassian.net/browse/TARIFFS-552