### PR TITLE
New: Add guidance for using 'previous page' link

### DIFF
--- a/app/views/workbaskets/shared/_action_links.html.slim
+++ b/app/views/workbaskets/shared/_action_links.html.slim
@@ -27,3 +27,6 @@
   - if step_pointer.has_previous_step?
     = link_to "Previous step", previous_step_url,
                                class: "secondary-button js-workbasket-base-previous-step-link"
+
+    p.m-t-10
+      | If you need to return to the previous page for any reason, please save your progress and use the &quot;Previous step&quot; link above. Do not use the browser 'Back' button, as your changes will be lost.


### PR DESCRIPTION
This commit adds text to explain to users that they should save progress before using the previous
page link.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-703