### PR TITLE
Fix: Measure Type search on Find/Edit Measure page

### DIFF
--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -43,8 +43,6 @@ class MeasureType < Sequel::Model
 
       if filter_ops[:quota].present? && filter_ops[:quota] == "true"
         scope = scope.where(order_number_capture_code: 1)
-      elsif filter_ops[:quota].present? && filter_ops[:quota] == "false"
-        scope = scope.where(Sequel.~(order_number_capture_code: 1))
       end
 
       if filter_ops[:q].present?


### PR DESCRIPTION
Prior to this change, License Quota measure types were hidden from this
form as they were expected to be edited via the Find Quota screens. This
is not now possible, so they need to access via the Find Measure.

https://uktrade.atlassian.net/browse/TARIFFS-514