### PR TITLE
New: Remove cross-check stage

### DIFF
--- a/app/assets/javascripts/components/validators/additional_codes.js
+++ b/app/assets/javascripts/components/validators/additional_codes.js
@@ -166,11 +166,11 @@ AdditionalCodesValidator.prototype.setSummary = function() {
   if (this.level == "one" && this.action == "save_progress") {
     this.summary = "You cannot save progress yet because you have not entered the minimum required data.";
   } else if (this.level == "one") {
-    this.summary = "You cannot submit for cross-check yet because you have not entered the minimum required data.";
+    this.summary = "You cannot submit for approval yet because you have not entered the minimum required data.";
   } else if (this.level == "two" && this.action == "save_progress") {
     this.summary = "You cannot save progress yet because there is invalid data that cannot be saved.";
   }  else if (this.level == "two") {
-    this.summary = "You cannot submit for cross-check yet because there is invalid data that cannot be saved..";
+    this.summary = "You cannot submit for approval yet because there is invalid data that cannot be saved..";
   } else if (this.level == "three") {
     this.summary = "There is missing and/or invalid data on this page.";
   } else if (this.level == "four") {

--- a/app/assets/javascripts/components/validators/geographical_areas.js
+++ b/app/assets/javascripts/components/validators/geographical_areas.js
@@ -145,11 +145,11 @@ GeographicalAreasValidator.prototype.setSummary = function() {
   if (this.level == "one" && this.action == "save_progress") {
     this.summary = "You cannot save progress yet because you have not entered the minimum required data.";
   } else if (this.level == "one") {
-    this.summary = "You cannot submit for cross-check yet because you have not entered the minimum required data.";
+    this.summary = "You cannot submit for approval yet because you have not entered the minimum required data.";
   } else if (this.level == "two" && this.action == "save_progress") {
     this.summary = "You cannot save progress yet because there is invalid data that cannot be saved.";
   }  else if (this.level == "two") {
-    this.summary = "You cannot submit for cross-check yet because there is invalid data that cannot be saved..";
+    this.summary = "You cannot submit for approval yet because there is invalid data that cannot be saved..";
   } else if (this.level == "three") {
     this.summary = "There is missing and/or invalid data on this page.";
   } else if (this.level == "four") {

--- a/app/assets/javascripts/components/validators/work-with-selected-quota.js
+++ b/app/assets/javascripts/components/validators/work-with-selected-quota.js
@@ -104,11 +104,11 @@ WorkWithSelectedQuotaValidator.prototype.setSummary = function() {
   if (this.level == "one" && this.action == "continue") {
     this.summary = "You cannot proceed yet because you have not entered the minimum required data.";
   } else if (this.level == "one") {
-    this.summary = "You cannot submit for cross-check yet because you have not entered the minimum required data.";
+    this.summary = "You cannot submit for approval yet because you have not entered the minimum required data.";
   } else if (this.level == "two" && this.action == "continue") {
     this.summary = "You cannot proceed yet because there is invalid data that cannot be saved.";
   }  else if (this.level == "two") {
-    this.summary = "You cannot submit for cross-check yet because there is invalid data that cannot be saved..";
+    this.summary = "You cannot submit for approval yet because there is invalid data that cannot be saved..";
   } else if (this.level == "three") {
     this.summary = "There is missing and/or invalid data on this page.";
   }

--- a/app/assets/javascripts/components/work-with-selected-quota.js
+++ b/app/assets/javascripts/components/work-with-selected-quota.js
@@ -38,7 +38,7 @@ $(document).ready(function() {
           return "Proceed to selected quota measures";
         }
 
-        return "Submit for cross-check";
+        return "Submit for approval";
       }
     },
     methods: {

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -355,11 +355,7 @@ module Workbaskets
           end
 
           def submit_for_cross_check!(current_admin:)
-            move_status_to!(current_admin, :awaiting_cross_check)
-
-            settings.collection.map do |item|
-              item.move_status_to!(:awaiting_cross_check)
-            end
+            submit_for_approval!(current_admin: current_admin)
           end
 
           def move_to_editing!(current_admin:)
@@ -378,6 +374,8 @@ module Workbaskets
           end
 
           def submit_for_approval!(current_admin:)
+            move_status_to!(current_admin, :awaiting_approval)
+
             settings.collection.map do |item|
               item.move_status_to!(:awaiting_approval)
             end

--- a/app/views/measures/bulks/_action_buttons.html.slim
+++ b/app/views/measures/bulks/_action_buttons.html.slim
@@ -1,7 +1,7 @@
 .bulk-edit-of-measures-actions-block
   - if workbasket_is_editable?
     .submit_group_for_cross_check_block
-      = link_to "Submit for cross-check", "#", class: "secondary-button js-bulk-edit-of-measures-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
+      = link_to "Submit for approval", "#", class: "secondary-button js-bulk-edit-of-measures-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
 
       .js-bulk-edit-of-measures-submit-for-cross-check-spinner.spinner_block.hidden
         = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/quotas/bulks/_action_buttons.html.slim
+++ b/app/views/quotas/bulks/_action_buttons.html.slim
@@ -1,7 +1,7 @@
 .bulk-edit-of-measures-actions-block
   - if workbasket_is_editable?
     .submit_group_for_cross_check_block
-      = link_to "Submit for cross-check", "#", class: "secondary-button js-bulk-edit-of-measures-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
+      = link_to "Submit for approval", "#", class: "secondary-button js-bulk-edit-of-measures-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
 
       .js-bulk-edit-of-measures-submit-for-cross-check-spinner.spinner_block.hidden
         = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/shared/bulks/_action_buttons.html.slim
+++ b/app/views/shared/bulks/_action_buttons.html.slim
@@ -1,7 +1,7 @@
 .bulk-edit-of-records-actions-block
   - if workbasket_is_editable?
     .submit_group_for_cross_check_block
-      = link_to "Submit for cross-check", "#", class: "button js-bulk-edit-of-records-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
+      = link_to "Submit for approval", "#", class: "button js-bulk-edit-of-records-submit-for-cross-check", "v-on:click.prevent" => "saveForCrossCheck"
 
       .js-bulk-edit-of-records-submit-for-cross-check-spinner.spinner_block.hidden
         = render "shared/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/workbaskets/create_additional_code/_action_links.html.slim
+++ b/app/views/workbaskets/create_additional_code/_action_links.html.slim
@@ -4,7 +4,7 @@
     = render "workbaskets/shared/success_message", f: f
   .submit_group_for_cross_check_block
     button type="submit" name="submit_for_cross_check" class="button js-workbasket-base-continue-button js-workbasket-base-submit-button" v-on:click.prevent="submitCrossCheck" v-if="!submitting" :disabled="saving || submitting"
-      | Submit for cross-check
+      | Submit for approval
 
     span.js-workbasket-base-continue-spinner.spinner_block v-if="submitting" v-cloak=""
       = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/workbaskets/create_certificate/_action_links.slim
+++ b/app/views/workbaskets/create_certificate/_action_links.slim
@@ -3,7 +3,7 @@
     | Finish
     = render "workbaskets/shared/success_message", f: f
   .submit_group_for_cross_check_block
-    = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
+    = f.button :submit, "Submit for approval", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 
     .js-workbasket-base-continue-spinner.spinner_block.hidden
       = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/workbaskets/create_footnote/_action_links.html.slim
+++ b/app/views/workbaskets/create_footnote/_action_links.html.slim
@@ -3,7 +3,7 @@
     | Finish
     = render "workbaskets/shared/success_message", f: f
   .submit_group_for_cross_check_block
-    = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
+    = f.button :submit, "Submit for approval", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 
     .js-workbasket-base-continue-spinner.spinner_block.hidden
       = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/workbaskets/create_geographical_area/_action_links.html.slim
+++ b/app/views/workbaskets/create_geographical_area/_action_links.html.slim
@@ -3,7 +3,7 @@
     | Finish
     = render "workbaskets/shared/success_message", f: f
   .submit_group_for_cross_check_block
-    = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
+    = f.button :submit, "Submit for approval", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 
     .js-workbasket-base-continue-spinner.spinner_block.hidden
       = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/workbaskets/create_nomenclature/edit.html.erb
+++ b/app/views/workbaskets/create_nomenclature/edit.html.erb
@@ -209,7 +209,7 @@
         <button type="submit"
                 class='button'
                 data-disable-with='Processing'>
-          Submit for cross-check
+          Submit for approval
         </button>
 
         <%= link_to "Cancel", '#', onclick: "history.back()", class: "secondary-button" %>

--- a/app/views/workbaskets/create_quota_association/edit.html.erb
+++ b/app/views/workbaskets/create_quota_association/edit.html.erb
@@ -169,7 +169,7 @@
 
       <div class="m-t-30">
         <div class="submit_group_for_cross_check_block">
-          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for cross-check</button>
+          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for approval</button>
           <div class="js-workbasket-base-continue-spinner spinner_block hidden">
             <%= render "measures/bulks/loading_spinner", message: "Saving..." %>
           </div>

--- a/app/views/workbaskets/create_quota_blocking_period/edit.html.erb
+++ b/app/views/workbaskets/create_quota_blocking_period/edit.html.erb
@@ -116,7 +116,7 @@
 
       <div class="m-t-30">
         <div class="submit_group_for_cross_check_block">
-          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for cross-check</button>
+          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for approval</button>
           <div class="js-workbasket-base-continue-spinner spinner_block hidden">
             <%= render "measures/bulks/loading_spinner", message: "Saving..." %>
           </div>

--- a/app/views/workbaskets/create_quota_suspension/edit.html.erb
+++ b/app/views/workbaskets/create_quota_suspension/edit.html.erb
@@ -89,7 +89,7 @@
 
       <div class="m-t-30">
         <div class="submit_group_for_cross_check_block">
-          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for cross-check</button>
+          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for approval</button>
           <div class="js-workbasket-base-continue-spinner spinner_block hidden">
             <%= render "measures/bulks/loading_spinner", message: "Saving..." %>
           </div>

--- a/app/views/workbaskets/create_regulation/_action_links.html.slim
+++ b/app/views/workbaskets/create_regulation/_action_links.html.slim
@@ -6,7 +6,7 @@
     - if step_pointer.has_next_step?
       = f.button :submit, "Create regulation", name: "continue", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
     - else
-      = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
+      = f.button :submit, "Submit for approval", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 
     .js-workbasket-base-continue-spinner.spinner_block.hidden
       = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/workbaskets/delete_quota_association/new.html.erb
+++ b/app/views/workbaskets/delete_quota_association/new.html.erb
@@ -124,7 +124,7 @@
         <button type="submit"
                 class='button'
                 data-disable-with='Processing'>
-          Submit for Cross-Check
+          Submit for approval
         </button>
 
         <%= link_to "Cancel", root_path, class: "secondary-button" %>

--- a/app/views/workbaskets/delete_quota_suspension/new.html.erb
+++ b/app/views/workbaskets/delete_quota_suspension/new.html.erb
@@ -126,7 +126,7 @@
           <button type="submit"
                   class='button'
                   data-disable-with='Processing'>
-            Submit for Cross-Check
+            Submit for approval
           </button>
 
           <%= link_to "Cancel", root_path, class: "secondary-button" %>

--- a/app/views/workbaskets/edit_certificate/_action_links.html.slim
+++ b/app/views/workbaskets/edit_certificate/_action_links.html.slim
@@ -3,7 +3,7 @@
     | Finish
 
   .submit_group_for_cross_check_block
-    = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
+    = f.button :submit, "Submit for approval", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 
     .js-workbasket-base-continue-spinner.spinner_block.hidden
       = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/workbaskets/edit_footnote/_action_links.html.slim
+++ b/app/views/workbaskets/edit_footnote/_action_links.html.slim
@@ -3,7 +3,7 @@
     | Finish
 
   .submit_group_for_cross_check_block
-    = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
+    = f.button :submit, "Submit for approval", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 
     .js-workbasket-base-continue-spinner.spinner_block.hidden
       = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/workbaskets/edit_geographical_area/_action_links.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/_action_links.html.slim
@@ -3,7 +3,7 @@
     | Finish
 
   .submit_group_for_cross_check_block
-    = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
+    = f.button :submit, "Submit for approval", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button"
 
     .js-workbasket-base-continue-spinner.spinner_block.hidden
       = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/app/views/workbaskets/edit_nomenclature/edit.html.erb
+++ b/app/views/workbaskets/edit_nomenclature/edit.html.erb
@@ -133,7 +133,7 @@
         <button type="submit"
                 class='button'
                 data-disable-with='Processing'>
-          Submit for cross-check
+          Submit for approval
         </button>
 
         <%= link_to "Cancel", '#', onclick: "history.back()", class: "secondary-button" %>

--- a/app/views/workbaskets/edit_quota_blocking_period/edit.html.erb
+++ b/app/views/workbaskets/edit_quota_blocking_period/edit.html.erb
@@ -113,7 +113,7 @@
 
       <div class="m-t-30">
         <div class="submit_group_for_cross_check_block">
-          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for cross-check</button>
+          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for approval</button>
           <div class="js-workbasket-base-continue-spinner spinner_block hidden">
             <%= render "measures/bulks/loading_spinner", message: "Saving..." %>
           </div>

--- a/app/views/workbaskets/edit_quota_suspension/edit.html.erb
+++ b/app/views/workbaskets/edit_quota_suspension/edit.html.erb
@@ -88,7 +88,7 @@
 
       <div class="m-t-30">
         <div class="submit_group_for_cross_check_block">
-          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for cross-check</button>
+          <button class="button js-workbasket-base-continue-button" type="submit" aria-disabled="true">Submit for approval</button>
           <div class="js-workbasket-base-continue-spinner spinner_block hidden">
             <%= render "measures/bulks/loading_spinner", message: "Saving..." %>
           </div>

--- a/app/views/workbaskets/edit_regulation/edit.html.slim
+++ b/app/views/workbaskets/edit_regulation/edit.html.slim
@@ -74,5 +74,5 @@ h1 class="heading-large m-b-20"
 
   .form-actions
     button.button data-disable-with='Processing'
-      | Submit for cross-check
+      | Submit for approval
     = link_to 'Cancel', root_path, class: 'secondary-button'

--- a/app/views/workbaskets/main_menu_parts/_withdraw_confirmation_popup.html.slim
+++ b/app/views/workbaskets/main_menu_parts/_withdraw_confirmation_popup.html.slim
@@ -17,7 +17,7 @@
             strong
               | The workbasket '#{workbasket.title}' will be withdrawn from workflow and returned to you. Its status will
               |  be reset to either 'New - in progress' (if it has never been sent to CDS), or 'Editing' (if it is already
-              |  on CDS). You will be able to edit it as required, then re-submit for cross-check when ready.
+              |  on CDS). You will be able to edit it as required, then re-submit for approval when ready.
 
           h4 class="heading-small"
             | Are you sure you want to withdraw this workbasket from workflow?

--- a/app/views/workbaskets/shared/_action_links.html.slim
+++ b/app/views/workbaskets/shared/_action_links.html.slim
@@ -10,7 +10,7 @@
     - if step_pointer.has_next_step?
       = f.button :submit, "Continue", name: "continue", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button", ":disabled" => "disableButtons"
     - else
-      = f.button :submit, "Submit for cross-check", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button", ":disabled" => "disableButtons"
+      = f.button :submit, "Submit for approval", name: "submit_for_cross_check", class: "button js-workbasket-base-continue-button js-workbasket-base-submit-button", ":disabled" => "disableButtons"
 
     .js-workbasket-base-continue-spinner.spinner_block.hidden
       = render "measures/bulks/loading_spinner", message: "Checking data..."

--- a/spec/features/workbasket/additional_codes/create_additional_codes/additional_codes_creation_spec.rb
+++ b/spec/features/workbasket/additional_codes/create_additional_codes/additional_codes_creation_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "adding additional codes", :js do
     fill_in('additional_code_code_0', with: new_code)
     fill_in('additional_code_description_0', with: new_description)
 
-    click_on "Submit for cross-check"
+    click_on "Submit for approval"
 
     expect(page).to have_content "New additional codes submitted"
 

--- a/spec/features/workbasket/footnotes/footnotes_creation_spec.rb
+++ b/spec/features/workbasket/footnotes/footnotes_creation_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "adding footnotes", :js do
     fill_in("What is the footnote description?", with: footnote_description)
     input_date_gds("#validity_start_date", footnote_valid_from)
 
-    click_on "Submit for cross-check"
+    click_on "Submit for approval"
 
     expect(page).to have_content("has been submitted for cross-check.")
     expect(Footnote.last).to have_attributes(description: footnote_description,

--- a/spec/features/workbasket/geographical_area/geographical_area_creation_spec.rb
+++ b/spec/features/workbasket/geographical_area/geographical_area_creation_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "adding geographical areas", :js do
     fill_in("What is the area description?", with: "A description")
     input_date_gds("#validity_start_date", 3.days.from_now)
 
-    click_on "Submit for cross-check"
+    click_on "Submit for approval"
 
     expect(page).to have_content "Geographical area submitted"
   end
@@ -40,7 +40,7 @@ RSpec.describe "adding geographical areas", :js do
 
     expect(area_membership_codes).to include group.geographical_area_id
 
-    click_on "Submit for cross-check"
+    click_on "Submit for approval"
 
     expect(page).to have_content "Geographical area submitted"
     expect_to_be_a_member(group)
@@ -69,7 +69,7 @@ RSpec.describe "adding geographical areas", :js do
 
     expect(area_membership_codes).to include "XX"
 
-    click_on "Submit for cross-check"
+    click_on "Submit for approval"
 
     expect(page).to have_content "Geographical area submitted"
     expect_to_have_member(country)
@@ -99,7 +99,7 @@ RSpec.describe "adding geographical areas", :js do
 
     expect(page).to_not have_content("1008")
 
-    click_on "Submit for cross-check"
+    click_on "Submit for approval"
 
     expect(page).to have_content "Geographical area submitted"
     expect_to_not_be_a_member(third_countries)

--- a/spec/features/workbasket/goods_nomenclature/goods_nomenclature_spec.rb
+++ b/spec/features/workbasket/goods_nomenclature/goods_nomenclature_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "edit description" do
     fill_in("Day", with: "01")
     fill_in("Month", with: "01")
     fill_in("Year", with: "2030")
-    click_on("Submit for cross-check")
+    click_on("Submit for approval")
 
     expect(page).to have_content("The workbasket Test basket name has been submitted for cross-check.")
   end

--- a/spec/features/workbasket/measure/measure_creation_spec.rb
+++ b/spec/features/workbasket/measure/measure_creation_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "adding measures", :js do
 
     expect(page).to have_content "Review and submit"
 
-    click_on("Submit for cross-check")
+    click_on("Submit for approval")
 
     expect(page).to have_content "Measures submitted"
   end

--- a/spec/features/workbasket/quota/quota_spec.rb
+++ b/spec/features/workbasket/quota/quota_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "quotas", :js do
       fill_out_configure_quota_form
       skip_optional_footnote_form
       expect_to_be_on_submit_for_cross_check_page
-      click_button 'Submit for cross-check'
+      click_button 'Submit for approval'
       navigate_to_edit_form
       change_precision_quota_and_submit
       expect(page).to have_content('Quota submitted')
@@ -145,6 +145,6 @@ RSpec.describe "quotas", :js do
     click_button 'Continue'
     click_button 'Continue'
     click_button 'Continue'
-    click_button 'Submit for cross-check'
+    click_button 'Submit for approval'
   end
 end

--- a/spec/support/shared_contexts/system/create_regulation_base_context.rb
+++ b/spec/support/shared_contexts/system/create_regulation_base_context.rb
@@ -103,7 +103,7 @@ shared_context 'create_regulation_base_context' do
 
     context 'filled required fields' do
       context 'click on Create regulation' do
-        context 'click on Submit for cross-check' do
+        context 'click on Submit for approval' do
           it 'is okay' do
             visit_create_regulation
 
@@ -112,7 +112,7 @@ shared_context 'create_regulation_base_context' do
             click_on 'Create regulation'
             expect(page).to have_content('Review and submit')
 
-            click_on 'Submit for cross-check'
+            click_on 'Submit for approval'
             expect(page).to have_content('has been submitted for cross-check')
           end
         end
@@ -121,7 +121,7 @@ shared_context 'create_regulation_base_context' do
 
     context 'filled all fields' do
       context 'click on Create regulation' do
-        context 'click on Submit for cross-check' do
+        context 'click on Submit for approval' do
           it 'is okay' do
             visit_create_regulation
 
@@ -130,7 +130,7 @@ shared_context 'create_regulation_base_context' do
             click_on 'Create regulation'
             expect(page).to have_content('Review and submit')
 
-            click_on 'Submit for cross-check'
+            click_on 'Submit for approval'
             expect(page).to have_content('has been submitted for cross-check')
           end
         end


### PR DESCRIPTION
Prior to this change, users would submit a workbasket for cross-check once approved by a cross-checker it
would then go to the approval stage to get a second, and final, approval.

This change removes the cross-check stage and now upon submission workbaskets go directly to the approval
stage.