### PR TITLE
Remove Additional Code from Quota Search

### DIFF
--- a/app/assets/javascripts/components/find-quotas.js
+++ b/app/assets/javascripts/components/find-quotas.js
@@ -47,7 +47,6 @@ $(document).ready(function() {
           {enabled: true, title: "Start date", field: "validity_start_date"},
           {enabled: true, title: "End date", field: "validity_end_date"},
           {enabled: true, title: "Commodity code(s)", field: "goods_nomenclature_item_ids"},
-          {enabled: true, title: "Additional code(s)", field: "additional_code_ids"},
           {enabled: true, title: "Origin", field: "origin"},
           {enabled: true, title: "Origin exclusions", field: "origin_exclusions"},
           {enabled: true, title: "Status", field: "status"}
@@ -182,11 +181,6 @@ $(document).ready(function() {
           operator: "includes",
           value: null
         },
-        additional_code: {
-          enabled: false,
-          operator: "is",
-          value: null
-        },
         origin: {
           enabled: false,
           operator: "is",
@@ -213,7 +207,6 @@ $(document).ready(function() {
         "validity_start_date",
         "validity_end_date",
         "commodity_code",
-        "additional_code",
         "origin",
         "origin_exclusions"
       ];
@@ -246,7 +239,6 @@ $(document).ready(function() {
           valid_from: "validity_start_date",
           valid_to: "validity_end_date",
           commodity_code: "commodity_code",
-          additional_code: "additional_code",
           origin: "origin"
         };
 
@@ -479,16 +471,6 @@ $(document).ready(function() {
       "commodity_code.value": function(val) {
         if (val) {
           this.commodity_code.enabled = true;
-        }
-      },
-      "additional_code.operator": function(val) {
-        if (val) {
-          this.additional_code.enabled = true;
-        }
-      },
-      "additional_code.value": function(val) {
-        if (val) {
-          this.additional_code.enabled = true;
         }
       },
       "origin.operator": function(val) {

--- a/app/assets/javascripts/components/find-quotas.js
+++ b/app/assets/javascripts/components/find-quotas.js
@@ -126,8 +126,7 @@ $(document).ready(function() {
         },
         license: {
           enabled: false,
-          operator: "no",
-          value: null
+          operator: "no"
         },
         staged: {
           enabled: false,
@@ -494,11 +493,6 @@ $(document).ready(function() {
         }
       },
       "license.operator": function(val) {
-        if (val) {
-          this.license.enabled = true;
-        }
-      },
-      "license.value": function(val) {
         if (val) {
           this.license.enabled = true;
         }

--- a/app/searches/quotas/search_filters/license.rb
+++ b/app/searches/quotas/search_filters/license.rb
@@ -4,14 +4,11 @@ module Quotas
       attr_accessor :operator,
                     :license
 
-      def initialize(operator, license = nil)
+      def initialize(operator, _license = nil)
         @operator = operator
-        @license = license.to_s.strip
       end
 
       def sql_rules
-        return nil if license.blank? && operator == 'yes'
-
         clause
       end
 
@@ -21,7 +18,7 @@ module Quotas
         case operator
         when "yes"
 
-          [yes_clause, license]
+          yes_clause
         when "no"
 
           no_clause
@@ -36,7 +33,7 @@ module Quotas
                     WHERE measures.ordernumber = quota_definitions.quota_order_number_id
                       AND measures.validity_start_date = quota_definitions.validity_start_date
                       AND measure_conditions.measure_sid = measures.measure_sid
-                      AND measure_conditions.certificate_code = ?)
+                      AND measure_conditions.certificate_code IS NOT NULL)
         eos
       end
 

--- a/app/views/quotas/quotas/_search_form.html.erb
+++ b/app/views/quotas/quotas/_search_form.html.erb
@@ -84,14 +84,6 @@
     <div class="find-items__is">
       <custom-select :options="conditionsForLicense" label-field="label" value-field="value"  v-model="license.operator" name="search[license][operator]"></custom-select>
     </div>
-    <div class="find-item__text">
-      <span class='middle-text'>
-        with licence ID
-      </span>
-    </div>
-    <div class="find-item__short">
-      <custom-select url="/certificates" code-field="certificate_code" label-field="description" value-field="certificate_code" code-class-name="prefix--certificate-code"  placeholder="― start typing ―" min-length="1" v-model="license.value" name="search[license][value]" v-bind:disabled="licenseValueDisabled"></custom-select>
-    </div>
   </div>
   <div class="find-items__row">
     <div class="find-items__checkbox-column">

--- a/app/views/quotas/quotas/_search_form.html.erb
+++ b/app/views/quotas/quotas/_search_form.html.erb
@@ -159,22 +159,6 @@
   <div class="find-items__row">
     <div class="find-items__checkbox-column">
       <div class="multiple-choice">
-        <input name="search[additional_code][enabled]" id="toggle-additional-code" type="checkbox" value="1" v-model="additional_code.enabled" />
-        <label for="toggle-additional-code">
-          Additional code
-        </label>
-      </div>
-    </div>
-    <div class="find-items__is">
-      <custom-select :options="conditionsForAdditionalCode" label-field="label" value-field="value"  v-model="additional_code.operator" name="search[additional_code][operator]"></custom-select>
-    </div>
-    <div class="find-item__short">
-      <input name="search[additional_code][value]" class="form-control" v-model="additional_code.value" />
-    </div>
-  </div>
-  <div class="find-items__row">
-    <div class="find-items__checkbox-column">
-      <div class="multiple-choice">
         <input id="toggle-origin" name="search[origin][enabled]" type="checkbox" value="1" v-model="origin.enabled" />
         <label for="toggle-origin">
           Origin


### PR DESCRIPTION
Prior to this change, Quota search form had an 'Additional Code' field
and was displayed in the table. But there is never an additional code
on a Quota so should be removed.

Also, remove ability to search for a specific license ID

https://uktrade.atlassian.net/browse/TARIFFS-697
https://uktrade.atlassian.net/browse/TARIFFS-698
