### PR TITLE
Fix edit quota suspension bugs

### DIFF
--- a/app/controllers/quota_suspensions/quota_suspensions_controller.rb
+++ b/app/controllers/quota_suspensions/quota_suspensions_controller.rb
@@ -1,6 +1,6 @@
 class QuotaSuspensions::QuotaSuspensionsController < ApplicationController
   def index
-    @quota_suspensions = QuotaSuspensionPeriod.where('suspension_end_date > ?', Date.yesterday)
+    @quota_suspensions = QuotaSuspensionPeriod.where('suspension_end_date > ? AND status = ?', Date.yesterday, 'published')
      .all.select { |suspension_period| suspension_period.definition }
       .sort_by { |suspension_period| [suspension_period.definition.quota_order_number_id, suspension_period.suspension_start_date] }
   end

--- a/app/controllers/workbaskets/edit_quota_suspension_controller.rb
+++ b/app/controllers/workbaskets/edit_quota_suspension_controller.rb
@@ -21,11 +21,13 @@ module Workbaskets
 
     def create
       @quota_definition = QuotaDefinition.find(quota_definition_sid: params[:quota_definition_sid])
+      @quota_suspension_period_sid = params[:quota_suspension_period_sid]
       @edit_quota_suspension_form = WorkbasketForms::EditQuotaSuspensionForm.new(edit_quota_suspension_params, current_user)
+
       if @edit_quota_suspension_form.save
         redirect_to edit_edit_quota_suspension_path(id: @edit_quota_suspension_form.workbasket.id, quota_suspension_period_sid: params[:quota_suspension_period_sid], quota_definition_sid: params[:quota_definition_sid])
       else
-        redirect_to new_edit_quota_suspension_path(quota_definition_sid: params[:quota_definition_sid], quota_suspension_period_sid: params[:quota_suspension_period_sid])
+        render :action => 'new'
       end
     end
 


### PR DESCRIPTION
This PR addresses two issues with editing quota suspension periods.

1) Errors not correctly showing on the new page.

2) All quota suspension periods being shown in the find and edit page. The intended functionality is that only suspension periods which have the status 'published' should be shown.