### PR TITLE
Fix: rubyzip and simple_form upgrade for security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'omniauth-rails_csrf_protection', '~> 0.1'
 gem "shrine"
 gem "aws-sdk-rails"
 gem "aws-sdk-s3"
-gem "rubyzip", "~> 1.2.2"
+gem "rubyzip", "~> 1.3.0"
 
 gem 'filesaverjs-rails'
 
@@ -61,7 +61,7 @@ gem "addressable", "~> 2.3"
 gem 'slim-rails'
 gem 'kaminari'
 gem 'kaminari-sequel'
-gem "simple_form", "~> 3.5"
+gem "simple_form", "~> 5.0"
 gem "jbuilder"
 gem "enumerize"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ GEM
     rubocop-rspec (1.30.1)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     rufus-scheduler (3.5.2)
       fugit (~> 1.1, >= 1.1.5)
     safe_yaml (1.0.5)
@@ -466,9 +466,9 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 3)
       tilt (>= 1.4.0)
-    simple_form (3.5.1)
-      actionpack (> 4, < 5.2)
-      activemodel (> 4, < 5.2)
+    simple_form (5.0.1)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -592,7 +592,7 @@ DEPENDENCIES
   responders (~> 2.1, >= 2.1.0)
   rspec-rails
   rspec_junit_formatter
-  rubyzip (~> 1.2.2)
+  rubyzip (~> 1.3.0)
   sass-rails (= 5.0.6)
   selectize-rails
   selenium-webdriver
@@ -602,7 +602,7 @@ DEPENDENCIES
   shrine
   sidekiq (~> 4.1.4)
   sidekiq-scheduler (~> 2.1.8)
-  simple_form (~> 3.5)
+  simple_form (~> 5.0)
   simplecov
   site_prism
   slim-rails


### PR DESCRIPTION
Prior to this change, security alerts were raised for:
  rubyzip: < 1.3.0
  simple_form: < 5.0.0

This change upgrades:
  rubyzip: 1.3.0
  simple_form: 5.0.1