### PR TITLE
Fix: the formatting of the regulation ID

### DIFF
--- a/app/models/base_regulation.rb
+++ b/app/models/base_regulation.rb
@@ -58,11 +58,6 @@ class BaseRegulation < Sequel::Model
   #
   def formatted_id
     return "I9999/YY" if base_regulation_id == "IYY99990"
-
-    year = Date.strptime(base_regulation_id.slice(1, 2), "%y").strftime("%Y");
-    number = base_regulation_id.slice(3, 4)
-
-    # "#{year}/#{number}"
     base_regulation_id
   end
 


### PR DESCRIPTION
Prior to this change, there were some unecessary calculations that
expected the 2nd and 3rd digits to represent the year.

This change deletes the unecessary calculations as the 2nd and 3rd
characterrs are not necessarily the year and the calculations were no
longer needed/used.

https://uktrade.atlassian.net/browse/TARIFFS-658