### PR TITLE
Fix edit quota save bug

### DIFF
--- a/app/controllers/workbaskets/edit_quota_suspension_controller.rb
+++ b/app/controllers/workbaskets/edit_quota_suspension_controller.rb
@@ -67,7 +67,8 @@ module Workbaskets
           quota_definition_sid: params[:quota_definition_sid],
           description: params[:workbasket_forms_edit_edit_quota_suspension_form][:description],
           start_date: params[:workbasket_forms_edit_edit_quota_suspension_form][:start_date],
-          end_date: params[:workbasket_forms_edit_edit_quota_suspension_form][:end_date]
+          end_date: params[:workbasket_forms_edit_edit_quota_suspension_form][:end_date],
+          quota_suspension_period_sid: params[:quota_suspension_period_sid]
         }
       end
   end

--- a/app/controllers/workbaskets/edit_quota_suspension_controller.rb
+++ b/app/controllers/workbaskets/edit_quota_suspension_controller.rb
@@ -39,12 +39,15 @@ module Workbaskets
     end
 
     def update
+      @quota_definition = QuotaDefinition.find(quota_definition_sid: params[:quota_definition_sid])
+      @quota_suspension_period_sid = params[:quota_suspension_period_sid]
+      @quota_suspension_period = QuotaSuspensionPeriod.find(quota_suspension_period_sid: params[:quota_suspension_period_sid])
       @edit_edit_quota_suspension_form = WorkbasketForms::EditEditQuotaSuspensionForm.new(params[:id], update_quota_suspension_params)
 
       if @edit_edit_quota_suspension_form.save
         redirect_to submitted_for_cross_check_edit_quota_suspension_path(@edit_edit_quota_suspension_form.workbasket.id)
       else
-        render :edit
+        render :action => 'edit'
       end
     end
 

--- a/app/forms/workbasket_forms/edit_edit_quota_suspension_form.rb
+++ b/app/forms/workbasket_forms/edit_edit_quota_suspension_form.rb
@@ -58,20 +58,20 @@ module WorkbasketForms
         start_date = format_date(@workbasket_settings.start_date)
         end_date = format_date(@workbasket_settings.end_date)
 
-        suspension = QuotaSuspensionPeriod.new(
-          quota_definition_sid: @workbasket_settings.quota_definition_sid,
-          suspension_start_date: start_date,
-          suspension_end_date: end_date,
-          description: @workbasket_settings.description
-        )
+        suspension = QuotaSuspensionPeriod.find(quota_suspension_period_sid: @settings_params[:quota_suspension_period_sid])
+
+        suspension.suspension_start_date = start_date
+        suspension.suspension_end_date = end_date
+        suspension.description = @workbasket_settings.description
+        suspension.workbasket_id = workbasket.id
 
         if @settings_errors.empty?
+          suspension.save
           ::WorkbasketValueObjects::Shared::PrimaryKeyGenerator.new(suspension).assign!
           ::WorkbasketValueObjects::Shared::SystemOpsAssigner.new(
             suspension, system_ops.merge(operation: "U")
           ).assign!
 
-          suspension.save
           workbasket.submit_for_cross_check!(current_admin: current_admin)
         end
       end

--- a/app/views/workbaskets/edit_quota_suspension/edit.html.erb
+++ b/app/views/workbaskets/edit_quota_suspension/edit.html.erb
@@ -79,6 +79,7 @@
             <div class='col-md-6'>
               <div class='form-group'>
                 <%= f.input :description, label: false, required: true, input_html: { value: "#{@quota_suspension_period.description}", maxlength: 500 }%>
+                <%= hidden_field_tag :quota_suspension_period_sid, @quota_suspension_period.quota_suspension_period_sid %>
               </div>
             </div>
           </div>

--- a/app/views/workbaskets/edit_quota_suspension/edit.html.erb
+++ b/app/views/workbaskets/edit_quota_suspension/edit.html.erb
@@ -55,6 +55,7 @@
             <div class="column-one-third">
               <select id="quota_definition_sid" class="form-control" name="quota_definition_sid" >
                 <option readonly='true' value="<%= @quota_definition.quota_definition_sid %>"><%= @quota_definition.validity_start_date.to_s(:uk_Mmm) %> to <%= @quota_definition.validity_end_date.to_s(:uk_Mmm) %></option>
+                <%= hidden_field_tag :quota_definition_sid, @quota_definition.quota_definition_sid %>
               </select>
             </div>
           </div>


### PR DESCRIPTION
This PR fixes two bugs in the edit quota suspension feature.

1) Editing an existing quota suspension period creating a new quota suspension period.

2) Page crashing when editing a quota suspension period and changing the validity dates to outside the dates of the definition.