### PR TITLE
Fix: Minor layout change for duty expression

### DIFF
--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -137,7 +137,7 @@ label abbr {
 }
 
 .measure-component {
-  padding: 0 0 10px;
+  padding: 0;
 
   .modal & {
     padding: 0;

--- a/app/assets/stylesheets/components/measure-components.scss
+++ b/app/assets/stylesheets/components/measure-components.scss
@@ -2,7 +2,7 @@
   border-bottom: 1px solid $border-colour;
   a {
     display: block;
-    margin-bottom: 1em;
+    margin-bottom: 0px
   }
 }
 


### PR DESCRIPTION
This change removes some gratuitous spacing around duty expressions.

https://uktrade.atlassian.net/browse/TARIFFS-660