### PR TITLE
Fix: License Quotas do not save any info in the Quota tables.

### DIFF
--- a/app/interactors/workbasket_interactions/create_quota/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_quota/settings_saver.rb
@@ -57,6 +57,8 @@ module WorkbasketInteractions
         settings.quota_period_sids_jsonb = @quota_period_sids.to_json
         settings.parent_quota_period_sids_jsonb = @parent_quota_period_sids.to_json
         settings.set_searchable_data_for_created_measures! if settings.save
+
+        clean_up_license_quota!
       end
 
     private
@@ -223,6 +225,14 @@ module WorkbasketInteractions
         end
 
         "::WorkbasketServices::QuotaSavers::#{target_klass_name}".constantize
+      end
+
+      def clean_up_license_quota!
+        if @order_number.is_license_quota?
+          @workbasket.collection.select do |item|
+            Workbaskets::CreateQuotaSettings.license_quota_excluded_models.include?(item.class)
+          end.each(&:destroy)
+        end
       end
     end
   end

--- a/app/models/quota_order_number.rb
+++ b/app/models/quota_order_number.rb
@@ -38,6 +38,10 @@ class QuotaOrderNumber < Sequel::Model
     end
   end
 
+  def is_license_quota?
+    quota_order_number_id.start_with?('094')
+  end
+
   def record_code
     "360".freeze
   end

--- a/app/models/workbaskets/create_quota_settings.rb
+++ b/app/models/workbaskets/create_quota_settings.rb
@@ -21,6 +21,16 @@ module Workbaskets
       )
     end
 
+    def self.license_quota_excluded_models
+      [
+        QuotaAssociation,
+        QuotaOrderNumber,
+        QuotaOrderNumberOrigin,
+        QuotaOrderNumberOriginExclusion,
+        QuotaDefinition
+      ]
+    end
+
     def settings
       main_step_settings.merge(configure_quota_step_settings)
                         .merge(conditions_footnotes_step_settings)

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -400,10 +400,14 @@ module Workbaskets
           end
 
           def testing_status_backdoor!(current_admin:, status:)
-            move_status_to!(current_admin, status, 'Tester backdoor')
+            if status == :published
+              published!
+            else
+              move_status_to!(current_admin, status, 'Tester backdoor')
 
-            settings.collection.map do |item|
-              item.move_status_to!(status)
+              settings.collection.map do |item|
+                item.move_status_to!(status)
+              end
             end
           end
 

--- a/app/views/workbaskets/create_quota/steps/main/_licensed_block.html.slim
+++ b/app/views/workbaskets/create_quota/steps/main/_licensed_block.html.slim
@@ -16,12 +16,7 @@ fieldset
         | Licence
 
       span.form-hint
-        | Begin typing the quota_licence description or code, then select the required quota_licence.
-        br
-        | If the license you need is not in the list, you can &nbsp;
-
-        = link_to "add it from here", root_url, target: "_blank"
-        |.
+        | Please select a certificate / licence.
         br
 
     .row

--- a/app/views/workbaskets/create_quota/steps/review_and_submit/_message.html.slim
+++ b/app/views/workbaskets/create_quota/steps/review_and_submit/_message.html.slim
@@ -14,10 +14,14 @@
       | ), comprising
 
     =<> workbasket_quota_periods_overview
-    | over
 
-    =< workbasket_quota_periods_years_length
+    - unless attributes_parser.quota_ordernumber.starts_with?('094') # I.e. is license quota with no quota definitions
+      | over
+
+      =< workbasket_quota_periods_years_length
+
     | .
+
 
   p
     | This quota will have


### PR DESCRIPTION
License Quotas should not store anything in the Quota tables:
 quota_associations
 quota_order_numbers
 quota_order_number_origins
 quota_order_number_origin_exclusions
 quota_definitions

https://uktrade.atlassian.net/browse/TARIFFS-93
https://uktrade.atlassian.net/browse/TARIFFS-673