### PR TITLE
Fix: Ensure new nomenclatures match with a Chapter

### DIFF
--- a/app/interactors/workbasket_interactions/create_nomenclature/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/create_nomenclature/initial_validator.rb
@@ -32,6 +32,7 @@ module WorkbasketInteractions
         check_description!
         check_validity_period!
         check_origin!
+        check_section_and_chapter!
 
         errors
       end
@@ -83,7 +84,18 @@ module WorkbasketInteractions
         end
       end
 
+      def check_section_and_chapter!
+        unless chapter_exists_for_nomenclature?(settings.goods_nomenclature_item_id)
+          @errors[:goods_nomenclature_item_id] = errors_translator(:chapter_doesnt_exist)
+          @errors_summary = errors_translator(:chapter_doesnt_exist)
+        end
+      end
 
+      def chapter_exists_for_nomenclature?(goods_nomenclature_item_id)
+        # check if an item exists using the first 4 characters - this will correspond to the section chapter
+        section_chapter = GoodsNomenclature.actual(include_future: true).where(goods_nomenclature_item_id: goods_nomenclature_item_id.first(4).ljust(10, '0'), status: 'published').first
+        section_chapter.present?
+      end
     end
   end
 end

--- a/app/services/nomenclature_tree_service.rb
+++ b/app/services/nomenclature_tree_service.rb
@@ -38,7 +38,11 @@ class NomenclatureTreeService
         else
           # item is a heading group - do nothing (e.g. see 7101000000 which has an item suffix 10 as a group heading)
         end
-      elsif (nomenclature[:number_indents] -1 == current_path[-1].content[:number_indents])
+      elsif (nomenclature[:number_indents] > current_path[-1].content[:number_indents])
+        # If this item has indentations that are larger than one step down we need to move the indentations up
+        if nomenclature[:number_indents] - 1 != current_path[-1].content[:number_indents]
+          nomenclature[:number_indents] = current_path[-1].content[:number_indents] + 1
+        end
         # new_node is a child of the current path end
         current_path[-1].children << new_node
         current_path << new_node

--- a/app/views/workbaskets/create_nomenclature/edit.html.erb
+++ b/app/views/workbaskets/create_nomenclature/edit.html.erb
@@ -92,9 +92,22 @@
 <%= simple_form_for @create_nomenclature_form, url: create_nomenclature_path, method: :put, html: {novalidate: false} do |f| %>
   <h3 class="heading-large m-t-25">Define the new commodity code</h3>
 
+  <% if saver.errors.any? %>
+    <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+      <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        Error
+      </h2>
+      <ul class="error-summary-list">
+        <% saver.errors.each do | error | %>
+          <span class="error-message"><%= error[1] %></span>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="grid-row">
     <div class="column-full">
-      <div <%= 'class="panel panel-border-narrow form-group-error' if saver&.errors[:goods_nomenclature_item_id] %>">
+      <div class="panel panel-border-narrow <%= 'form-group-error' if saver&.errors[:goods_nomenclature_item_id] %>">
         <% if saver&.errors[:goods_nomenclature_item_id]  %>
           <span class="error-message"><%= saver&.errors[:goods_nomenclature_item_id] %></span>
         <% end %>
@@ -109,7 +122,7 @@
 
   <div class="grid-row">
     <div class="column-full">
-      <div <%= 'class="panel panel-border-narrow form-group-error' if saver&.errors[:description] %>">
+      <div class="panel panel-border-narrow <%= 'form-group-error' if saver&.errors[:description] %>">
         <% if saver&.errors[:description]  %>
           <span class="error-message"><%= saver&.errors[:description] %></span>
         <% end %>
@@ -128,7 +141,7 @@
 
   <div class="grid-row">
     <div class="column-full">
-      <div <%= 'class="panel panel-border-narrow form-group-error' if saver&.errors[:producline_suffix] %>">
+      <div class="panel panel-border-narrow <%= 'form-group-error' if saver&.errors[:producline_suffix] %>">
         <% if saver&.errors[:producline_suffix]  %>
           <span class="error-message"><%= saver&.errors[:producline_suffix] %></span>
         <% end %>
@@ -144,7 +157,7 @@
 
   <div class="grid-row">
     <div class="column-full">
-      <div <%= 'class="panel panel-border-narrow form-group-error' if saver&.errors[:number_indents] %>">
+      <div class="panel panel-border-narrow <%= 'form-group-error' if saver&.errors[:number_indents] %>">
         <% if saver&.errors[:number_indents]  %>
           <span class="error-message"><%= saver&.errors[:number_indents] %></span>
         <% end %>
@@ -159,7 +172,7 @@
 
   <div class="grid-row">
     <div class="column-full">
-      <div <%= 'class="panel panel-border-narrow form-group-error' if saver&.errors[:origin_code] %>">
+      <div class="panel panel-border-narrow <%= 'form-group-error' if saver&.errors[:origin_code] %>">
         <% if saver&.errors[:origin_code]  %>
           <span class="error-message"><%= saver&.errors[:origin_code] %></span>
         <% end %>
@@ -174,7 +187,7 @@
 
   <div class="grid-row">
     <div class="column-full">
-      <div <%= 'class="panel panel-border-narrow form-group-error' if saver&.errors[:origin_producline_suffix] %>">
+      <div class="panel panel-border-narrow <%= 'form-group-error' if saver&.errors[:origin_producline_suffix] %>">
         <% if saver&.errors[:origin_producline_suffix]  %>
           <span class="error-message"><%= saver&.errors[:origin_producline_suffix] %></span>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,4 +203,5 @@ en:
   create_nomenclature:
     description_blank: "Description cannot be left blank and must comprise at least one word."
     validity_start_date_blank: "Start date must be specified."
-    origin_code_not_valid: "The origin code/suffix is not a valid commodiy."
+    origin_code_not_valid: "The origin code/suffix is not a valid commodity."
+    chapter_doesnt_exist: "The chapter indicated by the item id does not exist."


### PR DESCRIPTION
Prior to this change, it was possible to create a nomenclture that could
not be displayed as it didn't correspond to a vaild section/chapter.

This change makes sure that one exists. Also, this change will display a
nomenclature item that had previously been 'orphaned' due to it's indent
being a higher value than expected. (E.g. If an item had an indent of 3
and the next item had an indent of 5, then the item with 5 would not
have been displayed as it was considered to be detached. This is now
displayed so that it can be deleted if necessary.

https://uktrade.atlassian.net/browse/TARIFFS-639