### PR TITLE
Fix: Edit latest Quota order number

### DIFF
--- a/app/forms/workbasket_forms/edit_quota_suspension_form.rb
+++ b/app/forms/workbasket_forms/edit_quota_suspension_form.rb
@@ -49,7 +49,7 @@ module WorkbasketForms
     end
 
     def quota_order_number
-      QuotaOrderNumber.where(quota_order_number_id: quota_order_number_id).order(Sequel.desc(:added_at)).first
+      QuotaOrderNumber.where(quota_order_number_id: quota_order_number_id).order(Sequel.desc(:validity_start_date)).first
     end
   end
 end


### PR DESCRIPTION
Prior to this change, when a user selects a quota order number to edit they sometimes get an error
saying that the quota order number has an end date which means it is not editable, when it does not
have an end date.

This change ensures that the user is always editing the latest quota order number period.