### PR TITLE
Create quota blocking period approval bugs

### DIFF
--- a/app/decorators/workbaskets/workbasket_decorator.rb
+++ b/app/decorators/workbaskets/workbasket_decorator.rb
@@ -46,6 +46,10 @@ module Workbaskets
         "Create Quota Suspension Period"
       when "edit_quota_suspension"
         "Edit Quota Suspension Period"
+      when "create_quota_blocking_period"
+        "Create Quota Blocking Period"
+      when "edit_quota_blocking_period"
+        "Edit Quota Blocking Period"
       end
     end
 

--- a/app/forms/workbasket_forms/edit_create_quota_blocking_period_form.rb
+++ b/app/forms/workbasket_forms/edit_create_quota_blocking_period_form.rb
@@ -60,7 +60,7 @@ module WorkbasketForms
 
       if all_fields_completed?
         unless start_date_valid?
-          @settings_errors[:start_date_invalid] = 'You must select the date as on or after start date or before end date of the selected definition or blocking period'
+          @settings_errors[:start_date_invalid] = 'You must select the date as in the future and on or after start date or before end date of the selected definition or blocking period'
         end
 
         if @workbasket_settings.description.length > 500
@@ -106,11 +106,12 @@ module WorkbasketForms
     def start_date_valid?
       definition = QuotaDefinition.find(quota_definition_sid: @workbasket_settings.quota_definition_sid)
 
-      starts_same_day_or_after_definition?(definition) &&
-       starts_before_end_day_of_definition?(definition) &&
-        ends_after_start_date_of_definition(definition) &&
-         ends_same_day_or_before_definition?(definition) &&
-          ends_after_start_date?
+      starts_in_future? &&
+        starts_same_day_or_after_definition?(definition) &&
+         starts_before_end_day_of_definition?(definition) &&
+          ends_after_start_date_of_definition(definition) &&
+           ends_same_day_or_before_definition?(definition) &&
+            ends_same_day_or_after_start_date?
     end
 
     def all_fields_completed?
@@ -133,8 +134,12 @@ module WorkbasketForms
       definition.validity_end_date >= @workbasket_settings.end_date
     end
 
-    def ends_after_start_date?
-      @workbasket_settings.start_date < @workbasket_settings.end_date
+    def ends_same_day_or_after_start_date?
+      @workbasket_settings.start_date <= @workbasket_settings.end_date
+    end
+
+    def starts_in_future?
+      @workbasket_settings.start_date.to_date >= Date.tomorrow
     end
 
     def blocking_reasons

--- a/app/helpers/approval_helper.rb
+++ b/app/helpers/approval_helper.rb
@@ -88,6 +88,10 @@ module ApprovalHelper
       "workbaskets/shared/steps/review_and_submit/approval/create_certificate"
     elsif workbasket.type == 'edit_certificate'
       "workbaskets/shared/steps/review_and_submit/approval/edit_certificate"
+    elsif workbasket.type == 'create_quota_blocking_period'
+      "workbaskets/shared/steps/review_and_submit/approval/create_quota_blocking_period"
+    elsif workbasket.type == 'edit_quota_blocking_period'
+      "workbaskets/shared/steps/review_and_submit/approval/edit_quota_blocking_period"
     end
   end
 end

--- a/app/helpers/cross_check_helper.rb
+++ b/app/helpers/cross_check_helper.rb
@@ -40,6 +40,10 @@ module CrossCheckHelper
       "Cross-check and create quota suspension period"
     elsif workbasket.type == 'edit_quota_suspension'
       "Cross-check and edit quota suspension period"
+    elsif workbasket.type == 'create_quota_blocking_period'
+      "Cross-check and create quota blocking period"
+    elsif workbasket.type == 'edit_quota_suspension'
+      "Cross-check and edit quota blocking period"
     end
   end
 
@@ -84,6 +88,10 @@ module CrossCheckHelper
       "workbaskets/shared/steps/review_and_submit/edit_certificate"
     elsif workbasket.type == 'edit_quota_suspension'
       "workbaskets/shared/steps/review_and_submit/quota_suspension"
