### PR TITLE
Fix: Create Measure validation

### DIFF
--- a/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
+++ b/app/interactors/workbasket_interactions/create_measures/settings_saver.rb
@@ -144,6 +144,7 @@ module WorkbasketInteractions
         end
 
         if commodity_codes.present?
+          commodity_codes.squish!
           invalid_commodity_codes = get_invalid_commodity_codes(CodeParsingService.csv_string_to_array(commodity_codes))
           invalid_commodity_codes << commodity_codes.split(', ').select { |code| code.length > 10 || !code.scan(/\D/).empty? }
           invalid_commodity_codes = invalid_commodity_codes.flatten.uniq
@@ -291,7 +292,7 @@ module WorkbasketInteractions
 
             def get_invalid_commodity_codes(codes)
               codes.reject do |code|
-                GoodsNomenclature.by_code(code).declarable.first.present?
+                code.length == 10 && GoodsNomenclature.by_code(code).declarable.first.present?
               end
             end
 

--- a/app/services/code_parsing_service.rb
+++ b/app/services/code_parsing_service.rb
@@ -1,6 +1,6 @@
 class CodeParsingService
   def self.csv_string_to_array(codes_string)
-    codes_string = codes_string || ""
+    codes_string = codes_string&.squish || ""
     codes_string.split(/[\s|,]+/)
       .map(&:strip)
       .reject(&:blank?)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,14 +45,14 @@ en:
       blank_workbasket_name: "Workbasket name can not be blank."
       blank_commodity_and_additional_codes: "Goods commodity codes: can be empty but only if one or more Meursing codes are entered in the Additional codes field."
       commodity_codes_exclusions: "Exceptions: if one or more codes are entered here, Goods commodity codes field must not be empty; each exception code must be a child of one of the goods commodity codes above."
-      commodity_codes_invalid: "There are no any valid code specified in 'Goods commodity codes' or 'Additional codes' inputs! Please double check params"
+      commodity_codes_invalid: "There are no valid codes specified in 'Goods commodity codes' or 'Additional codes' inputs! Please double check params"
 
   create_quota:
     errors:
       quota_ordernumber: "Order number can not be blank."
       blank_commodity_and_additional_codes: "Goods commodity codes: can be empty but only if one or more Meursing codes are entered in the Additional codes field."
       commodity_codes_exclusions: "Exceptions: if one or more codes are entered here, Goods commodity codes field must not be empty; each exception code must be a child of one of the goods commodity codes above."
-      commodity_codes_invalid: "There are no any valid code specified in 'Goods commodity codes' or 'Additional codes' inputs! Please double check params"
+      commodity_codes_invalid: "There are no valid codes specified in 'Goods commodity codes' or 'Additional codes' inputs! Please double check params"
       no_any_quota_period: "Need to specify at least of one valid quota period. Period type, Start date, Length of period, Balance and either Measurement or Monetary Unit are required!"
       no_geographical_area: "A geographical origin (or Erga Omnes) must be specified."
       maximum_precision_blank: "Maximum precision must be specified."


### PR DESCRIPTION
Prior to this fix:
1. Entering a commodity code exception that had more than 10 characters  would be truncated. Changed so that it flags an error.
2. Blank lines in Commodity Code field would cause an error

https://uktrade.atlassian.net/browse/TARIFFS-684