### PR TITLE
Fix: Change "Add a new one instead" text

### DIFF
--- a/app/views/additional_codes/additional_codes/_search_page.html.slim
+++ b/app/views/additional_codes/additional_codes/_search_page.html.slim
@@ -8,8 +8,10 @@
 
 h2.heading-large
   | Find and edit additional codes
-  small
-    = link_to "(add a new one instead)", new_create_additional_code_url
+p
+  ' Alternatively,
+  = link_to "create a new additional code", new_create_additional_code_url
+  |.
 
 script
   == "window.__search_params = #{full_search_params.to_json};"

--- a/app/views/certificates/certificates/search.html.slim
+++ b/app/views/certificates/certificates/search.html.slim
@@ -9,8 +9,10 @@
 header
   h1.heading-large
     | Find and edit certificates
-    small
-      = link_to "(add a new one instead)", new_create_certificate_url
+  p
+    ' Alternatively,
+    = link_to "create a new certificate", new_create_certificate_url
+    |.
 
   .js-search-certificates-section
     = render "certificates/certificates/search/form"

--- a/app/views/footnotes/footnotes/search.html.slim
+++ b/app/views/footnotes/footnotes/search.html.slim
@@ -9,8 +9,10 @@
 header
   h1.heading-large
     | Find and edit footnotes
-    small
-      = link_to "(add a new one instead)", new_create_footnote_url
+  p
+    ' Alternatively,
+    = link_to "create a new footnote", new_create_footnote_url
+    |.
 
   .js-search-footnotes-section
     = render "footnotes/footnotes/search/form"

--- a/app/views/geo_areas/geo_areas/index.html.slim
+++ b/app/views/geo_areas/geo_areas/index.html.slim
@@ -9,8 +9,10 @@
 header
   h1.heading-large
     | Find and edit geographical areas
-    small
-      = link_to "(add a new one instead)", new_create_geographical_area_url
+  p
+    ' Alternatively,
+    = link_to "create a new geographical area", new_create_geographical_area_url
+    |.
 
   .js-search-geographical-areas-section
     = render "geo_areas/geo_areas/search/form"

--- a/app/views/measures/measures/_search_page.html.slim
+++ b/app/views/measures/measures/_search_page.html.slim
@@ -7,8 +7,10 @@
 
 h2.heading-large
   | Find and edit measures
-  small
-    = link_to "(add a new one instead)", new_create_measure_url
+p
+  ' Alternatively,
+  = link_to "create a new measure", new_create_measure_url
+  |.
 
 script
   == "window.__search_params = #{full_search_params.to_json};"

--- a/app/views/quotas/quotas/_search_page.html.slim
+++ b/app/views/quotas/quotas/_search_page.html.slim
@@ -46,8 +46,10 @@ div
 
 h2.heading-large
   | Find and edit a quota
-  small
-    = link_to "(add a new one instead)", new_create_quotum_url
+p
+  ' Alternatively,
+  = link_to "create a new quota", new_create_quotum_url
+  |.
 
 script
   == "window.__search_params = #{full_search_params.to_json};"

--- a/app/views/regulations/index.html.slim
+++ b/app/views/regulations/index.html.slim
@@ -9,8 +9,10 @@
 header
   h1.heading-large
     | Find a regulation
-    small
-      = link_to "(add a new one instead)", new_create_regulation_url
+  p
+    ' Alternatively,
+    = link_to "create a new regulation", new_create_regulation_url
+    |.
 
   = render "regulations/search/form"
   - if search_mode?

--- a/app/views/workbaskets/edit_certificate/edit.html.slim
+++ b/app/views/workbaskets/edit_certificate/edit.html.slim
@@ -1,4 +1,4 @@
-= render "workbaskets/shared/edit_base", subheader: link_to("(add a new one instead)", new_create_certificate_url)
+= render "workbaskets/shared/edit_base", subheader: link_to("create a new certificate", new_create_certificate_url)
 
 script
   == "window.__original_certificate_description = '#{j(form.original_certificate_description)}';"

--- a/app/views/workbaskets/edit_footnote/edit.html.slim
+++ b/app/views/workbaskets/edit_footnote/edit.html.slim
@@ -1,4 +1,4 @@
-= render "workbaskets/shared/edit_base", subheader: link_to("(add a new one instead)", new_create_footnote_url)
+= render "workbaskets/shared/edit_base", subheader: link_to("create a new footnote", new_create_footnote_url)
 
 script
   == "window.__original_footnote_description = '#{j(form.original_footnote_description)}';"

--- a/app/views/workbaskets/edit_geographical_area/edit.html.slim
+++ b/app/views/workbaskets/edit_geographical_area/edit.html.slim
@@ -1,4 +1,4 @@
-= render "workbaskets/shared/edit_base", subheader: link_to("(add a new one instead)", new_create_geographical_area_url)
+= render "workbaskets/shared/edit_base", subheader: link_to("create a new geographical area", new_create_geographical_area_url)
 = render "shared/vue_templates/add_geo_areas_to_group_popup"
 = render "shared/vue_templates/add_geo_areas_to_country_region_popup"
 = render "shared/vue_templates/edit_geographical_area_membership_popup"

--- a/app/views/workbaskets/shared/_edit_base.html.slim
+++ b/app/views/workbaskets/shared/_edit_base.html.slim
@@ -3,9 +3,11 @@
 header
   h1.heading-large
     = public_send("#{settings_type}_section_header")
-    - unless local_assigns[:subheader].nil?
-      small
-        = local_assigns[:subheader]
+  - unless local_assigns[:subheader].nil?
+    p
+      ' Alternatively,
+      = local_assigns[:subheader]
+      |.
 
 - if step_pointer.current_step_is_form_step?
   = render "workbaskets/#{settings_type}/form"


### PR DESCRIPTION
Across all of the search screens, there is a link to "Add a new one instead".
This is inaccessible, because the term needs to make sense out of context.
Changed to
 'Alternatively, <a href="{url}">create a new xxxx</a>'

https://uktrade.atlassian.net/browse/TARIFFS-696