### PR TITLE
Fix: Edit/Delete quota suspension period xml bug

### DIFF
--- a/app/services/xml_generation/node_message.rb
+++ b/app/services/xml_generation/node_message.rb
@@ -174,7 +174,10 @@ module XmlGeneration
     private
 
     def record_is_a_pending_deletion?
-      [FootnoteAssociationMeasure, QuotaAssociation, QuotaSuspensionPeriod].include?(record.class) && record.operation == :update
+      workbasket = Workbaskets::Workbasket.find(id: record.workbasket_id)
+      return true if workbasket.settings.class == Workbaskets::DeleteQuotaSuspensionSettings
+
+      [FootnoteAssociationMeasure, QuotaAssociation].include?(record.class) && record.operation == :update
     end
 
     def record_class


### PR DESCRIPTION
Prior to this change, both edit and delete quota suspension workbaskets are rendering the XML for a delete
transaction.

This is due `record_is_a_pending_deletion?` returning true anytime the model in question is a quota
suspension period.

This change instead looks at the type of workbasket and only returns true if the workbasket type is a
DeleteQuotaSuspensionSettings which fixes the issue.