### PR TITLE
Fix: "Edit <workbasket object type>" link had exception or failed

### DIFF
--- a/app/views/workbaskets/create_footnote/show.html.slim
+++ b/app/views/workbaskets/create_footnote/show.html.slim
@@ -17,7 +17,7 @@ header
 
     - if iam_workbasket_author? && workbasket_rejected?
       = link_to "Edit footnote", '#',
-              data: {target_url: move_to_editing_mode_edit_footnote_url(workbasket.id), target_modal: workbasket.id},
+              data: {target_url: move_to_editing_mode_create_footnote_url(workbasket.id), target_modal: workbasket.id},
               class: "secondary-button view-workbasket-edit-measures-link js-main-menu-show-withdraw-confirmation-link"
 
     = render "workbaskets/create_footnote/workflow_screens_parts/summary_of_configuration"

--- a/app/views/workbaskets/create_geographical_area/show.html.slim
+++ b/app/views/workbaskets/create_geographical_area/show.html.slim
@@ -16,8 +16,8 @@ header
     = render "workbaskets/create_geographical_area/workflow_screens_parts/workbasket_details"
 
     - if iam_workbasket_author? && workbasket_rejected?
-      = link_to "Edit  geographical area", '#',
-              data: {target_url: move_to_editing_mode_create_geographical_area_url(workbasket.id)},
+      = link_to "Edit geographical area", '#',
+              data: {target_url: move_to_editing_mode_create_geographical_area_url(workbasket.id), target_modal: workbasket.id},
               class: "secondary-button view-workbasket-edit-measures-link js-main-menu-show-withdraw-confirmation-link"
 
     = render "workbaskets/create_geographical_area/workflow_screens_parts/area_details"

--- a/app/views/workbaskets/create_measures/show.html.slim
+++ b/app/views/workbaskets/create_measures/show.html.slim
@@ -20,7 +20,7 @@ header
 
     - if iam_workbasket_author? && workbasket_rejected?
       = link_to "Edit measures", '#',
-              data: {target_url: move_to_editing_mode_create_measure_url(workbasket.id)},
+              data: {target_url: move_to_editing_mode_create_measure_url(workbasket.id), target_modal: workbasket.id},
               class: "secondary-button view-workbasket-edit-measures-link js-main-menu-show-withdraw-confirmation-link"
 
     = render "workbaskets/create_measures/workflow_screens_parts/summary_of_configuration"

--- a/app/views/workbaskets/create_quota/show.html.slim
+++ b/app/views/workbaskets/create_quota/show.html.slim
@@ -20,7 +20,7 @@ header
 
     - if iam_workbasket_author? && workbasket_rejected?
       = link_to "Edit quota", '#',
-              data: {target_url: move_to_editing_mode_create_quotum_url(workbasket.id)},
+              data: {target_url: move_to_editing_mode_create_quotum_url(workbasket.id), target_modal: workbasket.id},
               class: "secondary-button view-workbasket-edit-measures-link js-main-menu-show-withdraw-confirmation-link"
 
     = render "workbaskets/create_quota/workflow_screens_parts/summary_of_configuration"


### PR DESCRIPTION
Prior to this fix, when 'View'ing a Create Footnote workbasket that had been rejected, the link was redirecting to edit_footnote instead of create_footnote.
Also, create "Geographical Area", "Measure" and "Quota" all were missing a parameter so their calls were failing as well.

 https://uktrade.atlassian.net/browse/TARIFFS-471