### PR TITLE
Fix: Adding a nomenclature code to a parent that starts in the future…

### DIFF
--- a/app/forms/workbasket_forms/create_nomenclature_form.rb
+++ b/app/forms/workbasket_forms/create_nomenclature_form.rb
@@ -18,7 +18,9 @@ module WorkbasketForms
       @goods_nomenclature_item_id = settings[:goods_nomenclature_item_id]
       @validity_start_date = settings.present? ? settings[:validity_start_date] : nil
       @producline_suffix = settings[:producline_suffix]
-      @number_indents = settings[:number_indents] || original_nomenclature.number_indents + 1
+      TimeMachine.at(original_nomenclature.validity_start_date) do
+        @number_indents = settings[:number_indents] || original_nomenclature.number_indents + 1
+      end
       @origin_code = settings[:origin_nomenclature] || original_nomenclature.goods_nomenclature_item_id
       @origin_producline_suffix = settings[:origin_producline_suffix] || original_nomenclature.producline_suffix
     end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -46,7 +46,7 @@ class GoodsNomenclature < Sequel::Model
 
   one_to_many :goods_nomenclature_indents, key: :goods_nomenclature_sid,
                                            primary_key: :goods_nomenclature_sid do |ds|
-    ds.with_actual(GoodsNomenclatureIndent, self, true)
+    ds.with_actual(GoodsNomenclatureIndent, self)
       .order(Sequel.desc(:goods_nomenclature_indents__validity_start_date))
   end
 

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -46,7 +46,7 @@ class GoodsNomenclature < Sequel::Model
 
   one_to_many :goods_nomenclature_indents, key: :goods_nomenclature_sid,
                                            primary_key: :goods_nomenclature_sid do |ds|
-    ds.with_actual(GoodsNomenclatureIndent, self)
+    ds.with_actual(GoodsNomenclatureIndent, self, true)
       .order(Sequel.desc(:goods_nomenclature_indents__validity_start_date))
   end
 

--- a/app/views/workbaskets/create_nomenclature/edit.html.erb
+++ b/app/views/workbaskets/create_nomenclature/edit.html.erb
@@ -15,7 +15,9 @@
 
 <div class="panel panel-border-narrow p-t-5 p-b-5">
   <p>
-    <%= original_nomenclature.goods_nomenclature_item_id %> - <%= original_nomenclature.description %>
+    <% TimeMachine.at(original_nomenclature.validity_start_date) do %>
+      <%= original_nomenclature.goods_nomenclature_item_id %> - <%= original_nomenclature.description %>
+    <% end %>
   </p>
 </div>
 
@@ -52,34 +54,36 @@
       <div class="panel panel-border-narrow m-b-60">
         <table>
           <tbody>
-          <tr>
-            <td class="bold-small">Commodity code</td>
-            <td><%= original_nomenclature.goods_nomenclature_item_id %></td>
-          </tr>
-          <tr>
-            <td class="bold-small">Description</td>
-            <td><%= original_nomenclature.description %></td>
-          </tr>
-          <tr>
-            <td class="bold-small">Product line suffix</td>
-            <td><%= original_nomenclature.producline_suffix %></td>
-          </tr>
-          <tr>
-            <td class="bold-small">Indents</td>
-            <td><%= original_nomenclature.number_indents %></td>
-          </tr>
-          <tr>
-            <td class="bold-small">Footnotes</td>
-            <td><%= original_nomenclature.footnotes.map(&:code).join(", ") %></td>
-          </tr>
-          <tr>
-            <td class="bold-small">Code valid from</td>
-            <td><%= original_nomenclature.validity_start_date.to_formatted_s(:uk_Mmm) %></td>
-          </tr>
-          <tr>
-            <td class="bold-small">Code valid until</td>
-            <td><%= original_nomenclature.validity_end_date %></td>
-          </tr>
+          <% TimeMachine.at(original_nomenclature.validity_start_date) do %>
+            <tr>
+              <td class="bold-small">Commodity code</td>
+              <td><%= original_nomenclature.goods_nomenclature_item_id %></td>
+            </tr>
+            <tr>
+              <td class="bold-small">Description</td>
+              <td><%= original_nomenclature.description %></td>
+            </tr>
+            <tr>
+              <td class="bold-small">Product line suffix</td>
+              <td><%= original_nomenclature.producline_suffix %></td>
+            </tr>
+            <tr>
+              <td class="bold-small">Indents</td>
+              <td><%= original_nomenclature.number_indents %></td>
+            </tr>
+            <tr>
+              <td class="bold-small">Footnotes</td>
+              <td><%= original_nomenclature.footnotes.map(&:code).join(", ") %></td>
+            </tr>
+            <tr>
+              <td class="bold-small">Code valid from</td>
+              <td><%= original_nomenclature.validity_start_date.to_formatted_s(:uk_Mmm) %></td>
+            </tr>
+            <tr>
+              <td class="bold-small">Code valid until</td>
+              <td><%= original_nomenclature.validity_end_date %></td>
+            </tr>
+          <% end %>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
… would fail.

This commit, correctly retrieves 'number_indents' when they start in the future.

https://uktrade.atlassian.net/browse/TARIFFS-642