### PR TITLE
Fix: More selectize-input freaky styley

### DIFF
--- a/app/assets/stylesheets/components/select.scss
+++ b/app/assets/stylesheets/components/select.scss
@@ -13,6 +13,7 @@
   max-width: 90% !important;
   overflow: hidden !important;
   text-overflow: ellipsis !important;
+  display:block;
 }
 
 .abbreviation {

--- a/vendor/assets/stylesheets/selectize.bootstrap3.scss
+++ b/vendor/assets/stylesheets/selectize.bootstrap3.scss
@@ -309,7 +309,7 @@
 .selectize-control .clear-selection {
   position: absolute;
   right: 35px;
-  top: 6px;
+  top: 4px;
   display: inline-block;
   font-size: 1.2em;
   font-weight: 400;


### PR DESCRIPTION
Prior to this change, the electize-input changes height when values are
selected.

This change changes the display type to block so this stops happening.

https://uktrade.atlassian.net/browse/TARIFFS-681