### PR TITLE
Fix future nomenclature search

### DIFF
--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -377,7 +377,8 @@ $(document).ready(function() {
           $.ajax({
             url: url,
             data: {
-              q: this[code].trim()
+              q: this[code].trim(),
+              start_date: this.measure.validity_start_date
             },
             success: function(data) {
 

--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -3,7 +3,7 @@ class GoodsNomenclaturesController < ApplicationController
   around_action :configure_time_machine
 
   def index
-    @nomenclature = GoodsNomenclature.actual
+    @nomenclature = GoodsNomenclature.actual(include_future: true)
                                      .where(goods_nomenclature_item_id: params[:q])
                                      .first.try(:sti_instance)
 


### PR DESCRIPTION
Prior to this change, future codes would fail validation and not appear
when checking the code descriptions..

This change allows future codes.

https://uktrade.atlassian.net/browse/TARIFFS-645