### PR TITLE
Fix: Quota Order Number conformance error ON2

### DIFF
--- a/app/validators/quota_order_number_validator.rb
+++ b/app/validators/quota_order_number_validator.rb
@@ -41,8 +41,10 @@ class QuotaOrderNumberValidator < TradeTariffBackend::Validator
       record.class.where(
         quota_order_number_id: record.quota_order_number_id
       ) {
-        (validity_end_date > record.validity_start_date)
-      }.empty?
+        (validity_end_date > record.validity_start_date) | Sequel.lit('validity_end_date is null')
+      }.exclude(
+        quota_order_number_sid: record.quota_order_number_sid
+      ).empty?
     end
   end
 


### PR DESCRIPTION
Prior to this change, ON2 was not being triggered when a new quota is
created with the same quota order number.

This change checks if there is an open-ended quota order number already
with the same quota_order_number_id

https://uktrade.atlassian.net/browse/TARIFFS-164