+    elsif workbasket.type == 'create_quota_blocking_period'
+      "workbaskets/shared/steps/review_and_submit/quota_blocking_period"
+    elsif workbasket.type == 'edit_quota_blocking_period'
+      "workbaskets/shared/steps/review_and_submit/quota_blocking_period"
     end
   end
 

--- a/app/views/workbaskets/create_quota_blocking_period/edit.html.erb
+++ b/app/views/workbaskets/create_quota_blocking_period/edit.html.erb
@@ -41,7 +41,7 @@
         <div class="column-full">
           <div class="form-group">
             <label class="heading-medium" for="parent_definition_period">
-              Select the quota definition period to suspend
+              Select the quota blocking period to suspend
               <span class="form-hint">
                   This is the quota definition on to which the quota blocking period will be assigned. This list only includes future and current definition periods
               </span>

--- a/app/views/workbaskets/shared/steps/review_and_submit/approval/_create_quota_blocking_period.html.erb
+++ b/app/views/workbaskets/shared/steps/review_and_submit/approval/_create_quota_blocking_period.html.erb
@@ -1,0 +1,32 @@
+<% blocking_period = QuotaBlockingPeriod.find(workbasket_id: workbasket.id) %>
+<% definition = QuotaDefinition.find(quota_definition_sid: blocking_period.quota_definition_sid) %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+
+    <table>
+      <tbody>
+      <tr>
+        <td class="header_column">Quota order number</td>
+        <td><%= definition.quota_order_number_id %></td>
+      </tr>
+      <tr>
+        <td class="header_column">Definition dates</td>
+        <td><%= "#{definition.validity_start_date.strftime("%d-%m-%y")} to #{definition.validity_end_date.strftime("%d-%m-%y")}" %></td>
+      </tr>
+      <tr>
+        <td class="header_column">Blocking period dates</td>
+        <td><%= "#{blocking_period.blocking_start_date.strftime("%d-%m-%y")} to #{blocking_period.blocking_end_date.strftime("%d-%m-%y")}" %></td>
+      </tr>
+      <tr>
+        <td class="header_column">Blocking period type</td>
+        <td><%= WorkbasketForms::EditCreateQuotaBlockingPeriodForm::BLOCKING_TYPES[blocking_period.blocking_period_type] %></td>
+      </tr>
+      <tr>
+        <td class="header_column">Description</td>
+        <td><%= blocking_period.description %></td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/workbaskets/shared/steps/review_and_submit/approval/_edit_quota_blocking_period.html.erb
+++ b/app/views/workbaskets/shared/steps/review_and_submit/approval/_edit_quota_blocking_period.html.erb
@@ -1,0 +1,32 @@
+<% blocking_period = QuotaBlockingPeriod.find(workbasket_id: workbasket.id) %>
+<% definition = QuotaDefinition.find(quota_definition_sid: blocking_period.quota_definition_sid) %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+
+    <table>
+      <tbody>
+      <tr>
+        <td class="header_column">Quota order number</td>
+        <td><%= definition.quota_order_number_id %></td>
+      </tr>
+      <tr>
+        <td class="header_column">Definition dates</td>
+        <td><%= "#{definition.validity_start_date.strftime("%d-%m-%y")} to #{definition.validity_end_date.strftime("%d-%m-%y")}" %></td>
+      </tr>
+      <tr>
+        <td class="header_column">Blocking period dates</td>
+        <td><%= "#{blocking_period.blocking_start_date.strftime("%d-%m-%y")} to #{blocking_period.blocking_end_date.strftime("%d-%m-%y")}" %></td>
+      </tr>
+      <tr>
+        <td class="header_column">Blocking period type</td>
+        <td><%= WorkbasketForms::EditCreateQuotaBlockingPeriodForm::BLOCKING_TYPES[blocking_period.blocking_period_type] %></td>
+      </tr>
+      <tr>
+        <td class="header_column">Description</td>
+        <td><%= blocking_period.description %></td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
Prior to this change, cross checking and approving create/edit quota blocking periods was causing crashes due to some of the helper methods not having the correct options for the new workbasket types and some of the necessary views being missing.

This PR fixes these issues.