### PR TITLE
Fix: displaying nomenclatures not published

### DIFF
--- a/app/services/nomenclature_tree_service.rb
+++ b/app/services/nomenclature_tree_service.rb
@@ -24,6 +24,7 @@ class NomenclatureTreeService
       where (gn.validity_end_date is null or gn.validity_end_date >= :view_date)
         and gn.validity_start_date <= :view_date
         and gn.goods_nomenclature_item_id like :nomenclature_code
+        and gn.status = 'published'
       order by gn.goods_nomenclature_item_id, gn.producline_suffix;
     SQL
 


### PR DESCRIPTION
Prior to this change, when viewing dates in the future it was possible
to view nomenclature items that were not yet published.

This change ensures all nomenclatures are published.

https://uktrade.atlassian.net/browse/TARIFFS-638