### PR TITLE
Fix: Crash page shown after withdrawing and resubmitting edited quota…

### DIFF
--- a/app/controllers/workbaskets/base_controller.rb
+++ b/app/controllers/workbaskets/base_controller.rb
@@ -158,6 +158,8 @@ module Workbaskets
     end
 
     def clean_up_persisted_data_on_update!
+      return if workbasket.type == "edit_quota_suspension"
+      
       unless step_pointer.review_and_submit_step?
         workbasket_settings.clean_up_temporary_data!
       end


### PR DESCRIPTION
… suspension

Prior to this change, when a user edited a quota suspension period, withdrew it, edited it again and
tried to submit it they would see a crash page.

This issue arose due to the before action `clean_up_persisted_data_on_update!` being run via the
workbaskets::base_controller. This deleted all of the workbasket settings collection unless the step_pointer
was a 'review_and_submit' to ensure that unsaved workbaskets were not persisted.

In the case of the newer, smaller workbaskets we are creating there is not a specific review_and_submit step
and (I think) the workbaskets should always be persisted.

I have added a guard clause to the `clean_up_persisted_data_on_update!` method to ensure it does not
run for 'edit_quota_suspension' to address this issue. It is possible we will see similar issues with other
newer and smaller workbaskets which do not have specific 'review_and_submit' steps.