### PR TITLE
Fix: Submitted text alignment.

### DIFF
--- a/app/assets/stylesheets/gds_overrides.scss
+++ b/app/assets/stylesheets/gds_overrides.scss
@@ -42,3 +42,10 @@
   font-size:12px !important;
 }
 
+.govuk-box-highlight {
+  p.font-large {
+    max-width: 100% !important;
+  }
+}
+
+


### PR DESCRIPTION
Prior to this change, some other CSS changes caused the 'submitted'
notice to be mis-aligned.

https://uktrade.atlassian.net/browse/TARIFFS-718