### PR TITLE
Fix: Allow component and conditions to be removed.

### DIFF
--- a/app/assets/javascripts/vue_components/change-conditions-popup.js
+++ b/app/assets/javascripts/vue_components/change-conditions-popup.js
@@ -74,7 +74,7 @@ Vue.component("change-conditions-popup", {
       return this.measures.length > 1;
     },
     canRemoveMeasureCondition: function () {
-      return this.conditions.length > 1;
+      return (this.conditions.length > 1) || (this.conditions[0].condition_code);
     },
     disableUpdate: function () {
       return this.replacing && this.mode == null;

--- a/app/assets/javascripts/vue_components/components-coordinator.js
+++ b/app/assets/javascripts/vue_components/components-coordinator.js
@@ -22,8 +22,8 @@ var template = [
         '</div>',
       '</measure-component>',
     '</div>',
-    '<a href="#" v-on:click.prevent="addComponent" v-if="isMeasureConditionComponent">Add another component</a>',
-    '<a href="#" v-on:click.prevent="addComponent" v-if="isMeasureComponent">Add another duty expression</a>',
+    '<a href="#" v-on:click.prevent="addComponent" v-if="isMeasureConditionComponent">Add component</a>',
+    '<a href="#" v-on:click.prevent="addComponent" v-if="isMeasureComponent">Add duty expression</a>',
   '</div>'
 ].join("");
 
@@ -78,7 +78,7 @@ Vue.component("components-coordinator", {
       return this.flattenArray(conditions_allow_duty).includes(false);
     },
     canRemoveComponent: function() {
-      return this.components.length > 1;
+      return (this.components.length > 1) || (this.components[0].duty_expression);
     },
     isMeasureConditionComponent: function() {
       return this.type == "measure_condition_component";

--- a/app/assets/javascripts/vue_components/conditions-coordinator.js
+++ b/app/assets/javascripts/vue_components/conditions-coordinator.js
@@ -13,7 +13,7 @@ var template = [
       '</measure-condition>',
     '</div>',
     '<p>',
-      '<a href="#" v-on:click.prevent="addCondition">Add another condition</a>',
+      '<a href="#" v-on:click.prevent="addCondition">Add condition</a>',
     '</p>',
   '</div>'
 ].join("");
@@ -64,7 +64,7 @@ Vue.component("conditions-coordinator", {
   },
   computed: {
     canRemoveMeasureCondition: function() {
-      return this.conditions.length > 1;
+      return (this.conditions.length > 1) || (this.conditions[0].condition_code);
     },
     showReferencedValue: function() {
       var codes = ["E1", "E2", "F", "G", "I1", "I2", "L", "M1", "M2", "N", "R", "S", "U", "V"];

--- a/app/assets/javascripts/vue_components/measure-condition.js
+++ b/app/assets/javascripts/vue_components/measure-condition.js
@@ -44,7 +44,7 @@ Vue.component('measure-condition', {
       return codes.indexOf(this.condition.condition_code) > -1;
     },
     canRemoveComponent: function() {
-      return this.condition.measure_condition_components.length > 1;
+      return (this.condition.measure_condition_components.length > 1) || (this.condition.measure_condition_components[0].condition_code);
     },
     showMonetaryUnit: function() {
       var codes = ["E2", "I2", "M1", "M2"];

--- a/app/assets/javascripts/vue_components/sub-quota-definitions.js
+++ b/app/assets/javascripts/vue_components/sub-quota-definitions.js
@@ -41,7 +41,7 @@ var template = '\
 \
   <p>\
     <a href="#" v-on:click.prevent="addDefinition();">\
-      Add another associated sub quota\
+      Add associated sub quota\
     </a>\
   </p>\
 </div>';

--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -3,6 +3,11 @@
 	-moz-osx-font-smoothing: grayscale;
 }
 
+main {
+  font-size: 16px;
+  line-height: 1.25;
+}
+
 .header-global {
   width: 70%;
   float: left;

--- a/app/views/measures/measures/_search_form.html.erb
+++ b/app/views/measures/measures/_search_form.html.erb
@@ -157,7 +157,7 @@
         <input type="hidden" :name="'search[origin_exclusions][value][' + index + ']'" :value="exclusion.value" :disabled="exclusionsValueDisabled" />
       </div>
       <a href="#" v-on:click.prevent="addOriginExclusion" v-if="!exclusionsValueDisabled">
-        Add another exclusion
+        Add exclusion
       </a>
     </div>
   </div>
@@ -183,7 +183,7 @@
         <input type="hidden" :name="'search[duties][value][' + index + '][' + duty.duty_expression_id + ']'" :value="duty.duty_amount" />
       </div>
       <a href="#" v-on:click.prevent="addDuty" v-if="duties.enabled">
-        Add another duty expression
+        Add duty expression
       </a>
     </div>
   </div>
@@ -207,7 +207,7 @@
         <input type="hidden" :name="'search[conditions][value][' + index + ']'" :value="condition.measure_condition_code" :disabled="conditionsValueDisabled" />
       </div>
       <a href="#" v-on:click.prevent="addCondition" v-if="!conditionsValueDisabled">
-        Add another condition
+        Add condition
       </a>
     </div>
   </div>
@@ -237,7 +237,7 @@
         <input type="hidden" :name="'search[footnotes][value][' + index + '][' + footnote.footnote_type_id || 'null' + ']'" :value="footnote.footnote_id" :disabled="footnotesValueDisabled" />
       </div>
       <a href="#" v-on:click.prevent="addFootnote" v-if="!footnotesValueDisabled">
-        Add another footnote
+        Add footnote
       </a>
     </div>
   </div>

--- a/app/views/quotas/quotas/_search_form.html.erb
+++ b/app/views/quotas/quotas/_search_form.html.erb
@@ -208,7 +208,7 @@
         <input type="hidden" :name="'search[origin_exclusions][value][' + index + ']'" :value="exclusion.value" :disabled="exclusionsValueDisabled" />
       </div>
       <a href="#" v-on:click.prevent="addOriginExclusion" v-if="!exclusionsValueDisabled">
-        Add another exclusion
+        Add exclusion
       </a>
     </div>
   </div>

--- a/app/views/shared/vue_templates/_change_footnotes.html.slim
+++ b/app/views/shared/vue_templates/_change_footnotes.html.slim
@@ -22,7 +22,7 @@ script type="text/x-template" id="change-footnotes-popup-template"
 
     div
       a href="#" v-on:click.prevent="addFootnote"
-        | Add another footnote
+        | Add footnote
 
     .form-actions
       div v-if="!onlyOneMeasure && !hideUpdateMode"

--- a/app/views/shared/vue_templates/_measure_origin.html.slim
+++ b/app/views/shared/vue_templates/_measure_origin.html.slim
@@ -13,10 +13,10 @@ script type="text/x-template" id="measure-origin-template"
                 | Remove
         p v-if="origin.selected"
           a href="#" v-on:click.prevent="addCountryOrTerritory"
-            | Add another country
+            | Add country
           | &nbsp;|&nbsp;
           a href="#" v-on:click.prevent="addGroup"
-            | Add another group
+            | Add group
       label :for="radioID" v-if="!notErgaOmnes"
         | Erga Omnes (all origins)
 
@@ -34,4 +34,4 @@ script type="text/x-template" id="measure-origin-template"
 
       p.add-another-wrapper
         a href="#" v-on:click.prevent="addExclusion"
-          | Add another exclusion
+          | Add exclusion

--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -136,7 +136,7 @@
         </div>
 
         <p v-if="canAddMorePeriods">
-          <a href="#" v-on:click.prevent="addPeriod">Add another custom period this year</a>
+          <a href="#" v-on:click.prevent="addPeriod">Add custom period this year</a>
         </p>
       </fieldset>
       <br>

--- a/app/views/shared/vue_templates/_quota_sections_manager.html.erb
+++ b/app/views/shared/vue_templates/_quota_sections_manager.html.erb
@@ -10,7 +10,7 @@
 
     <p>
       <a href="#" v-on:click.prevent="addSection">
-        Add another section
+        Add section
       </a>
     </p>
   </div>

--- a/app/views/workbaskets/shared/regulations/_regulation_identifier_help_text.html.erb
+++ b/app/views/workbaskets/shared/regulations/_regulation_identifier_help_text.html.erb
@@ -1,4 +1,4 @@
-<details class="govuk-details" data-module="govuk-details" open="">
+<details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       Help with regulation identifiers

--- a/app/views/workbaskets/shared/steps/duties_conditions_footnotes/_footnotes.html.slim
+++ b/app/views/workbaskets/shared/steps/duties_conditions_footnotes/_footnotes.html.slim
@@ -11,4 +11,4 @@ fieldset
           | Remove
   div
     a href="#" v-on:click.prevent="addFootnote"
-      | Add another footnote
+      | Add footnote

--- a/features/page_objects/create_measure_page_elements.rb
+++ b/features/page_objects/create_measure_page_elements.rb
@@ -27,7 +27,7 @@ class CreateMeasurePageElements < SitePrism::Page
   element :check_additional_code_link, ".js-workbasket-check-code-description", text: "Check an additional code description"
   element :check_additional_code_field, :xpath, '//div[@class="js-workbasket-check-code-container"]//input'
   element :check_additional_code_description, ".additional_code_preview_block"
-  element :add_another_condition, "a", text: "Add another condition"
+  element :add_another_condition, "a", text: "Add condition"
 
   section :conditions, "#wrapper fieldset:nth-child(5)" do
     element :duty_amount, "#measure-condition-0-measure-condition-component-0-amount"


### PR DESCRIPTION
Prior to this change, it was not easy to remove a component or condition if it was the only one and data was entered into it.

This change shows the 'Remove' link if more than one item or if the one item has data in it.

https://uktrade.atlassian.net/browse/TARIFFS-84