### PR TITLE
Reassign workbasket bugs

### DIFF
--- a/app/views/workbaskets/bulk_edit_of_additional_codes/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_additional_codes/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The additional codes are being edited.

--- a/app/views/workbaskets/bulk_edit_of_additional_codes/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_additional_codes/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The additional codes detailed below are in progress.

--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The measures are being edited.

--- a/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/bulk_edit_of_measures/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The measures below are in progress.

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The certificate is being edited.

--- a/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_additional_code/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The additional code detailed below is in progress.

--- a/app/views/workbaskets/create_certificate/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_certificate/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The certificate is being edited.

--- a/app/views/workbaskets/create_certificate/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_certificate/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The footnote detailed below is in progress.

--- a/app/views/workbaskets/create_footnote/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_footnote/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The footnote is being edited.

--- a/app/views/workbaskets/create_footnote/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_footnote/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The footnote detailed below is in progress.

--- a/app/views/workbaskets/create_geographical_area/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_geographical_area/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The geographical area is being edited.

--- a/app/views/workbaskets/create_geographical_area/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_geographical_area/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The geographical area detailed below is in progress.

--- a/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_measures/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The measure detailed below is in progress.

--- a/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_quota/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota detailed below is in progress.

--- a/app/views/workbaskets/create_quota_association/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_quota_association/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota association is being edited.

--- a/app/views/workbaskets/create_quota_association/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_quota_association/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The footnote detailed below is in progress.

--- a/app/views/workbaskets/create_quota_blocking_period/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_quota_blocking_period/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota blocking period is being edited.

--- a/app/views/workbaskets/create_quota_blocking_period/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_quota_blocking_period/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota blocking period detailed below is in progress.

--- a/app/views/workbaskets/create_quota_suspension/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_quota_suspension/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota suspension period is being edited.

--- a/app/views/workbaskets/create_quota_suspension/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_quota_suspension/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota suspension period detailed below is in progress.

--- a/app/views/workbaskets/create_regulation/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/create_regulation/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The regulation is being edited.

--- a/app/views/workbaskets/create_regulation/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/create_regulation/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The regulation detailed below is in progress.

--- a/app/views/workbaskets/delete_quota_association/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/delete_quota_association/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The regulation detailed below is in progress.

--- a/app/views/workbaskets/delete_quota_suspension/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/delete_quota_suspension/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The regulation detailed below is in progress.

--- a/app/views/workbaskets/edit_certificate/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/edit_certificate/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The certificate is being edited.

--- a/app/views/workbaskets/edit_certificate/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/edit_certificate/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The certificate detailed below is in progress.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The footnote is being edited.

--- a/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/edit_footnote/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The footnote detailed below is in progress.

--- a/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The geographical area detailed below is in progress.

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The nomenclature is being edited.

--- a/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/edit_nomenclature/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The nomenclature below is in progress.

--- a/app/views/workbaskets/edit_quota_blocking_period/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/edit_quota_blocking_period/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota blocking period is being edited.

--- a/app/views/workbaskets/edit_quota_blocking_period/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/edit_quota_blocking_period/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The nomenclature below is in progress.

--- a/app/views/workbaskets/edit_quota_suspension/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/edit_quota_suspension/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The quota suspension period detailed below is in progress.

--- a/app/views/workbaskets/edit_regulation/workflow_screens_parts/notifications/view/_editing.html.slim
+++ b/app/views/workbaskets/edit_regulation/workflow_screens_parts/notifications/view/_editing.html.slim
@@ -1,0 +1,2 @@
+p
+  | The regulation is being edited.

--- a/app/views/workbaskets/edit_regulation/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
+++ b/app/views/workbaskets/edit_regulation/workflow_screens_parts/notifications/view/_new_in_progress.html.slim
@@ -1,0 +1,2 @@
+p
+  | The regulation detailed below is in progress.

--- a/app/views/workbaskets/reassigns/new.html.slim
+++ b/app/views/workbaskets/reassigns/new.html.slim
@@ -1,3 +1,42 @@
+h1.heading-large Reassign workbasket
+
+h3.heading-medium Workbasket details
+
+table.create-measures-details-table
+  tbody
+    tr
+      td.heading_column
+        | Workbasket ID
+      td
+        = @workbasket.id
+
+    tr
+      td.heading_column
+        | Workbasket name
+      td
+        = @workbasket.title
+
+    tr
+      td.heading_column
+        | Created by
+      td
+        = @workbasket.author_name
+
+    tr
+      td.heading_column
+        | Type
+      td
+        = @workbasket.decorate.type
+
+    tr
+      td.heading_column
+        | Status
+      td
+        = @workbasket.decorate.status
+
+    - @workbasket.ordered_events.map do |event|
+      = render "workbaskets/events/#{event.event_type}", event: event
+
 = simple_form_for form, url: reassigns_url(@workbasket.id),
                         html: { \
                           class: "cross-check-form create-measures-v2", \
@@ -29,6 +68,6 @@
       | Next step
 
     .submit_group_for_cross_check_block
-      = f.button :submit, "Reassign", name: "submit_for_cross_check", class: "button"
+      = f.button :submit, "Reassign workbasket", name: "submit_for_cross_check", class: "button"
 
     = link_to "Cancel", root_url, class: "secondary-button"


### PR DESCRIPTION
This PR fixes 2 bugs.

1. Approver users can now see every workbasket on their homepage, however when clicking 'view' it led them to a crash page. This was due to the relevant view not existing. To fix this these views have been added.

2. Some information about the workbasket was missing from the reassign page. This info has not been added.