### PR TITLE
Fix: conformance rules for create nomenclature

### DIFF
--- a/app/interactors/workbasket_interactions/create_nomenclature/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_nomenclature/settings_saver.rb
@@ -191,6 +191,7 @@ module WorkbasketInteractions
 
         if conformance_errors.present?
           @errors_summary = initial_validator.errors_translator(:summary_conformance_rules)
+          @errors.merge!(@conformance_errors)
         end
       end
 

--- a/app/views/workbaskets/manage_nomenclatures/new.html.erb
+++ b/app/views/workbaskets/manage_nomenclatures/new.html.erb
@@ -60,7 +60,8 @@
         </label>
       </div>
       <div class="multiple-choice">
-        <input type='radio' id="remove_nomenclature" class="radio-inline-group" name="workbasket_forms_manage_nomenclature_form[action]" value="remove_nomenclature" disabled>
+        <input type='radio' id="remove_nomenclature" class="radio-inline-group" name="workbasket_forms_manage_nomenclature_form[action]" value="remove_nomenclature"
+               <%= 'disabled' if @nomenclature.goods_nomenclature_item_id.ends_with?('000000') %> >
         <label for="remove_nomenclature">
           Remove this code (structural) (Not implemented)
         </label>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,3 +205,4 @@ en:
     validity_start_date_blank: "Start date must be specified."
     origin_code_not_valid: "The origin code/suffix is not a valid commodity."
     chapter_doesnt_exist: "The chapter indicated by the item id does not exist."
+    summary_conformance_rules: "The commodity code could not be submitted because there are conformance errors."


### PR DESCRIPTION
Prior to this change, conformance rules were not blocking creation.

This change corrects traps conformance errors.

https://uktrade.atlassian.net/browse/TARIFFS-212