### PR TITLE
Fix: Prevent indents being set to 0

### DIFF
--- a/app/interactors/workbasket_interactions/create_nomenclature/initial_validator.rb
+++ b/app/interactors/workbasket_interactions/create_nomenclature/initial_validator.rb
@@ -32,6 +32,7 @@ module WorkbasketInteractions
         check_description!
         check_validity_period!
         check_origin!
+        check_indents!
         check_section_and_chapter!
 
         errors
@@ -96,6 +97,14 @@ module WorkbasketInteractions
         section_chapter = GoodsNomenclature.actual(include_future: true).where(goods_nomenclature_item_id: goods_nomenclature_item_id.first(4).ljust(10, '0'), status: 'published').first
         section_chapter.present?
       end
+
+      def check_indents!
+        if settings.number_indents < 1
+          @errors[:number_indents] = errors_translator(:indents_must_be_greater_than_zero)
+          @errors_summary = errors_translator(:indents_must_be_greater_than_zero)
+        end
+      end
+
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,3 +206,4 @@ en:
     origin_code_not_valid: "The origin code/suffix is not a valid commodity."
     chapter_doesnt_exist: "The chapter indicated by the item id does not exist."
     summary_conformance_rules: "The commodity code could not be submitted because there are conformance errors."
+    indents_must_be_greater_than_zero: "Number of indents must be greater than 0"


### PR DESCRIPTION
Prior to this change, indents could be set to 0 for a new commodity
code.

This value is used only for section chapters, so should be prevented
from being added as a child code.

https://uktrade.atlassian.net/browse/TARIFFS-654