### PR TITLE
Fix: help text for the Commodity Code check

### DIFF
--- a/app/views/workbaskets/shared/steps/main/_check_a_additional_code_description.html.slim
+++ b/app/views/workbaskets/shared/steps/main/_check_a_additional_code_description.html.slim
@@ -9,7 +9,7 @@ label.form-label
     span.form-hint
       | If you need to check an additional code, enter it here to see the description.
       br
-      | Codes entered here will not be added to the measures.
+      | Codes entered here will not be added to the measures. Please note, this function will only find currently active commodity codes.
 
   .row
     .col-md-1


### PR DESCRIPTION
Prior to this change, it wasn't clear that on the Create Quota pages
when the user checks for a commodity code, we only check if it's
currently a valid commodity code - we cannot tell which date they may
want to check.

This change adds some explanation.