### PR TITLE
Fix: Rename editquotasuspensionform

### DIFF
--- a/app/controllers/workbaskets/create_quota_suspension_controller.rb
+++ b/app/controllers/workbaskets/create_quota_suspension_controller.rb
@@ -28,12 +28,12 @@ module Workbaskets
     end
 
     def edit
-      @edit_quota_suspension_form = WorkbasketForms::EditQuotaSuspensionForm.new(params[:id])
+      @edit_quota_suspension_form = WorkbasketForms::EditCreateQuotaSuspensionForm.new(params[:id])
       @workbasket = Workbasket.find(id: params[:id])
     end
 
     def update
-      @edit_quota_suspension_form = WorkbasketForms::EditQuotaSuspensionForm.new(params[:id], update_quota_suspension_params)
+      @edit_quota_suspension_form = WorkbasketForms::EditCreateQuotaSuspensionForm.new(params[:id], update_quota_suspension_params)
 
       if @edit_quota_suspension_form.save
         redirect_to submitted_for_cross_check_create_quota_suspension_path(@edit_quota_suspension_form.workbasket.id)
@@ -51,9 +51,9 @@ module Workbaskets
       def update_quota_suspension_params
         {
           quota_definition_sid: params[:quota_definition_sid],
-          description: params[:workbasket_forms_edit_quota_suspension_form][:description],
-          start_date: params[:workbasket_forms_edit_quota_suspension_form][:start_date],
-          end_date: params[:workbasket_forms_edit_quota_suspension_form][:end_date]
+          description: params[:workbasket_forms_edit_create_quota_suspension_form][:description],
+          start_date: params[:workbasket_forms_edit_create_quota_suspension_form][:start_date],
+          end_date: params[:workbasket_forms_edit_create_quota_suspension_form][:end_date]
         }
       end
 

--- a/app/forms/workbasket_forms/edit_create_quota_suspension_form.rb
+++ b/app/forms/workbasket_forms/edit_create_quota_suspension_form.rb
@@ -1,5 +1,5 @@
 module WorkbasketForms
-  class EditQuotaSuspensionForm
+  class EditCreateQuotaSuspensionForm
     extend ActiveModel::Naming
     include ActiveModel::Conversion
     include ::WorkbasketHelpers::SettingsSaverHelperMethods

--- a/app/views/workbaskets/create_quota_suspension/edit.html.erb
+++ b/app/views/workbaskets/create_quota_suspension/edit.html.erb
@@ -65,9 +65,9 @@
         </div>
       </div>
 
-      <%= content_tag "date-gds", "", "label" => "Suspension period start date", "hint" => "Please ensure that this date falls on or after the definition start date", "id" => "start_date", "input_name" => "workbasket_forms_edit_quota_suspension_form[start_date]", ":error" => "errors.start_date" %>
+      <%= content_tag "date-gds", "", "label" => "Suspension period start date", "hint" => "Please ensure that this date falls on or after the definition start date", "id" => "start_date", "input_name" => "workbasket_forms_edit_create_quota_suspension_form[start_date]", ":error" => "errors.start_date" %>
 
-      <%= content_tag "date-gds", "", "label" => "Suspension period end date", "hint" => "Please ensure that this date falls on or before the definition end date", "id" => "end_date", "input_name" => "workbasket_forms_edit_quota_suspension_form[end_date]", ":error" => "errors.start_date" %>
+      <%= content_tag "date-gds", "", "label" => "Suspension period end date", "hint" => "Please ensure that this date falls on or before the definition end date", "id" => "end_date", "input_name" => "workbasket_forms_edit_create_quota_suspension_form[end_date]", ":error" => "errors.start_date" %>
 
       <div>
         <h3 class='heading medium'>


### PR DESCRIPTION
This commit changes EditQuotaSuspensionForm to EditCreateQuotaSuspensionForm. This fix is needed
because editquotasuspensionform needs to be used to edit and existing quota suspension.