### PR TITLE
Fix: User unable to edit quota blocking periods after withdrawing wor…

### DIFF
--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -370,6 +370,7 @@ module Workbaskets
                                  type == 'edit_footnote' ||
                                  type == 'create_quota_association' ||
                                  type == 'delete_quota_association' ||
+                                 type == 'edit_quota_blocking_period'
                                  type == 'create_nomenclature')
 
             settings.collection.map do |item|


### PR DESCRIPTION
…kbasket

Prior to this change, a user withdrawing a edit_quota_blocking_period workbasket would see an error page
when submitting the edited workbasket for approval.

This was due to the quota blocking period being deleted upon withdrawal of the workbasket.

This commit stops the object being deleted.

https://uktrade.atlassian.net/jira/software/projects/TARIFFS/boards/127?selectedIssue=TARIFFS-540